### PR TITLE
Feature/tuesday 2016 06 28

### DIFF
--- a/FieldOpt/AdgprsResultsReader/adgprs_results_reader.cpp
+++ b/FieldOpt/AdgprsResultsReader/adgprs_results_reader.cpp
@@ -1,3 +1,4 @@
+#include <Utilities/settings/simulator.h>
 #include "adgprs_results_reader.h"
 #include "Utilities/unix/execution.h"
 #include "Utilities/file_handling/filehandling.h"
@@ -8,7 +9,16 @@ AdgprsResultsReader::AdgprsResultsReader(QString summary_path)
 {
     hdf5_path_ = summary_path;
     json_path_ = summary_path.split(".SIM.H5").first() + ".json";
-    convertHdfSummaryToJson();
+    build_path_ = Utilities::FileHandling::GetBuildDirectoryPath();
+    convertHdfSummaryToJson(build_path_);
+    json_reader_ = new JsonSummaryReader(json_path_);
+}
+
+AdgprsResultsReader::AdgprsResultsReader(QString summary_path, QString build_path)
+{
+    hdf5_path_ = summary_path;
+    json_path_ = summary_path.split(".SIM.H5").first() + ".json";
+    convertHdfSummaryToJson(build_path);
     json_reader_ = new JsonSummaryReader(json_path_);
 }
 
@@ -17,11 +27,10 @@ AdgprsResultsReader::~AdgprsResultsReader()
     delete json_reader_;
 }
 
-void AdgprsResultsReader::convertHdfSummaryToJson()
+void AdgprsResultsReader::convertHdfSummaryToJson(QString build_path)
 {
-    QString conversion_script_path = Utilities::FileHandling::GetBuildDirectoryPath() + "/AdgprsSummaryConverter/AdgprsSummaryConverter.py";
+    QString conversion_script_path = build_path + "/AdgprsSummaryConverter/AdgprsSummaryConverter.py";
     QStringList params = {hdf5_path_, json_path_};
     Utilities::Unix::ExecShellScript(conversion_script_path, params);
 }
-
 }

--- a/FieldOpt/AdgprsResultsReader/adgprs_results_reader.cpp
+++ b/FieldOpt/AdgprsResultsReader/adgprs_results_reader.cpp
@@ -9,7 +9,7 @@ AdgprsResultsReader::AdgprsResultsReader(QString summary_path)
 {
     hdf5_path_ = summary_path;
     json_path_ = summary_path.split(".SIM.H5").first() + ".json";
-    build_path_ = Utilities::FileHandling::GetBuildDirectoryPath();
+    build_path_ = Utilities::FileHandling::GetCurrentDirectoryPath();
     convertHdfSummaryToJson(build_path_);
     json_reader_ = new JsonSummaryReader(json_path_);
 }

--- a/FieldOpt/AdgprsResultsReader/adgprs_results_reader.h
+++ b/FieldOpt/AdgprsResultsReader/adgprs_results_reader.h
@@ -14,6 +14,7 @@ public:
      * \param summary_path Path to a ADGPRS summary file in the HDF5 format, including the .SIM.H5 suffix.
      */
     AdgprsResultsReader(QString summary_path);
+    AdgprsResultsReader(QString summary_path,QString build_path);
 
     ~AdgprsResultsReader();
 
@@ -26,9 +27,10 @@ public:
 private:
     QString hdf5_path_;
     QString json_path_;
+    QString build_path_;
     JsonSummaryReader *json_reader_;
 
-    void convertHdfSummaryToJson();
+    void convertHdfSummaryToJson(QString build_path);
 
 };
 

--- a/FieldOpt/Runner/main.cpp
+++ b/FieldOpt/Runner/main.cpp
@@ -47,6 +47,8 @@ int main(int argc, char *argv[])
                  "type of runner (serial/oneoff)")
                 ("grid-path,g", po::value<std::string>(),
                  "path to model grid file (e.g. *.GRID)")
+                ("exec-path,e", po::value<std::string>(),
+                 "path to executable running reservoir simulation")
                 ("sim-drv-path,s", po::value<std::string>(),
                  "path to simulator driver file (e.g. *.DATA)")
                 ("simulation-timeout,t", po::value<int>(&simulation_timeout)->default_value(0),

--- a/FieldOpt/Runner/main.cpp
+++ b/FieldOpt/Runner/main.cpp
@@ -49,8 +49,8 @@ int main(int argc, char *argv[])
                  "path to model grid file (e.g. *.GRID)")
                 ("sim-exec-path,e", po::value<std::string>(),
                  "path to script that executes the reservoir simulation")
-                ("fieldopt-build-path,b", po::value<std::string>(),
-                 "path to FieldOpt build folder")
+                ("fieldopt-build-dir,b", po::value<std::string>(),
+                 "path to FieldOpt build directory")
                 ("sim-drv-path,s", po::value<std::string>(),
                  "path to simulator driver file (e.g. *.DATA)")
                 ("simulation-timeout,t", po::value<int>(&simulation_timeout)->default_value(0),

--- a/FieldOpt/Runner/main.cpp
+++ b/FieldOpt/Runner/main.cpp
@@ -47,8 +47,8 @@ int main(int argc, char *argv[])
                  "type of runner (serial/oneoff)")
                 ("grid-path,g", po::value<std::string>(),
                  "path to model grid file (e.g. *.GRID)")
-                ("exec-path,e", po::value<std::string>(),
-                 "path to executable running reservoir simulation")
+                ("sim-exec-path,e", po::value<std::string>(),
+                 "path to script that executes the reservoir simulation")
                 ("sim-drv-path,s", po::value<std::string>(),
                  "path to simulator driver file (e.g. *.DATA)")
                 ("simulation-timeout,t", po::value<int>(&simulation_timeout)->default_value(0),

--- a/FieldOpt/Runner/main.cpp
+++ b/FieldOpt/Runner/main.cpp
@@ -49,6 +49,8 @@ int main(int argc, char *argv[])
                  "path to model grid file (e.g. *.GRID)")
                 ("sim-exec-path,e", po::value<std::string>(),
                  "path to script that executes the reservoir simulation")
+                ("fieldopt-build-path,b", po::value<std::string>(),
+                 "path to FieldOpt build folder")
                 ("sim-drv-path,s", po::value<std::string>(),
                  "path to simulator driver file (e.g. *.DATA)")
                 ("simulation-timeout,t", po::value<int>(&simulation_timeout)->default_value(0),

--- a/FieldOpt/Runner/runners/abstract_runner.cpp
+++ b/FieldOpt/Runner/runners/abstract_runner.cpp
@@ -72,7 +72,7 @@ void AbstractRunner::InitializeSettings(QString output_subdirectory)
 
     // Override FieldOpt build directory path if it has been passed as command line arguments
     if (runtime_settings_->fieldopt_build_dir().length() > 0)
-        settings_->simulator()->set_fieldopt_build_path(runtime_settings_->fieldopt_build_dir());
+        settings_->set_build_path(runtime_settings_->fieldopt_build_dir());
 }
 
 void AbstractRunner::InitializeModel()

--- a/FieldOpt/Runner/runners/abstract_runner.cpp
+++ b/FieldOpt/Runner/runners/abstract_runner.cpp
@@ -60,16 +60,19 @@ void AbstractRunner::InitializeSettings(QString output_subdirectory)
     settings_ = new Utilities::Settings::Settings(runtime_settings_->driver_file(), output_directory);
     settings_->set_verbosity(runtime_settings_->verbose());
 
-    // Override simulator driver, grid file and simulator executable paths if they have been passed as command line arguments
+    // Override simulator driver file if it has been passed as command line arguments
     if (runtime_settings_->simulator_driver_path().length() > 0)
         settings_->simulator()->set_driver_file_path(runtime_settings_->simulator_driver_path());
+    // Override grid file if it has been passed as command line arguments
     if (runtime_settings_->grid_file_path().length() > 0)
         settings_->model()->set_reservoir_grid_path(runtime_settings_->grid_file_path());
+    // Override simulator executable path if it has been passed as command line arguments
     if (runtime_settings_->simulator_exec_script_path().length() > 0)
         settings_->simulator()->set_execution_script_path(runtime_settings_->simulator_exec_script_path());
 
-    if (runtime_settings_->simulator_fieldopt_build_path().length() > 0)
-        settings_->simulator()->set_fieldopt_build_path(runtime_settings_->simulator_fieldopt_build_path());
+    // Override FieldOpt build directory path if it has been passed as command line arguments
+    if (runtime_settings_->fieldopt_build_dir().length() > 0)
+        settings_->simulator()->set_fieldopt_build_path(runtime_settings_->fieldopt_build_dir());
 }
 
 void AbstractRunner::InitializeModel()

--- a/FieldOpt/Runner/runners/abstract_runner.cpp
+++ b/FieldOpt/Runner/runners/abstract_runner.cpp
@@ -60,13 +60,16 @@ void AbstractRunner::InitializeSettings(QString output_subdirectory)
     settings_ = new Utilities::Settings::Settings(runtime_settings_->driver_file(), output_directory);
     settings_->set_verbosity(runtime_settings_->verbose());
 
-    // Override simulator driver and grid file paths if the have been passed as command line arguments
+    // Override simulator driver, grid file and simulator executable paths if they have been passed as command line arguments
     if (runtime_settings_->simulator_driver_path().length() > 0)
         settings_->simulator()->set_driver_file_path(runtime_settings_->simulator_driver_path());
     if (runtime_settings_->grid_file_path().length() > 0)
         settings_->model()->set_reservoir_grid_path(runtime_settings_->grid_file_path());
     if (runtime_settings_->simulator_exec_script_path().length() > 0)
         settings_->simulator()->set_execution_script_path(runtime_settings_->simulator_exec_script_path());
+
+    if (runtime_settings_->simulator_fieldopt_build_path().length() > 0)
+        settings_->simulator()->set_fieldopt_build_path(runtime_settings_->simulator_fieldopt_build_path());
 }
 
 void AbstractRunner::InitializeModel()

--- a/FieldOpt/Runner/runners/abstract_runner.cpp
+++ b/FieldOpt/Runner/runners/abstract_runner.cpp
@@ -65,6 +65,8 @@ void AbstractRunner::InitializeSettings(QString output_subdirectory)
         settings_->simulator()->set_driver_file_path(runtime_settings_->simulator_driver_path());
     if (runtime_settings_->grid_file_path().length() > 0)
         settings_->model()->set_reservoir_grid_path(runtime_settings_->grid_file_path());
+    if (runtime_settings_->simulator_exec_script_path().length() > 0)
+        settings_->simulator()->set_execution_script_path(runtime_settings_->simulator_exec_script_path());
 }
 
 void AbstractRunner::InitializeModel()

--- a/FieldOpt/Runner/runtime_settings.cpp
+++ b/FieldOpt/Runner/runtime_settings.cpp
@@ -70,19 +70,26 @@ RuntimeSettings::RuntimeSettings(boost::program_options::variables_map vm)
         else simulator_driver_path_ = sim_drv_path;
     } else simulator_driver_path_ = "";
 
+    if (vm.count("sim-exec-path")) {
+        QString sim_exec_path = QString::fromStdString(vm["sim-exec-path"].as<std::string>());
+        if (!Utilities::FileHandling::FileExists(sim_exec_path))
+            throw std::runtime_error("Custom executable file path specified as argument does not exist.");
+        else simulator_exec_script_path_ = sim_exec_path;
+    } else simulator_exec_script_path_ = "";
+
+    if (vm.count("fieldopt-build-path")) {
+        QString fieldopt_build_path = QString::fromStdString(vm["fieldopt-build-path"].as<std::string>());
+        if (!Utilities::FileHandling::FileExists(fieldopt_build_path))
+            throw std::runtime_error("Custom executable file path specified as argument does not exist.");
+        else simulator_fieldopt_build_path_ = fieldopt_build_path;
+    } else simulator_fieldopt_build_path_ = "";
+
     if (vm.count("grid-path")) {
         QString grid_path = QString::fromStdString(vm["grid-path"].as<std::string>());
         if (!Utilities::FileHandling::FileExists(grid_path))
             throw std::runtime_error("Grid file path specified as argument does not exist.");
         else grid_file_path_ = grid_path;
     } else grid_file_path_ = "";
-
-    if (vm.count("sim-exec-path")) {
-        QString exec_path = QString::fromStdString(vm["sim-exec-path"].as<std::string>());
-        if (!Utilities::FileHandling::FileExists(exec_path))
-            throw std::runtime_error("Custom executable file path specified as argument does not exist.");
-        else simulator_exec_script_path_ = exec_path;
-    } else simulator_exec_script_path_ = "";
 
     if (vm.count("well-prod-points")) {
         if (vm["well-prod-points"].as<std::vector<double>>().size() != 6)
@@ -107,6 +114,7 @@ RuntimeSettings::RuntimeSettings(boost::program_options::variables_map vm)
         std::cout << "Sim driver file:" << (simulator_driver_path_.length() > 0 ? simulator_driver_path_.toStdString() : "from FieldOpt driver file") << std::endl;
         std::cout << "Grid file path: " << (grid_file_path_.length() > 0 ? grid_file_path_.toStdString() : "from FieldOpt driver file") << std::endl;
         std::cout << "Exec file path: " << (simulator_exec_script_path_.length() > 0 ? simulator_exec_script_path_.toStdString() : "from FieldOpt driver file") << std::endl;
+        std::cout << "Build path: " << (simulator_fieldopt_build_path_.length() > 0 ? simulator_fieldopt_build_path_.toStdString() : "from FieldOpt driver file") << std::endl;
         std::cout << "Runner type:    " << runnerTypeString().toStdString() << std::endl;
         std::cout << "Verbose output: " << verbose_ << std::endl;
         std::cout << "Overwr. existing out files: " << overwrite_existing_ << std::endl;

--- a/FieldOpt/Runner/runtime_settings.cpp
+++ b/FieldOpt/Runner/runtime_settings.cpp
@@ -77,12 +77,12 @@ RuntimeSettings::RuntimeSettings(boost::program_options::variables_map vm)
         else grid_file_path_ = grid_path;
     } else grid_file_path_ = "";
 
-    if (vm.count("exec-path")) {
-        QString exec_path = QString::fromStdString(vm["exec-path"].as<std::string>());
+    if (vm.count("sim-exec-path")) {
+        QString exec_path = QString::fromStdString(vm["sim-exec-path"].as<std::string>());
         if (!Utilities::FileHandling::FileExists(exec_path))
             throw std::runtime_error("Custom executable file path specified as argument does not exist.");
-        else exec_file_path_ = exec_path;
-    } else exec_file_path_ = "";
+        else simulator_exec_script_path_ = exec_path;
+    } else simulator_exec_script_path_ = "";
 
     if (vm.count("well-prod-points")) {
         if (vm["well-prod-points"].as<std::vector<double>>().size() != 6)
@@ -106,7 +106,7 @@ RuntimeSettings::RuntimeSettings(boost::program_options::variables_map vm)
         std::cout << "Output dir:     " << output_dir().toStdString() << std::endl;
         std::cout << "Sim driver file:" << (simulator_driver_path_.length() > 0 ? simulator_driver_path_.toStdString() : "from FieldOpt driver file") << std::endl;
         std::cout << "Grid file path: " << (grid_file_path_.length() > 0 ? grid_file_path_.toStdString() : "from FieldOpt driver file") << std::endl;
-        std::cout << "Exec file path: " << (exec_file_path_.length() > 0 ? exec_file_path_.toStdString() : "from FieldOpt driver file") << std::endl;
+        std::cout << "Exec file path: " << (simulator_exec_script_path_.length() > 0 ? simulator_exec_script_path_.toStdString() : "from FieldOpt driver file") << std::endl;
         std::cout << "Runner type:    " << runnerTypeString().toStdString() << std::endl;
         std::cout << "Verbose output: " << verbose_ << std::endl;
         std::cout << "Overwr. existing out files: " << overwrite_existing_ << std::endl;

--- a/FieldOpt/Runner/runtime_settings.cpp
+++ b/FieldOpt/Runner/runtime_settings.cpp
@@ -77,12 +77,12 @@ RuntimeSettings::RuntimeSettings(boost::program_options::variables_map vm)
         else simulator_exec_script_path_ = sim_exec_path;
     } else simulator_exec_script_path_ = "";
 
-    if (vm.count("fieldopt-build-path")) {
-        QString fieldopt_build_path = QString::fromStdString(vm["fieldopt-build-path"].as<std::string>());
-        if (!Utilities::FileHandling::FileExists(fieldopt_build_path))
-            throw std::runtime_error("Custom executable file path specified as argument does not exist.");
-        else simulator_fieldopt_build_path_ = fieldopt_build_path;
-    } else simulator_fieldopt_build_path_ = "";
+    if (vm.count("fieldopt-build-dir")) {
+        QString fieldopt_build_dir = QString::fromStdString(vm["fieldopt-build-dir"].as<std::string>());
+        if (!Utilities::FileHandling::DirectoryExists(fieldopt_build_dir))
+            throw std::runtime_error("FieldOpt build directory specified as argument does not exist.");
+        else fieldopt_build_dir_ = fieldopt_build_dir;
+    } else fieldopt_build_dir_ = "";
 
     if (vm.count("grid-path")) {
         QString grid_path = QString::fromStdString(vm["grid-path"].as<std::string>());
@@ -114,7 +114,7 @@ RuntimeSettings::RuntimeSettings(boost::program_options::variables_map vm)
         std::cout << "Sim driver file:" << (simulator_driver_path_.length() > 0 ? simulator_driver_path_.toStdString() : "from FieldOpt driver file") << std::endl;
         std::cout << "Grid file path: " << (grid_file_path_.length() > 0 ? grid_file_path_.toStdString() : "from FieldOpt driver file") << std::endl;
         std::cout << "Exec file path: " << (simulator_exec_script_path_.length() > 0 ? simulator_exec_script_path_.toStdString() : "from FieldOpt driver file") << std::endl;
-        std::cout << "Build path: " << (simulator_fieldopt_build_path_.length() > 0 ? simulator_fieldopt_build_path_.toStdString() : "from FieldOpt driver file") << std::endl;
+        std::cout << "Build dir: " << fieldopt_build_dir_.toStdString() << std::endl;
         std::cout << "Runner type:    " << runnerTypeString().toStdString() << std::endl;
         std::cout << "Verbose output: " << verbose_ << std::endl;
         std::cout << "Overwr. existing out files: " << overwrite_existing_ << std::endl;

--- a/FieldOpt/Runner/runtime_settings.cpp
+++ b/FieldOpt/Runner/runtime_settings.cpp
@@ -120,6 +120,8 @@ RuntimeSettings::RuntimeSettings(boost::program_options::variables_map vm)
     QString RuntimeSettings::runnerTypeString() const {
     if (runner_type_ == RunnerType::SERIAL)
         return "serial";
+    else if (runner_type_ == RunnerType::ONEOFF)
+        return "oneoff";
     else return "NOT SET";
 }
 

--- a/FieldOpt/Runner/runtime_settings.cpp
+++ b/FieldOpt/Runner/runtime_settings.cpp
@@ -77,6 +77,13 @@ RuntimeSettings::RuntimeSettings(boost::program_options::variables_map vm)
         else grid_file_path_ = grid_path;
     } else grid_file_path_ = "";
 
+    if (vm.count("exec-path")) {
+        QString exec_path = QString::fromStdString(vm["exec-path"].as<std::string>());
+        if (!Utilities::FileHandling::FileExists(exec_path))
+            throw std::runtime_error("Custom executable file path specified as argument does not exist.");
+        else exec_file_path_ = exec_path;
+    } else exec_file_path_ = "";
+
     if (vm.count("well-prod-points")) {
         if (vm["well-prod-points"].as<std::vector<double>>().size() != 6)
             throw std::runtime_error("Exactly six coordinates must be provided for the production well position.");
@@ -99,6 +106,7 @@ RuntimeSettings::RuntimeSettings(boost::program_options::variables_map vm)
         std::cout << "Output dir:     " << output_dir().toStdString() << std::endl;
         std::cout << "Sim driver file:" << (simulator_driver_path_.length() > 0 ? simulator_driver_path_.toStdString() : "from FieldOpt driver file") << std::endl;
         std::cout << "Grid file path: " << (grid_file_path_.length() > 0 ? grid_file_path_.toStdString() : "from FieldOpt driver file") << std::endl;
+        std::cout << "Exec file path: " << (exec_file_path_.length() > 0 ? exec_file_path_.toStdString() : "from FieldOpt driver file") << std::endl;
         std::cout << "Runner type:    " << runnerTypeString().toStdString() << std::endl;
         std::cout << "Verbose output: " << verbose_ << std::endl;
         std::cout << "Overwr. existing out files: " << overwrite_existing_ << std::endl;

--- a/FieldOpt/Runner/runtime_settings.h
+++ b/FieldOpt/Runner/runtime_settings.h
@@ -57,7 +57,7 @@ public:
     QString output_dir() const { return output_dir_; }
     QString simulator_driver_path() const { return simulator_driver_path_; }
     QString grid_file_path() const { return grid_file_path_; }
-    QString exec_file_path() const { return exec_file_path_; }
+    QString simulator_exec_script_path() const { return simulator_exec_script_path_; }
     bool verbose() const { return verbose_; }
     bool overwrite_existing() const { return overwrite_existing_; }
     int max_parallel_sims() const { return max_parallel_sims_; }
@@ -71,7 +71,7 @@ private:
     QString output_dir_; //!< Directory in which to write all output.
     QString simulator_driver_path_; //!< Path to simulator driver file.
     QString grid_file_path_; //!< Path to reservoir grid file.
-    QString exec_file_path_; //!< Path to executable performing reservoir simulation.
+    QString simulator_exec_script_path_; //!< Path to script that launches the simulator.
     bool verbose_; //!< Verbose mode (i.e. whether or not to print detailed/debug/diagnostic info to the console while running).
     bool overwrite_existing_; //!< Whether or not files in the specified output directory should be overwritten (only relevant if the directory is not empty).
     int max_parallel_sims_; //!< Maximum number of parallel simulations to start. This is important to define if you for example have a limited number of simulator licenses.

--- a/FieldOpt/Runner/runtime_settings.h
+++ b/FieldOpt/Runner/runtime_settings.h
@@ -57,6 +57,7 @@ public:
     QString output_dir() const { return output_dir_; }
     QString simulator_driver_path() const { return simulator_driver_path_; }
     QString grid_file_path() const { return grid_file_path_; }
+    QString exec_file_path() const { return exec_file_path_; }
     bool verbose() const { return verbose_; }
     bool overwrite_existing() const { return overwrite_existing_; }
     int max_parallel_sims() const { return max_parallel_sims_; }
@@ -70,6 +71,7 @@ private:
     QString output_dir_; //!< Directory in which to write all output.
     QString simulator_driver_path_; //!< Path to simulator driver file.
     QString grid_file_path_; //!< Path to reservoir grid file.
+    QString exec_file_path_; //!< Path to executable performing reservoir simulation.
     bool verbose_; //!< Verbose mode (i.e. whether or not to print detailed/debug/diagnostic info to the console while running).
     bool overwrite_existing_; //!< Whether or not files in the specified output directory should be overwritten (only relevant if the directory is not empty).
     int max_parallel_sims_; //!< Maximum number of parallel simulations to start. This is important to define if you for example have a limited number of simulator licenses.

--- a/FieldOpt/Runner/runtime_settings.h
+++ b/FieldOpt/Runner/runtime_settings.h
@@ -58,7 +58,7 @@ public:
     QString simulator_driver_path() const { return simulator_driver_path_; }
     QString grid_file_path() const { return grid_file_path_; }
     QString simulator_exec_script_path() const { return simulator_exec_script_path_; }
-    QString simulator_fieldopt_build_path() const { return simulator_fieldopt_build_path_; }
+    QString fieldopt_build_dir() const { return fieldopt_build_dir_; }
     bool verbose() const { return verbose_; }
     bool overwrite_existing() const { return overwrite_existing_; }
     int max_parallel_sims() const { return max_parallel_sims_; }
@@ -73,7 +73,7 @@ private:
     QString simulator_driver_path_; //!< Path to simulator driver file.
     QString grid_file_path_; //!< Path to reservoir grid file.
     QString simulator_exec_script_path_; //!< Path to script that launches the simulator.
-    QString simulator_fieldopt_build_path_; //!< Directory in which FieldOpt is built.
+    QString fieldopt_build_dir_; //!< Directory in which FieldOpt is built.
     bool verbose_; //!< Verbose mode (i.e. whether or not to print detailed/debug/diagnostic info to the console while running).
     bool overwrite_existing_; //!< Whether or not files in the specified output directory should be overwritten (only relevant if the directory is not empty).
     int max_parallel_sims_; //!< Maximum number of parallel simulations to start. This is important to define if you for example have a limited number of simulator licenses.

--- a/FieldOpt/Runner/runtime_settings.h
+++ b/FieldOpt/Runner/runtime_settings.h
@@ -58,6 +58,7 @@ public:
     QString simulator_driver_path() const { return simulator_driver_path_; }
     QString grid_file_path() const { return grid_file_path_; }
     QString simulator_exec_script_path() const { return simulator_exec_script_path_; }
+    QString simulator_fieldopt_build_path() const { return simulator_fieldopt_build_path_; }
     bool verbose() const { return verbose_; }
     bool overwrite_existing() const { return overwrite_existing_; }
     int max_parallel_sims() const { return max_parallel_sims_; }
@@ -72,6 +73,7 @@ private:
     QString simulator_driver_path_; //!< Path to simulator driver file.
     QString grid_file_path_; //!< Path to reservoir grid file.
     QString simulator_exec_script_path_; //!< Path to script that launches the simulator.
+    QString simulator_fieldopt_build_path_; //!< Directory in which FieldOpt is built.
     bool verbose_; //!< Verbose mode (i.e. whether or not to print detailed/debug/diagnostic info to the console while running).
     bool overwrite_existing_; //!< Whether or not files in the specified output directory should be overwritten (only relevant if the directory is not empty).
     int max_parallel_sims_; //!< Maximum number of parallel simulations to start. This is important to define if you for example have a limited number of simulator licenses.

--- a/FieldOpt/Simulation/results/adgprsresults.cpp
+++ b/FieldOpt/Simulation/results/adgprsresults.cpp
@@ -25,6 +25,16 @@ void AdgprsResults::ReadResults(QString file_path)
     setAvailable();
 }
 
+void AdgprsResults::ReadResults(QString file_path, QString build_dir)
+{
+    if (file_path.split(".SIM.H5").length() == 1)
+        file_path = file_path + ".SIM.H5"; // Append the suffix if it's not already there
+    file_path_ = file_path;
+    build_dir_ = build_dir;
+    summary_reader_ = new AdgprsResultsReader::AdgprsResultsReader(file_path, build_dir);
+    setAvailable();
+}
+
 void AdgprsResults::DumpResults()
 {
     delete summary_reader_;

--- a/FieldOpt/Simulation/results/adgprsresults.h
+++ b/FieldOpt/Simulation/results/adgprsresults.h
@@ -23,6 +23,7 @@ public:
     // Results interface
 public:
     void ReadResults(QString file_path);
+    void ReadResults(QString file_path, QString build_dir);
     void DumpResults();
     double GetValue(Property prop);
     double GetValue(Property prop, QString well);
@@ -32,6 +33,7 @@ public:
 
 private:
     QString file_path_;
+    QString build_dir_;
     AdgprsResultsReader::AdgprsResultsReader *summary_reader_;
 
     // Mappings to summary keys.

--- a/FieldOpt/Simulation/results/eclresults.cpp
+++ b/FieldOpt/Simulation/results/eclresults.cpp
@@ -49,6 +49,11 @@ void ECLResults::ReadResults(QString file_path)
     setAvailable();
 }
 
+void ECLResults::ReadResults(QString file_path, QString build_dir)
+{
+
+}
+
 void ECLResults::DumpResults()
 {
     if (summary_reader_ != 0) delete summary_reader_;

--- a/FieldOpt/Simulation/results/eclresults.h
+++ b/FieldOpt/Simulation/results/eclresults.h
@@ -43,6 +43,7 @@ public:
     ECLResults();
 
     void ReadResults(QString file_path);
+    void ReadResults(QString file_path, QString build_dir);
     void DumpResults();
 
 

--- a/FieldOpt/Simulation/results/results.h
+++ b/FieldOpt/Simulation/results/results.h
@@ -75,7 +75,7 @@ public:
     /*!
      * \brief ReadResults Read the summary data from file.
      * \param file_path The path to the summary file without suffixes.
-     * \param build_dir
+     * \param build_dir Path to the FieldOpt build directory.
      */
     virtual void ReadResults(QString file_path, QString build_dir) = 0;
 

--- a/FieldOpt/Simulation/results/results.h
+++ b/FieldOpt/Simulation/results/results.h
@@ -73,6 +73,13 @@ public:
     virtual void ReadResults(QString file_path) = 0;
 
     /*!
+     * \brief ReadResults Read the summary data from file.
+     * \param file_path The path to the summary file without suffixes.
+     * \param build_dir
+     */
+    virtual void ReadResults(QString file_path, QString build_dir) = 0;
+
+    /*!
      * \brief DumpResults Dump the results that have been read. Should be called when the results are no longer valid.
      *
      * Should call setUnavailable().

--- a/FieldOpt/Simulation/simulator_interfaces/adgprssimulator.cpp
+++ b/FieldOpt/Simulation/simulator_interfaces/adgprssimulator.cpp
@@ -34,6 +34,9 @@ namespace Simulation {
             else
                 script_path_ = ExecutionScripts::GetScriptPath(settings->simulator()->script_name());
             script_args_ = (QStringList() << output_directory_ << output_directory_+"/"+initial_driver_file_name_);
+
+            if (settings->build_path().length() > 0)
+                build_dir_ = settings->build_path();
         }
 
         void AdgprsSimulator::Evaluate()
@@ -43,8 +46,7 @@ namespace Simulation {
             driver_file_writer_->WriteDriverFile(output_directory_);
             ::Utilities::Unix::ExecShellScript(script_path_, script_args_);
 
-            build_dir_ = settings_->simulator()->fieldopt_build_path();
-            if (settings_->simulator()->fieldopt_build_path().length() > 0)
+            if (build_dir_.length() > 0)
                 results_->ReadResults(output_h5_summary_file_path_, build_dir_);
             else
                 results_->ReadResults(output_h5_summary_file_path_);

--- a/FieldOpt/Simulation/simulator_interfaces/adgprssimulator.cpp
+++ b/FieldOpt/Simulation/simulator_interfaces/adgprssimulator.cpp
@@ -29,14 +29,14 @@ namespace Simulation {
             results_ = new Simulation::Results::AdgprsResults();
             driver_file_writer_ = new DriverFileWriters::AdgprsDriverFileWriter(settings_, model_);
 
+            if (settings->build_path().length() > 0)
+                build_dir_ = settings->build_path() + "/";
+
             if (settings->simulator()->custom_simulator_execution_script_path().length() > 0)
                 script_path_ = settings->simulator()->custom_simulator_execution_script_path();
             else
-                script_path_ = ExecutionScripts::GetScriptPath(settings->simulator()->script_name());
+                script_path_ = build_dir_ + ExecutionScripts::GetScriptPath(settings->simulator()->script_name());
             script_args_ = (QStringList() << output_directory_ << output_directory_+"/"+initial_driver_file_name_);
-
-            if (settings->build_path().length() > 0)
-                build_dir_ = settings->build_path();
         }
 
         void AdgprsSimulator::Evaluate()

--- a/FieldOpt/Simulation/simulator_interfaces/adgprssimulator.cpp
+++ b/FieldOpt/Simulation/simulator_interfaces/adgprssimulator.cpp
@@ -42,7 +42,13 @@ namespace Simulation {
             copyDriverFiles();
             driver_file_writer_->WriteDriverFile(output_directory_);
             ::Utilities::Unix::ExecShellScript(script_path_, script_args_);
-            results_->ReadResults(output_h5_summary_file_path_);
+
+            build_dir_ = settings_->simulator()->fieldopt_build_path();
+            if (settings_->simulator()->fieldopt_build_path().length() > 0)
+                results_->ReadResults(output_h5_summary_file_path_, build_dir_);
+            else
+                results_->ReadResults(output_h5_summary_file_path_);
+
         }
 
         void AdgprsSimulator::CleanUp()

--- a/FieldOpt/Simulation/simulator_interfaces/adgprssimulator.cpp
+++ b/FieldOpt/Simulation/simulator_interfaces/adgprssimulator.cpp
@@ -29,7 +29,10 @@ namespace Simulation {
             results_ = new Simulation::Results::AdgprsResults();
             driver_file_writer_ = new DriverFileWriters::AdgprsDriverFileWriter(settings_, model_);
 
-            script_path_ = ExecutionScripts::GetScriptPath(settings->simulator()->script_name());
+            if (settings->simulator()->custom_simulator_execution_script_path().length() > 0)
+                script_path_ = settings->simulator()->custom_simulator_execution_script_path();
+            else
+                script_path_ = ExecutionScripts::GetScriptPath(settings->simulator()->script_name());
             script_args_ = (QStringList() << output_directory_ << output_directory_+"/"+initial_driver_file_name_);
         }
 

--- a/FieldOpt/Simulation/simulator_interfaces/adgprssimulator.cpp
+++ b/FieldOpt/Simulation/simulator_interfaces/adgprssimulator.cpp
@@ -8,35 +8,17 @@ namespace Simulation {
     namespace SimulatorInterfaces {
 
         AdgprsSimulator::AdgprsSimulator(Utilities::Settings::Settings *settings, Model::Model *model)
+        : Simulator(settings)
         {
-            if (!Utilities::FileHandling::FileExists(settings->simulator()->driver_file_path()))
-                DriverFileDoesNotExistException(settings->simulator()->driver_file_path());
-            initial_driver_file_path_ = settings->simulator()->driver_file_path();
-
-            if (!Utilities::FileHandling::DirectoryExists(settings->output_directory()))
-                OutputDirectoryDoesNotExistException(settings->output_directory());
-            output_directory_ = settings->output_directory();
-
             QStringList tmp = initial_driver_file_path_.split("/");
-            initial_driver_file_name_ = tmp.last();
             tmp.removeLast();
             initial_driver_file_parent_dir_path_ = tmp.join("/");
             verifyOriginalDriverFileDirectory();
             output_h5_summary_file_path_ = output_directory_ + "/" + initial_driver_file_name_.split(".").first() + ".SIM.H5";
 
             model_ = model;
-            settings_ = settings;
             results_ = new Simulation::Results::AdgprsResults();
             driver_file_writer_ = new DriverFileWriters::AdgprsDriverFileWriter(settings_, model_);
-
-            if (settings->build_path().length() > 0)
-                build_dir_ = settings->build_path() + "/";
-
-            if (settings->simulator()->custom_simulator_execution_script_path().length() > 0)
-                script_path_ = settings->simulator()->custom_simulator_execution_script_path();
-            else
-                script_path_ = build_dir_ + ExecutionScripts::GetScriptPath(settings->simulator()->script_name());
-            script_args_ = (QStringList() << output_directory_ << output_directory_+"/"+initial_driver_file_name_);
         }
 
         void AdgprsSimulator::Evaluate()

--- a/FieldOpt/Simulation/simulator_interfaces/adgprssimulator.h
+++ b/FieldOpt/Simulation/simulator_interfaces/adgprssimulator.h
@@ -40,6 +40,7 @@ namespace Simulation {
             QString initial_driver_file_name_;
             QString output_h5_summary_file_path_;
             QString script_path_;
+            QString build_dir_;
             QStringList script_args_;
             Simulation::SimulatorInterfaces::DriverFileWriters::AdgprsDriverFileWriter *driver_file_writer_;
             void copyDriverFiles(); //!< Copy the original driver files.

--- a/FieldOpt/Simulation/simulator_interfaces/adgprssimulator.h
+++ b/FieldOpt/Simulation/simulator_interfaces/adgprssimulator.h
@@ -37,11 +37,7 @@ namespace Simulation {
 
         private:
             QString initial_driver_file_parent_dir_path_;
-            QString initial_driver_file_name_;
             QString output_h5_summary_file_path_;
-            QString script_path_;
-            QString build_dir_;
-            QStringList script_args_;
             Simulation::SimulatorInterfaces::DriverFileWriters::AdgprsDriverFileWriter *driver_file_writer_;
             void copyDriverFiles(); //!< Copy the original driver files.
             void verifyOriginalDriverFileDirectory(); //!< Ensure that all necessary files are present in the original dir.

--- a/FieldOpt/Simulation/simulator_interfaces/eclsimulator.cpp
+++ b/FieldOpt/Simulation/simulator_interfaces/eclsimulator.cpp
@@ -8,19 +8,8 @@ namespace Simulation {
     namespace SimulatorInterfaces {
 
         ECLSimulator::ECLSimulator(Utilities::Settings::Settings *settings, Model::Model *model)
+        : Simulator(settings)
         {
-            if (settings->driver_path().length() == 0)
-                throw DriverFileInvalidException("A path to a valid simulator driver file must be specified in the FieldOpt driver file or as a command line parameter.");
-
-            if (Utilities::FileHandling::FileExists(settings->driver_path()))
-                initial_driver_file_path_ = settings->driver_path();
-            else throw DriverFileDoesNotExistException(settings->driver_path());
-
-            if (Utilities::FileHandling::DirectoryExists(settings->output_directory()))
-                output_directory_ = settings->output_directory();
-            else throw OutputDirectoryDoesNotExistException(settings->output_directory());
-
-            settings_ = settings;
             model_ = model;
             driver_file_writer_ = new DriverFileWriters::EclDriverFileWriter(settings, model_);
 

--- a/FieldOpt/Simulation/simulator_interfaces/eclsimulator.h
+++ b/FieldOpt/Simulation/simulator_interfaces/eclsimulator.h
@@ -7,7 +7,7 @@
 #include <QStringList>
 
 namespace Simulation {
-namespace SimulatorInterfaces {
+    namespace SimulatorInterfaces {
 
 
 /*!
@@ -25,38 +25,38 @@ namespace SimulatorInterfaces {
  *
  * \todo Support custom execution commands.
  */
-class ECLSimulator : public Simulator
-{
-public:
-    ECLSimulator(Utilities::Settings::Settings *settings, Model::Model *model);
+        class ECLSimulator : public Simulator
+        {
+        public:
+            ECLSimulator(Utilities::Settings::Settings *settings, Model::Model *model);
 
-    /*!
-     * \brief Evaluate Executes the simulation of the current model. The evaluation is blocking.
-     */
-    void Evaluate();
+            /*!
+             * \brief Evaluate Executes the simulation of the current model. The evaluation is blocking.
+             */
+            void Evaluate();
 
-    /*!
-     * \brief CleanUp Deletes files created during the simulation.
-     * All files except the .DATA, .UNSMRY, .SMSPEC  and .LOG are deleted.
-     */
-    void CleanUp();
+            /*!
+             * \brief CleanUp Deletes files created during the simulation.
+             * All files except the .DATA, .UNSMRY, .SMSPEC  and .LOG are deleted.
+             */
+            void CleanUp();
 
-private:
-    DriverFileWriters::EclDriverFileWriter *driver_file_writer_;
-    QString script_path_;
-    QStringList script_args_;
+        private:
+            DriverFileWriters::EclDriverFileWriter *driver_file_writer_;
+            QString script_path_;
+            QStringList script_args_;
 
-    // Simulator interface
-protected:
-    void UpdateFilePaths();
+            // Simulator interface
+        protected:
+            void UpdateFilePaths();
 
-    // Simulator interface
-public:
-    QString GetCompdatString();
+            // Simulator interface
+        public:
+            QString GetCompdatString();
 
-    virtual bool Evaluate(int timeout) override;
-};
+            virtual bool Evaluate(int timeout) override;
+        };
 
-}
+    }
 }
 #endif // ECLSIMULATOR_H

--- a/FieldOpt/Simulation/simulator_interfaces/simulator.h
+++ b/FieldOpt/Simulation/simulator_interfaces/simulator.h
@@ -1,28 +1,3 @@
-/******************************************************************************
- *
- *
- *
- * Created: 15.10.2015 2015 by einar
- *
- * This file is part of the FieldOpt project.
- *
- * Copyright (C) 2015-2015 Einar J.M. Baumann <einar.baumann@ntnu.no>
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
- *****************************************************************************/
-
 #ifndef SIMULATOR
 #define SIMULATOR
 
@@ -34,7 +9,7 @@
 #include "Simulation/execution_scripts/execution_scripts.h"
 
 namespace Simulation {
-namespace SimulatorInterfaces {
+    namespace SimulatorInterfaces {
 
 /*!
  * \brief The Simulator class acts as an interface for all reservoir simulators.
@@ -49,58 +24,64 @@ namespace SimulatorInterfaces {
  *  sim.CleanUp();
  * \endcode
  */
-class Simulator {
-public:
-    /*!
-     * \brief SetOutputDirectory Set the directory in which to execute the simulation.
-     */
-    void SetOutputDirectory(QString output_directory);
+        class Simulator {
+        public:
+            /*!
+             * \brief SetOutputDirectory Set the directory in which to execute the simulation.
+             */
+            void SetOutputDirectory(QString output_directory);
 
-    /*!
-     * \brief results Get the simulation results.
-     */
-    ::Simulation::Results::Results *results();
+            /*!
+             * \brief results Get the simulation results.
+             */
+            ::Simulation::Results::Results *results();
 
-    /*!
-     * \brief Evaluate Writes the driver file and executes a simulation of the model.
-     */
-    virtual void Evaluate() = 0;
+            /*!
+             * \brief Evaluate Writes the driver file and executes a simulation of the model.
+             */
+            virtual void Evaluate() = 0;
 
-    /*!
-     * \brief Evaluate Writes the driver file and executes a simulation of the model. The simulation
-     * is terminated after the amount of seconds provided in the timeout argument.
-     * @param timeout Number of seconds before the simulation should be terminated.
-     * @return True if the simuation completes before the set timeout, otherwise false.
-     */
-    virtual bool Evaluate(int timeout) = 0;
+            /*!
+             * \brief Evaluate Writes the driver file and executes a simulation of the model. The simulation
+             * is terminated after the amount of seconds provided in the timeout argument.
+             * @param timeout Number of seconds before the simulation should be terminated.
+             * @return True if the simuation completes before the set timeout, otherwise false.
+             */
+            virtual bool Evaluate(int timeout) = 0;
 
-    /*!
-     * \brief CleanUp Perform cleanup after simulation, i.e. delete output files.
-     */
-    virtual void CleanUp() = 0;
+            /*!
+             * \brief CleanUp Perform cleanup after simulation, i.e. delete output files.
+             */
+            virtual void CleanUp() = 0;
 
-    /*!
-     * \brief GetCompdatString Get the compdat section used in the simulation's driver file.
-     * \return String containing the compdat section.
-     */
-    virtual QString GetCompdatString() = 0;
+            /*!
+             * \brief GetCompdatString Get the compdat section used in the simulation's driver file.
+             * \return String containing the compdat section.
+             */
+            virtual QString GetCompdatString() = 0;
 
-protected:
-    /*!
-     * \brief Simulator This constructor should only be called by child classes.
-     */
-    Simulator(){}
+        protected:
+            /*!
+             * Set various path variables. Should only be called by child classes.
+             * @param settings
+             * @return
+             */
+            Simulator(Utilities::Settings::Settings *settings);
 
-    QString initial_driver_file_path_; //!< Path to the driver file to be used as a base for the generated driver files.
-    QString output_directory_; //!< The directory in which to write new driver files and execute simulations.
+            QString initial_driver_file_path_; //!< Path to the driver file to be used as a base for the generated driver files.
+            QString output_directory_; //!< The directory in which to write new driver files and execute simulations.
+            QString initial_driver_file_name_;
 
-    ::Simulation::Results::Results *results_;
-    Utilities::Settings::Settings *settings_;
-    Model::Model *model_;
-    virtual void UpdateFilePaths() = 0;
-};
+            ::Simulation::Results::Results *results_;
+            Utilities::Settings::Settings *settings_;
+            Model::Model *model_;
+            QString build_dir_;
+            QString script_path_;
+            QStringList script_args_;
+            virtual void UpdateFilePaths() = 0;
+        };
 
-}
+    }
 }
 
 #endif // SIMULATOR

--- a/FieldOpt/Utilities/file_handling/filehandling.cpp
+++ b/FieldOpt/Utilities/file_handling/filehandling.cpp
@@ -74,16 +74,9 @@ void Utilities::FileHandling::WriteLineToFile(QString string, QString file_path)
     file.close();
 }
 
-QString Utilities::FileHandling::GetBuildDirectoryPath()
+QString Utilities::FileHandling::GetCurrentDirectoryPath()
 {
     QDir path = QDir::currentPath(); // Get current directory
-    return path.absolutePath();
-}
-
-QString Utilities::FileHandling::GetProjectDirectoryPath()
-{
-    QDir path(GetBuildDirectoryPath());
-    path.cdUp();
     return path.absolutePath();
 }
 

--- a/FieldOpt/Utilities/file_handling/filehandling.cpp
+++ b/FieldOpt/Utilities/file_handling/filehandling.cpp
@@ -117,7 +117,7 @@ void Utilities::FileHandling::CopyDirectory(QString origin, QString destination)
     if (!DirectoryExists(origin))
         throw DirectoryNotFoundException("Can't find parent directory for copying: ", origin);
     if (!DirectoryExists(destination))
-        throw DirectoryNotFoundException("Cant findt destination (parent) directory for copying: ", destination);
+        throw DirectoryNotFoundException("Can't find destination (parent) directory for copying: ", destination);
     QDir original(origin);
     QFileInfoList entries = original.entryInfoList(QDir::AllEntries | QDir::NoDotAndDotDot, QDir::DirsLast);
 

--- a/FieldOpt/Utilities/file_handling/filehandling.h
+++ b/FieldOpt/Utilities/file_handling/filehandling.h
@@ -95,20 +95,11 @@ namespace Utilities {
 
 
 /*!
- * \brief GetBuildDirectoryPath Gets the absolute path to the first directory in the tree
- * that starts with build-.
+ * \brief GetCurrentDirectoryPath Gets the absolute path to the current directory.
  *
  * \todo Improve this.
  */
-        QString GetBuildDirectoryPath();
-
-/*!
- * \brief GetProjectDirectoryPath Gets the absolute path to the project directory. Note that
- * this assumes that the root project directory contains the build directory.
- *
- * \todo Improve this.
- */
-        QString GetProjectDirectoryPath();
+        QString GetCurrentDirectoryPath();
 
     }
 }

--- a/FieldOpt/Utilities/settings/settings.cpp
+++ b/FieldOpt/Utilities/settings/settings.cpp
@@ -1,28 +1,3 @@
-/******************************************************************************
- *
- * settings.cpp
- *
- * Created: 28.09.2015 2015 by einar
- *
- * This file is part of the FieldOpt project.
- *
- * Copyright (C) 2015-2015 Einar J.M. Baumann <einar.baumann@ntnu.no>
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
- *****************************************************************************/
-
 #include "settings.h"
 #include "settings_exceptions.h"
 #include "Utilities/file_handling/filehandling.h"
@@ -31,106 +6,113 @@
 #include <iostream>
 
 namespace Utilities {
-namespace Settings {
+    namespace Settings {
 
-Settings::Settings(QString driver_path, QString output_directory)
-{
-    std::cout << "Reading driver: " + driver_path.toStdString() << std::endl;
-    if (!::Utilities::FileHandling::FileExists(driver_path))
-        throw FileNotFoundException(driver_path.toStdString());
-    driver_path_ = driver_path;
-    readDriverFile();
-    output_directory_ = output_directory;
-    simulator_->output_directory_ = output_directory;
-}
+        Settings::Settings(QString driver_path, QString output_directory)
+        {
+            std::cout << "Reading driver: " + driver_path.toStdString() << std::endl;
+            if (!::Utilities::FileHandling::FileExists(driver_path))
+                throw FileNotFoundException(driver_path.toStdString());
+            driver_path_ = driver_path;
+            readDriverFile();
+            output_directory_ = output_directory;
+            simulator_->output_directory_ = output_directory;
+        }
 
-QString Settings::GetLogCsvString() const
-{
-    QStringList header  = QStringList();
-    QStringList content = QStringList();
-    header  << "name"
-            << "maxevals"
-            << "initstep"
-            << "minstep";
-    content << name_
-            << QString::number(optimizer_->parameters().max_evaluations)
-            << QString::number(optimizer_->parameters().initial_step_length)
-            << QString::number(optimizer_->parameters().minimum_step_length);
+        QString Settings::GetLogCsvString() const
+        {
+            QStringList header  = QStringList();
+            QStringList content = QStringList();
+            header  << "name"
+                    << "maxevals"
+                    << "initstep"
+                    << "minstep";
+            content << name_
+                    << QString::number(optimizer_->parameters().max_evaluations)
+                    << QString::number(optimizer_->parameters().initial_step_length)
+                    << QString::number(optimizer_->parameters().minimum_step_length);
 
-    return QString("%1\n%2").arg(header.join(",")).arg(content.join(","));
-}
+            return QString("%1\n%2").arg(header.join(",")).arg(content.join(","));
+        }
 
-void Settings::readDriverFile()
-{
-    QFile *file = new QFile(driver_path_);
-    if (!file->open(QIODevice::ReadOnly))
-        throw DriverFileReadException("Unable to open the driver file");
+        void Settings::readDriverFile()
+        {
+            QFile *file = new QFile(driver_path_);
+            if (!file->open(QIODevice::ReadOnly))
+                throw DriverFileReadException("Unable to open the driver file");
 
-    QByteArray data = file->readAll();
+            QByteArray data = file->readAll();
 
-    QJsonDocument json = QJsonDocument::fromJson(data);
-    if (json.isNull())
-        throw DriverFileJsonParsingException("Unable to parse the input file to JSON.");
+            QJsonDocument json = QJsonDocument::fromJson(data);
+            if (json.isNull())
+                throw DriverFileJsonParsingException("Unable to parse the input file to JSON.");
 
-    if (!json.isObject())
-        throw DriverFileFormatException("Driver file format incorrect. Must be a JSON object.");
+            if (!json.isObject())
+                throw DriverFileFormatException("Driver file format incorrect. Must be a JSON object.");
 
-    json_driver_ = new QJsonObject(json.object());
+            json_driver_ = new QJsonObject(json.object());
 
-    readGlobalSection();
-    readSimulatorSection();
-    readModelSection();
-    readOptimizerSection();
+            readGlobalSection();
+            readSimulatorSection();
+            readModelSection();
+            readOptimizerSection();
 
-    file->close();
-}
+            file->close();
+        }
 
-void Settings::readGlobalSection()
-{
-    try {
-        QJsonObject global = json_driver_->value("Global").toObject();
-        name_ = global["Name"].toString();
-        bookkeeper_tolerance_ = global["BookkeeperTolerance"].toDouble();
-        if (bookkeeper_tolerance_ < 0.0) throw UnableToParseGlobalSectionException("The bookkeeper tolerance must be a positive number.");
+        void Settings::readGlobalSection()
+        {
+            try {
+                QJsonObject global = json_driver_->value("Global").toObject();
+                name_ = global["Name"].toString();
+                bookkeeper_tolerance_ = global["BookkeeperTolerance"].toDouble();
+                if (bookkeeper_tolerance_ < 0.0) throw UnableToParseGlobalSectionException("The bookkeeper tolerance must be a positive number.");
+            }
+            catch (std::exception const &ex) {
+                throw UnableToParseGlobalSectionException("Unable to parse driver file global section: " + std::string(ex.what()));
+            }
+        }
+
+        void Settings::readSimulatorSection()
+        {
+            // Simulator root
+            try {
+                QJsonObject json_simulator = json_driver_->value("Simulator").toObject();
+                simulator_ = new Simulator(json_simulator);
+            }
+            catch (std::exception const &ex) {
+                throw UnableToParseSimulatorSectionException("Unable to parse driver file simulator section: " + std::string(ex.what()));
+            }
+        }
+
+        void Settings::readOptimizerSection()
+        {
+            try {
+                QJsonObject optimizer = json_driver_->value("Optimizer").toObject();
+                optimizer_ = new Optimizer(optimizer);
+            }
+            catch (std::exception const &ex) {
+                throw UnableToParseOptimizerSectionException("Unable to parse driver file optimizer section: " + std::string(ex.what()));
+            }
+        }
+
+        void Settings::readModelSection()
+        {
+            try {
+                QJsonObject model = json_driver_->value("Model").toObject();
+                model_ = new Model(model);
+            }
+            catch (std::exception const &ex) {
+                throw UnableToParseModelSectionException("Unable to parse model section: " + std::string(ex.what()));
+            }
+        }
+
+        void Settings::set_build_path(const QString &build_path)
+        {
+            if (!Utilities::FileHandling::DirectoryExists(build_path))
+                throw std::runtime_error("Attempted to set the build path to a non-existent directory.");
+            build_path_ = build_path;
+        }
+
     }
-    catch (std::exception const &ex) {
-        throw UnableToParseGlobalSectionException("Unable to parse driver file global section: " + std::string(ex.what()));
-    }
-}
-
-void Settings::readSimulatorSection()
-{
-    // Simulator root
-    try {
-        QJsonObject json_simulator = json_driver_->value("Simulator").toObject();
-        simulator_ = new Simulator(json_simulator);
-    }
-    catch (std::exception const &ex) {
-        throw UnableToParseSimulatorSectionException("Unable to parse driver file simulator section: " + std::string(ex.what()));
-    }
-}
-
-void Settings::readOptimizerSection()
-{
-    try {
-        QJsonObject optimizer = json_driver_->value("Optimizer").toObject();
-        optimizer_ = new Optimizer(optimizer);
-    }
-    catch (std::exception const &ex) {
-        throw UnableToParseOptimizerSectionException("Unable to parse driver file optimizer section: " + std::string(ex.what()));
-    }
-}
-
-void Settings::readModelSection()
-{
-    try {
-        QJsonObject model = json_driver_->value("Model").toObject();
-        model_ = new Model(model);
-    }
-    catch (std::exception const &ex) {
-        throw UnableToParseModelSectionException("Unable to parse model section: " + std::string(ex.what()));
-    }
-}
-
-}
 }

--- a/FieldOpt/Utilities/settings/settings.h
+++ b/FieldOpt/Utilities/settings/settings.h
@@ -66,6 +66,9 @@ public:
 
     QString GetLogCsvString() const; //!< Get a string containing the CSV header and contents for the log.
 
+    const QString &build_path() const { return build_path_; } //!< Get the to the FieldOpt build directory.
+    void set_build_path(const QString &build_path); //!< Set the path to the FieldOpt build directory.
+
 private:
     QString driver_path_;
     QJsonObject *json_driver_;
@@ -76,6 +79,7 @@ private:
     Model *model_;
     Utilities::Settings::Optimizer *optimizer_;
     Simulator *simulator_;
+    QString build_path_;
 
     void readDriverFile();
     void readGlobalSection();

--- a/FieldOpt/Utilities/settings/simulator.cpp
+++ b/FieldOpt/Utilities/settings/simulator.cpp
@@ -1,73 +1,48 @@
-/******************************************************************************
- *
- * simulator.cpp
- *
- * Created: 28.09.2015 2015 by einar
- *
- * This file is part of the FieldOpt project.
- *
- * Copyright (C) 2015-2015 Einar J.M. Baumann <einar.baumann@ntnu.no>
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
- *****************************************************************************/
-
 #include "simulator.h"
 #include "settings_exceptions.h"
 
 namespace Utilities {
-namespace Settings {
+    namespace Settings {
 
-Simulator::Simulator(QJsonObject json_simulator)
-{
-    // Driver path
-    if (json_simulator.contains("DriverPath"))
-        driver_file_path_ = json_simulator["DriverPath"].toString();
-    else driver_file_path_ = "";
+        Simulator::Simulator(QJsonObject json_simulator)
+        {
+            // Driver path
+            if (json_simulator.contains("DriverPath"))
+                driver_file_path_ = json_simulator["DriverPath"].toString();
+            else driver_file_path_ = "";
 
-    // Simulator type
-    QString type = json_simulator["Type"].toString();
-    if (QString::compare(type, "ECLIPSE") == 0)
-        type_ = SimulatorType::ECLIPSE;
-    else if (QString::compare(type, "ADGPRS") == 0)
-        type_ = SimulatorType::ADGPRS;
-    else throw SimulatorTypeNotRecognizedException("The simulator type " + type.toStdString() + " was not recognized");
+            // Simulator type
+            QString type = json_simulator["Type"].toString();
+            if (QString::compare(type, "ECLIPSE") == 0)
+                type_ = SimulatorType::ECLIPSE;
+            else if (QString::compare(type, "ADGPRS") == 0)
+                type_ = SimulatorType::ADGPRS;
+            else throw SimulatorTypeNotRecognizedException("The simulator type " + type.toStdString() + " was not recognized");
 
-    // Simulator commands
-    QJsonArray commands = json_simulator["Commands"].toArray();
-    script_name_ = "";
-    if (json_simulator.contains("ExecutionScript") && json_simulator["ExecutionScript"].toString().size() > 0) {
-        script_name_ = json_simulator["ExecutionScript"].toString();
-    }
-    if (json_simulator.contains("Commands") && commands.size() > 0) {
-        commands_ = new QStringList();
-        for (int i = 0; i < commands.size(); ++i) {
-            commands_->append(commands[i].toString());
+            // Simulator commands
+            QJsonArray commands = json_simulator["Commands"].toArray();
+            script_name_ = "";
+            if (json_simulator.contains("ExecutionScript") && json_simulator["ExecutionScript"].toString().size() > 0) {
+                script_name_ = json_simulator["ExecutionScript"].toString();
+            }
+            if (json_simulator.contains("Commands") && commands.size() > 0) {
+                commands_ = new QStringList();
+                for (int i = 0; i < commands.size(); ++i) {
+                    commands_->append(commands[i].toString());
+                }
+            }
+            if (script_name_.length() == 0 && commands.size() == 0)
+                throw NoSimulatorCommandsGivenException("At least one simulator command or a simulator script must be given.");
+
+            if (json_simulator.contains("FluidModel")) {
+                QString fluid_model = json_simulator["FluidModel"].toString();
+                if (QString::compare(fluid_model, "DeadOil") == 0)
+                    fluid_model_ = SimulatorFluidModel::DeadOil;
+                else if (QString::compare(fluid_model, "BlackOil") == 0)
+                    fluid_model_ = SimulatorFluidModel::BlackOil;
+            }
+            else fluid_model_ = SimulatorFluidModel::BlackOil;
         }
-    }
-    if (script_name_.length() == 0 && commands.size() == 0)
-        throw NoSimulatorCommandsGivenException("At least one simulator command or a simulator script must be given.");
 
-    if (json_simulator.contains("FluidModel")) {
-        QString fluid_model = json_simulator["FluidModel"].toString();
-        if (QString::compare(fluid_model, "DeadOil") == 0)
-            fluid_model_ = SimulatorFluidModel::DeadOil;
-        else if (QString::compare(fluid_model, "BlackOil") == 0)
-            fluid_model_ = SimulatorFluidModel::BlackOil;
     }
-    else fluid_model_ = SimulatorFluidModel::BlackOil;
-}
-
-}
 }

--- a/FieldOpt/Utilities/settings/simulator.h
+++ b/FieldOpt/Utilities/settings/simulator.h
@@ -51,6 +51,8 @@ public:
     QString script_name() const { return script_name_; } //!< Get the name of the script to be used to execute simulations.
     QString driver_file_path() const { return driver_file_path_; } //!< Get the path to the driver file.
     void set_driver_file_path(const QString path) { driver_file_path_ = path; } //!< Set the driver file path. Used when the path is passed by command line argument.
+    void set_execution_script_path (const QString path) { custom_exec_script_path_ = path; } //!< Set a custom path for the simulator execution script.
+    QString custom_simulator_execution_script_path() const { return custom_exec_script_path_; }
     QString output_directory() const { return output_directory_; } //!< Get the output directory path.
     SimulatorFluidModel fluid_model() const { return fluid_model_; } //!< Get the fluid model
 
@@ -62,6 +64,7 @@ private:
     QString script_name_;
     QString driver_file_path_;
     QString output_directory_;
+    QString custom_exec_script_path_;
 };
 
 }

--- a/FieldOpt/Utilities/settings/simulator.h
+++ b/FieldOpt/Utilities/settings/simulator.h
@@ -1,28 +1,3 @@
-/******************************************************************************
- *
- * simulator.h
- *
- * Created: 28.09.2015 2015 by einar
- *
- * This file is part of the FieldOpt project.
- *
- * Copyright (C) 2015-2015 Einar J.M. Baumann <einar.baumann@ntnu.no>
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
- *****************************************************************************/
-
 #ifndef SETTINGS_SIMULATOR_H
 #define SETTINGS_SIMULATOR_H
 
@@ -31,46 +6,43 @@
 #include <QStringList>
 
 namespace Utilities {
-namespace Settings {
+    namespace Settings {
 
 /*!
  * \brief The Simulator class contains simulator-specific settings. Simulator settings objects
  * may _only_ be created by the Settings class. They are created when reading a JSON-formatted
  * "driver file".
  */
-class Simulator
-{
-    friend class Settings;
+        class Simulator
+        {
+            friend class Settings;
 
-public:
-    enum SimulatorType { ECLIPSE, ADGPRS };
-    enum SimulatorFluidModel { BlackOil, DeadOil };
+        public:
+            enum SimulatorType { ECLIPSE, ADGPRS };
+            enum SimulatorFluidModel { BlackOil, DeadOil };
 
-    SimulatorType type() const { return type_; } //!< Get the simulator type (e.g. ECLIPSE).
-    QStringList *commands() const { return commands_; } //!< Get the simulator commands (commands used to execute a simulation). Each list element is executed in sequence.
-    QString script_name() const { return script_name_; } //!< Get the name of the script to be used to execute simulations.
-    QString driver_file_path() const { return driver_file_path_; } //!< Get the path to the driver file.
-    void set_driver_file_path(const QString path) { driver_file_path_ = path; } //!< Set the driver file path. Used when the path is passed by command line argument.
-    void set_execution_script_path (const QString path) { custom_exec_script_path_ = path; } //!< Set a custom path for the simulator execution script.
-    void set_fieldopt_build_path (const QString path) { fieldopt_build_path_ = path; } //!< Specify FieldOpt build directory.
-    QString fieldopt_build_path() const { return fieldopt_build_path_; } //!< Get the FieldOpt directory path.
-    QString custom_simulator_execution_script_path() const { return custom_exec_script_path_; } //!< Get the path to the simulator execution script.
-    QString output_directory() const { return output_directory_; } //!< Get the output directory path.
-    SimulatorFluidModel fluid_model() const { return fluid_model_; } //!< Get the fluid model
+            SimulatorType type() const { return type_; } //!< Get the simulator type (e.g. ECLIPSE).
+            QStringList *commands() const { return commands_; } //!< Get the simulator commands (commands used to execute a simulation). Each list element is executed in sequence.
+            QString script_name() const { return script_name_; } //!< Get the name of the script to be used to execute simulations.
+            QString driver_file_path() const { return driver_file_path_; } //!< Get the path to the driver file.
+            void set_driver_file_path(const QString path) { driver_file_path_ = path; } //!< Set the driver file path. Used when the path is passed by command line argument.
+            void set_execution_script_path (const QString path) { custom_exec_script_path_ = path; } //!< Set a custom path for the simulator execution script.
+            QString custom_simulator_execution_script_path() const { return custom_exec_script_path_; } //!< Get the path to the simulator execution script.
+            QString output_directory() const { return output_directory_; } //!< Get the output directory path.
+            SimulatorFluidModel fluid_model() const { return fluid_model_; } //!< Get the fluid model
 
-private:
-    Simulator(QJsonObject json_simulator);
-    SimulatorType type_;
-    SimulatorFluidModel fluid_model_;
-    QStringList *commands_;
-    QString script_name_;
-    QString driver_file_path_;
-    QString output_directory_;
-    QString custom_exec_script_path_;
-    QString fieldopt_build_path_;
-};
+        private:
+            Simulator(QJsonObject json_simulator);
+            SimulatorType type_;
+            SimulatorFluidModel fluid_model_;
+            QStringList *commands_;
+            QString script_name_;
+            QString driver_file_path_;
+            QString output_directory_;
+            QString custom_exec_script_path_;
+        };
 
-}
+    }
 }
 
 #endif // SETTINGS_SIMULATOR_H

--- a/FieldOpt/Utilities/settings/simulator.h
+++ b/FieldOpt/Utilities/settings/simulator.h
@@ -52,6 +52,7 @@ public:
     QString driver_file_path() const { return driver_file_path_; } //!< Get the path to the driver file.
     void set_driver_file_path(const QString path) { driver_file_path_ = path; } //!< Set the driver file path. Used when the path is passed by command line argument.
     void set_execution_script_path (const QString path) { custom_exec_script_path_ = path; } //!< Set a custom path for the simulator execution script.
+    void set_fieldopt_build_path (const QString path) { fieldopt_build_path_ = path; } //!< Specify FieldOpt build directory.
     QString custom_simulator_execution_script_path() const { return custom_exec_script_path_; }
     QString output_directory() const { return output_directory_; } //!< Get the output directory path.
     SimulatorFluidModel fluid_model() const { return fluid_model_; } //!< Get the fluid model
@@ -65,6 +66,7 @@ private:
     QString driver_file_path_;
     QString output_directory_;
     QString custom_exec_script_path_;
+    QString fieldopt_build_path_;
 };
 
 }

--- a/FieldOpt/Utilities/settings/simulator.h
+++ b/FieldOpt/Utilities/settings/simulator.h
@@ -53,7 +53,8 @@ public:
     void set_driver_file_path(const QString path) { driver_file_path_ = path; } //!< Set the driver file path. Used when the path is passed by command line argument.
     void set_execution_script_path (const QString path) { custom_exec_script_path_ = path; } //!< Set a custom path for the simulator execution script.
     void set_fieldopt_build_path (const QString path) { fieldopt_build_path_ = path; } //!< Specify FieldOpt build directory.
-    QString custom_simulator_execution_script_path() const { return custom_exec_script_path_; }
+    QString fieldopt_build_path() const { return fieldopt_build_path_; } //!< Get the FieldOpt directory path.
+    QString custom_simulator_execution_script_path() const { return custom_exec_script_path_; } //!< Get the path to the simulator execution script.
     QString output_directory() const { return output_directory_; } //!< Get the output directory path.
     SimulatorFluidModel fluid_model() const { return fluid_model_; } //!< Get the fluid model
 


### PR DESCRIPTION
Works, but there is likely a much simpler way to implement specifying the FieldOpt build folder at runtime, and in particular, of passing this variable around (here: to AdgprsResultsReader). We can discuss further if needed.