### PR TITLE
Feature/h5 read saturation data

### DIFF
--- a/FieldOpt/CMakeLists.txt
+++ b/FieldOpt/CMakeLists.txt
@@ -9,7 +9,8 @@ option( COPY_EXAMPLES    "Copy examples to build directory (needed for many unit
 option( BUILD_TESTING    "Build unit tests"                                               ON )
 
 if (BUILD_TESTING AND NOT COPY_EXAMPLES)
-    message("It is recommended to copy examples when building texts. Some of the tests use files in the examples directory.")
+    message("It is recommended to copy examples when building tests.
+    Some of the tests use files in the examples directory.")
 endif()
 
 if (NOT BUILD_WIC_ONLY)

--- a/FieldOpt/Hdf5SummaryReader/hdf5_summary_reader.cpp
+++ b/FieldOpt/Hdf5SummaryReader/hdf5_summary_reader.cpp
@@ -31,27 +31,9 @@ void Hdf5SummaryReader::readSaturation(std::string file_path) {
     H5File file(file_path, H5F_ACC_RDONLY);
     Group group = Group(file.openGroup(GROUP_NAME_FLOW_TRANSPORT));
     auto dataset_exists = H5Lexists(group.getId(), "GRIDPROPTIME", H5F_ACC_RDONLY);
-    // std::cout << "dataset_exists = " << dataset_exists << std::endl;
-
     std::vector<std::vector<double>> sgas, soil, swat;
 
-    /*!
-    \todo Overall, this needs a better implementation, e.g., read soil and sgas
-    at the same time from the H5 group, instead of one vector at a time, which
-    appears inefficient... on the other hand, this reading needs to be made 
-    flexible/robust against the different phase combinations that might exist
-    in GRIDPROPTIME, e.g., soil/sgas, soil/sgas/swat, soil/swat, etc. 
-    */
-
-    /*!
-    \todo Later: to save space, load saturation data as additional columns in 
-    PTZ (replacing current compositional columns? comtrolled by custom KEYWORD?),
-    and remove GRIDPROPTIME completely
-    */
-
     if (dataset_exists) {
-
-        // std::cout << "number of phases = " << number_of_phases() << std::endl;
 
         hsize_t SOIL, SWAT, SGAS;
         if (number_of_phases() < 3){
@@ -151,7 +133,7 @@ void Hdf5SummaryReader::readReservoirPressure(std::string file_path) {
 
     // Reorder pressure vector
     // Note:
-    // Data/time component ordering inside vector:
+    // Data/time component ordering inside data vector:
     // Example: pressure vector with 5 cells over 8 time steps:
     // size of vector = ncells (x ndata_cols=1) x ntime_steps
     //

--- a/FieldOpt/Hdf5SummaryReader/hdf5_summary_reader.cpp
+++ b/FieldOpt/Hdf5SummaryReader/hdf5_summary_reader.cpp
@@ -3,7 +3,7 @@
 #include <assert.h>
 
 using namespace H5;
-Hdf5SummaryReader::Hdf5SummaryReader(const std::string file_path)
+Hdf5SummaryReader::Hdf5SummaryReader(const std::string file_path, bool cell_data)
 : GROUP_NAME_RESTART("RESTART"),
   DATASET_NAME_TIMES("TIMES"),
   GROUP_NAME_FLOW_TRANSPORT("FLOW_TRANSPORT"),
@@ -14,9 +14,15 @@ Hdf5SummaryReader::Hdf5SummaryReader(const std::string file_path)
 {
     readTimeVector(file_path);
     readWellStates(file_path);
-    readActiveCells(file_path);
-    readReservoirPressure(file_path);
-    readSaturation(file_path);
+
+    /*!
+     * These are only called if we want to extract cell data from
+     * the h5 file for postprocessing/visualization purposes
+     */
+    if (cell_data)
+        readActiveCells(file_path);
+        readReservoirPressure(file_path);
+        readSaturation(file_path);
 }
 
 void Hdf5SummaryReader::readSaturation(std::string file_path) {

--- a/FieldOpt/Hdf5SummaryReader/hdf5_summary_reader.cpp
+++ b/FieldOpt/Hdf5SummaryReader/hdf5_summary_reader.cpp
@@ -5,7 +5,7 @@
 
 using namespace H5;
 Hdf5SummaryReader::Hdf5SummaryReader(const std::string file_path,
-                                     std::string cell_data_STATUS,
+                                     bool get_cell_data,
                                      bool debug)
 : GROUP_NAME_RESTART("RESTART"),
   DATASET_NAME_TIMES("TIMES"),
@@ -23,7 +23,7 @@ Hdf5SummaryReader::Hdf5SummaryReader(const std::string file_path,
      * These are only called if we want to extract cell data from
      * the h5 file for postprocessing/visualization purposes
      */
-    if (cell_data_STATUS.compare("cell_data_ON") == 0){
+    if (get_cell_data){
         readActiveCells(file_path);
         readReservoirPressure(file_path);
         readSaturation(file_path);

--- a/FieldOpt/Hdf5SummaryReader/hdf5_summary_reader.cpp
+++ b/FieldOpt/Hdf5SummaryReader/hdf5_summary_reader.cpp
@@ -1,9 +1,11 @@
 #include "hdf5_summary_reader.h"
 #include <iostream>
 #include <assert.h>
+#include <boost/current_function.hpp>
 
 using namespace H5;
-Hdf5SummaryReader::Hdf5SummaryReader(const std::string file_path, bool cell_data)
+Hdf5SummaryReader::Hdf5SummaryReader(const std::string file_path,
+                                     bool cell_data)
 : GROUP_NAME_RESTART("RESTART"),
   DATASET_NAME_TIMES("TIMES"),
   GROUP_NAME_FLOW_TRANSPORT("FLOW_TRANSPORT"),
@@ -19,10 +21,11 @@ Hdf5SummaryReader::Hdf5SummaryReader(const std::string file_path, bool cell_data
      * These are only called if we want to extract cell data from
      * the h5 file for postprocessing/visualization purposes
      */
-    if (cell_data)
+    if (cell_data){
         readActiveCells(file_path);
         readReservoirPressure(file_path);
         readSaturation(file_path);
+    }
 }
 
 void Hdf5SummaryReader::readSaturation(std::string file_path) {
@@ -58,7 +61,8 @@ void Hdf5SummaryReader::readSaturation(std::string file_path) {
     }
 }
 
-std::vector<std::vector<double>> Hdf5SummaryReader::getSaturation(Group group, hsize_t sat_type) {
+std::vector<std::vector<double>> Hdf5SummaryReader::getSaturation(
+        Group group, hsize_t sat_type) {
 
     // Read the file
     DataSet dataset = DataSet(group.openDataSet(DATASET_NAME_SATURATION));
@@ -68,8 +72,6 @@ std::vector<std::vector<double>> Hdf5SummaryReader::getSaturation(Group group, h
 
     std::vector<double> vector;
     vector.resize(dims[0] * dims[2]);
-
-    // std::cout << "sat_type = " << (int)sat_type << std::endl;
     std::vector<std::vector<double>>  sat_; //!< Temporary saturation vector.
 
     if (sat_type > 0){
@@ -112,11 +114,12 @@ void Hdf5SummaryReader::readReservoirPressure(std::string file_path) {
     hsize_t dims[3];
 
     auto rank = dataspace.getSimpleExtentDims(dims, NULL);
-    // Uncomment to debug:
-    // std::cout << "dataset rank = " << rank << ", dimensions "
-    //     << (unsigned long)(dims[0]) << " x "
-    //     << (unsigned long)(dims[1]) << " x "
-    //     << (unsigned long)(dims[2]) << std::endl;
+    if (debug)
+        std::cout << "[\033[1;33m" << BOOST_CURRENT_FUNCTION << "\033[0m] "
+                  << "dataset rank " << rank << ", dims "
+                  << (unsigned long)(dims[0]) << " x "
+                  << (unsigned long)(dims[1]) << " x "
+                  << (unsigned long)(dims[2]) << std::endl;
 
     // Define hyperslab
     hsize_t count[3] = {dims[0], 1, dims[2]};
@@ -166,6 +169,11 @@ void Hdf5SummaryReader::readActiveCells(std::string file_path) {
 
     // rank variable can be used for debug
     auto rank = dataspace.getSimpleExtentDims(dims, NULL);
+    if (debug)
+        std::cout << "[\033[1;33m" << BOOST_CURRENT_FUNCTION << "\033[0m] "
+                  << "dataset rank " << rank << ", dims "
+                  << (unsigned long)(dims[0]) << " x "
+                  << (unsigned long)(dims[1]) << std::endl;
 
     // Define hyperslab
     hsize_t  count[2] = { dims[0], 1 };

--- a/FieldOpt/Hdf5SummaryReader/hdf5_summary_reader.cpp
+++ b/FieldOpt/Hdf5SummaryReader/hdf5_summary_reader.cpp
@@ -5,7 +5,8 @@
 
 using namespace H5;
 Hdf5SummaryReader::Hdf5SummaryReader(const std::string file_path,
-                                     bool cell_data)
+                                     std::string cell_data_STATUS,
+                                     bool debug)
 : GROUP_NAME_RESTART("RESTART"),
   DATASET_NAME_TIMES("TIMES"),
   GROUP_NAME_FLOW_TRANSPORT("FLOW_TRANSPORT"),
@@ -16,12 +17,13 @@ Hdf5SummaryReader::Hdf5SummaryReader(const std::string file_path,
 {
     readTimeVector(file_path);
     readWellStates(file_path);
+    debug_ = debug;
 
     /*!
      * These are only called if we want to extract cell data from
      * the h5 file for postprocessing/visualization purposes
      */
-    if (cell_data){
+    if (cell_data_STATUS.compare("cell_data_ON") == 0){
         readActiveCells(file_path);
         readReservoirPressure(file_path);
         readSaturation(file_path);
@@ -114,12 +116,13 @@ void Hdf5SummaryReader::readReservoirPressure(std::string file_path) {
     hsize_t dims[3];
 
     auto rank = dataspace.getSimpleExtentDims(dims, NULL);
-    if (debug)
-        std::cout << "[\033[1;33m" << BOOST_CURRENT_FUNCTION << "\033[0m] "
+    if (debug_){
+        std::cout << "[\033[1;33m" << BOOST_CURRENT_FUNCTION << ":\033[0m\n"
                   << "dataset rank " << rank << ", dims "
                   << (unsigned long)(dims[0]) << " x "
                   << (unsigned long)(dims[1]) << " x "
                   << (unsigned long)(dims[2]) << std::endl;
+    }
 
     // Define hyperslab
     hsize_t count[3] = {dims[0], 1, dims[2]};
@@ -169,11 +172,12 @@ void Hdf5SummaryReader::readActiveCells(std::string file_path) {
 
     // rank variable can be used for debug
     auto rank = dataspace.getSimpleExtentDims(dims, NULL);
-    if (debug)
-        std::cout << "[\033[1;33m" << BOOST_CURRENT_FUNCTION << "\033[0m] "
+    if (debug_){
+        std::cout << "[\033[1;33m" << BOOST_CURRENT_FUNCTION << ":\033[0m\n"
                   << "dataset rank " << rank << ", dims "
                   << (unsigned long)(dims[0]) << " x "
                   << (unsigned long)(dims[1]) << std::endl;
+    }
 
     // Define hyperslab
     hsize_t  count[2] = { dims[0], 1 };

--- a/FieldOpt/Hdf5SummaryReader/hdf5_summary_reader.h
+++ b/FieldOpt/Hdf5SummaryReader/hdf5_summary_reader.h
@@ -65,7 +65,7 @@ public:
      * \note The provided path is not checked by this method,
      * and should therefore be checked before invoking this.
      * @param file_path Path to a .H5 summary file.
-     * @param cell_data_STATUS Flag for whether to read cell data
+     * @param get_cell_data Flag for whether to read cell data
      * or not (defaults to empty string)
      * @param debug Flag to print H5 related data during testing
      * (defaults to false)
@@ -73,7 +73,7 @@ public:
      * information from the summary.
      */
     Hdf5SummaryReader(const std::string file_path,
-                      std::string cell_data_STATUS = "",
+                      bool get_cell_data = false,
                       bool debug = false);
 
     /*!
@@ -360,7 +360,7 @@ private:
     int ntimes_; //!< Number of time steps in the summary.
     int nphases_; //!< Number of phases in the model.
 
-    bool cell_data; //!< Flag for whether to read cell data from h5 file
+    bool cell_data_; //!< Flag for whether to read cell data from h5 file
 
     std::vector<double> times_; //!< Vector containing all time steps.
     std::vector<std::vector<double>> pressure_; //!< Vector containing reservoir pressures.

--- a/FieldOpt/Hdf5SummaryReader/hdf5_summary_reader.h
+++ b/FieldOpt/Hdf5SummaryReader/hdf5_summary_reader.h
@@ -255,7 +255,10 @@ public:
      */
     std::vector<double> field_cumulative_gas_injection_sc() const;
 
-
+    /*!
+     * Debug
+     */
+    bool debug; //!< Flag used by tests to get additional debug info
 
 private:
     const H5std_string GROUP_NAME_RESTART; //!< The name of the restart group in the HDF5 file.

--- a/FieldOpt/Hdf5SummaryReader/hdf5_summary_reader.h
+++ b/FieldOpt/Hdf5SummaryReader/hdf5_summary_reader.h
@@ -44,6 +44,21 @@ public:
     std::vector<std::vector<double>> reservoir_pressure() const { return pressure_; }
 
     /*!
+     * Get sgas vector.
+     */
+    std::vector<std::vector<double>> sgas() const { return sgas_; }
+
+    /*!
+     * Get soil vector.
+     */
+    std::vector<std::vector<double>> soil() const { return soil_; }
+
+    /*!
+     * Get swat vector.
+     */
+    std::vector<std::vector<double>> swat() const { return swat_; }
+
+    /*!
      * Return vector of active grid cells.
      */
     const std::vector<int> &cells_active() { return cells_active_; }
@@ -218,7 +233,7 @@ private:
     const H5std_string DATASET_NAME_WELL_STATES; //!< The name of the dataset containing the well states in the HDF5 file.
     const H5std_string DATASET_NAME_ACTIVE_CELLS; //!< The name of the dataset containing active cells vector.
     const H5std_string DATASET_NAME_PRESSURE; //!< The name of the dataset containing pressure and component data.
-
+    const H5std_string DATASET_NAME_SATURATION; //!< The name of the dataset containing saturation data.
     /*!
      * The wstype_t datatype represents the datatype in which well states are stored in the HDF5 file.
      * Each element in the dataset contains information about a well and its perforations at a specific
@@ -284,6 +299,7 @@ private:
 
     void readActiveCells(std::string file_path); //!< Read vector defining which cells are active from the HDF5 summary file.
     void readReservoirPressure(std::string file_path); //!< Read reservoir cell pressures for each time step.
+    void readSaturation(std::string file_path); //!< Read cell saturations for each time step.
 
     /*!
      * variables containing information about the reservoir cell ensemble,
@@ -304,6 +320,11 @@ private:
 
     std::vector<double> times_; //!< Vector containing all time steps.
     std::vector<std::vector<double>> pressure_; //!< Vector containing reservoir pressures.
+    std::vector<std::vector<double>> soil_; //!< Vector containing oil saturation.
+    std::vector<std::vector<double>> sgas_; //!< Vector containing gas saturation.
+    std::vector<std::vector<double>> swat_; //!< Vector containing water saturation.
+
+    std::vector<std::vector<double>> getSaturation(H5::Group dataset, hsize_t sat_type);
 
     /*!
      * Calculate the cumulative using the composite trapezoidal rule.

--- a/FieldOpt/Hdf5SummaryReader/hdf5_summary_reader.h
+++ b/FieldOpt/Hdf5SummaryReader/hdf5_summary_reader.h
@@ -5,33 +5,43 @@
 #include <H5Cpp.h>
 
 /*!
- * The Hdf5SummaryReader class reads the summaries written in the HDF5 format by the AD-GPRS reservoir simulator.
+ * The Hdf5SummaryReader class reads the summaries written
+ * in the HDF5 format by the AD-GPRS reservoir simulator.
  *
- * Currently the class supports getting rates and cumulatives for each well and for the field, as well as
- * bottom hole pressures and well type for each well.
+ * Currently the class supports getting rates and cumulatives
+ * for each well and for the field, as well as bottom hole
+ * pressures and well type for each well.
  *
- * Note that we do not have access to the well names in the summary, thus we use well numbers. This number
- * corresponds to the row on which information about the well is found. This number apparently does not correspond to
- * the order in which the wells were specified in the driver file, thus we have no way of distinguishing wells other
- * that by producer/injector. Note also that we do not know whether the order in which the wells appear can change
- * between subsequent runs of the simulator.
+ * Note that we do not have access to the well names in the
+ * summary, thus we use well numbers. This number corresponds
+ * to the row on which information about the well is found.
+ * This number apparentlydoes not correspond to the order in
+ * which the wells were specified in the driver file, thus we
+ * have no way of distinguishing wells other that by producer
+ * /injector. Note also that we do not know whether the order
+ * in which the wells appear can change between subsequent
+ * runs of the simulator.
  *
- * Note also that when you get the rates for an injector using the get_*_rates methods, the numbers will be negative,
- * whereas if you get them using the get_*_injection_rates methods, they will be positive.
+ * Note also that when you get the rates for an injector using
+ * the get_*_rates methods, the numbers will be negative, whereas
+ * if you get them using the get_*_injection_rates methods, they
+ * will be positive.
  *
- * \todo This must also be tested for a 3 phase black oil model, it has only been tested for 2 phase dead oil.
+ * \todo This must also be tested for a 3 phase black oil model,
+ * it has only been tested for 2 phase dead oil.
  */
 class Hdf5SummaryReader {
 public:
     /*!
      * Read the HDF5 summary file written by AD-GPRS at the specified path.
      *
-     * \note The provided path is not checked by this method, and should therefore be
-     * checked before invoking this.
+     * \note The provided path is not checked by this method,
+     * and should therefore be checked before invoking this.
      * @param file_path Path to a .H5 summary file.
+     * @param cell_data Flag for whether to read cell data or not (defaults to false)
      * @return A Hdf5SummaryReader object containing information from the summary.
      */
-    Hdf5SummaryReader(const std::string file_path);
+    Hdf5SummaryReader(const std::string file_path, bool cell_data = false);
 
     /*!
      * Get the vector containing all time steps in the summary.
@@ -94,7 +104,8 @@ public:
     int number_of_tsteps() const { return ntimes_; }
 
     /*!
-     * Get the type reported for a well. +1 indicates an injector, -1 indicates a producer.
+     * Get the type reported for a well.
+     * +1 indicates an injector, -1 indicates a producer.
      */
     int well_type(const int well_number) const;
 
@@ -318,6 +329,8 @@ private:
     int ntimes_; //!< Number of time steps in the summary.
     int nphases_; //!< Number of phases in the model.
 
+    bool cell_data; //!< Flag for whether to read cell data from h5 file
+
     std::vector<double> times_; //!< Vector containing all time steps.
     std::vector<std::vector<double>> pressure_; //!< Vector containing reservoir pressures.
     std::vector<std::vector<double>> soil_; //!< Vector containing oil saturation.
@@ -334,9 +347,10 @@ private:
      *  T(f, h) = \frac{h}{2} \sum_{k=1}^{M}\left[ f(x_{k-1}) + f(x_k) \right]
      * \f]
      *
-     * In our case, \f$ h \f$ (the time difference) is not constant but can vary from step to step in the time step
-     * vector \f$ t \f$, so \f$ h = f(k) = t_k - t_{k-1} \f$. Additionally, \f$ f(x_k) = r_k \f$ where \f$ r \f$ is
-     * the rate vector. We also need to compute the cumulative at various time steps, so \f$ M \f$ is a variable.
+     * In our case, \f$ h \f$ (the time difference) is not constant but can vary from
+     * step to step in the time step vector \f$ t \f$, so \f$ h = f(k) = t_k - t_{k-1} \f$.
+     * Additionally, \f$ f(x_k) = r_k \f$ where \f$ r \f$ is the rate vector. We also
+     * need to compute the cumulative at various time steps, so \f$ M \f$ is a variable.
      * So then we have
      * \f[
      *  T(M) = \sum_{k=1}^M \left[ \frac{t_k - t_{k-1}}{2} \left( r_{k-1} + r_k \right) \right]

--- a/FieldOpt/Hdf5SummaryReader/hdf5_summary_reader.h
+++ b/FieldOpt/Hdf5SummaryReader/hdf5_summary_reader.h
@@ -40,6 +40,12 @@
  * might exist in the H5 group (currently GRIDPROPTIME), e.g., 
  * soil/sgas, soil/sgas/swat, soil/swat, etc.
  *
+ * \todo To make thing much tidier, collect variables containing 
+ * information about the reservoir cell ensemble, i.e., 
+ * cells_all_vector_, cells_active_, cells_inactive_, etc, and of
+ * reservoir cell data, i.e., pressure_, soil_, sgas_, swat_, into 
+ * one or more reservoir cells/cell data structs.
+ *
  * \todo Later: to reduce the size of the H5 file, make ADGPRS/
  * Optimizer save the saturation data (and whatever else) as 
  * additional columns into the existing PTZ group (possibly 
@@ -53,15 +59,22 @@
 class Hdf5SummaryReader {
 public:
     /*!
-     * Read the HDF5 summary file written by AD-GPRS at the specified path.
+     * Read the HDF5 summary file written 
+     * by AD-GPRS at the specified path.
      *
      * \note The provided path is not checked by this method,
      * and should therefore be checked before invoking this.
      * @param file_path Path to a .H5 summary file.
-     * @param cell_data Flag for whether to read cell data or not (defaults to false)
-     * @return A Hdf5SummaryReader object containing information from the summary.
+     * @param cell_data_STATUS Flag for whether to read cell data
+     * or not (defaults to empty string)
+     * @param debug Flag to print H5 related data during testing
+     * (defaults to false)
+     * @return A Hdf5SummaryReader object containing 
+     * information from the summary.
      */
-    Hdf5SummaryReader(const std::string file_path, bool cell_data = false);
+    Hdf5SummaryReader(const std::string file_path,
+                      std::string cell_data_STATUS = "",
+                      bool debug = false);
 
     /*!
      * Get the vector containing all time steps in the summary.
@@ -255,11 +268,6 @@ public:
      */
     std::vector<double> field_cumulative_gas_injection_sc() const;
 
-    /*!
-     * Debug
-     */
-    bool debug; //!< Flag used by tests to get additional debug info
-
 private:
     const H5std_string GROUP_NAME_RESTART; //!< The name of the restart group in the HDF5 file.
     const H5std_string DATASET_NAME_TIMES; //!< The name of the dataset containing the time step vector in the HDF5 file.
@@ -336,7 +344,7 @@ private:
     void readSaturation(std::string file_path); //!< Read cell saturations for each time step.
 
     /*!
-     * variables containing information about the reservoir cell ensemble,
+     * Variables containing information about the reservoir cell ensemble,
      * e.g., number of active cells, corresponding active cell indices, etc.
      */
     std::vector<int> cells_all_vector_; //!< Vector def. status for all cells (size equal to total number of cells).
@@ -361,6 +369,12 @@ private:
     std::vector<std::vector<double>> swat_; //!< Vector containing water saturation.
 
     std::vector<std::vector<double>> getSaturation(H5::Group dataset, hsize_t sat_type);
+
+    /*!
+     * debug_ Flag used by tests (only) to get additional info from
+     * H5 read functions, e.g., data rank, etc.
+     */
+    bool debug_;
 
     /*!
      * Calculate the cumulative using the composite trapezoidal rule.

--- a/FieldOpt/Hdf5SummaryReader/hdf5_summary_reader.h
+++ b/FieldOpt/Hdf5SummaryReader/hdf5_summary_reader.h
@@ -29,6 +29,26 @@
  *
  * \todo This must also be tested for a 3 phase black oil model,
  * it has only been tested for 2 phase dead oil.
+ *
+ * \todo Overall, Hdf5SummaryReader::readSaturation needs a better 
+ * implementation that reads soil and sgas at the same time/as a 
+ * single chunck from the H5 group, instead of reading from H5 one 
+ * vector at a time (the thinking is that the former is probably
+ * more efficient that the latter).
+ * In either case, the reading functionality needs to be flexible/
+ * /robust with respect to the different phase combinations that 
+ * might exist in the H5 group (currently GRIDPROPTIME), e.g., 
+ * soil/sgas, soil/sgas/swat, soil/swat, etc.
+ *
+ * \todo Later: to reduce the size of the H5 file, make ADGPRS/
+ * Optimizer save the saturation data (and whatever else) as 
+ * additional columns into the existing PTZ group (possibly 
+ * replacing current mobility columns), and remove GRIDPROPTIME 
+ * completely. 
+ * Additionally, which cell data types (including custom data 
+ * types) to print to H5 during simulation may be controlled by 
+ * custom simulator KEYWORD.
+ *
  */
 class Hdf5SummaryReader {
 public:

--- a/FieldOpt/Hdf5SummaryReader/tests/test_hdf5_summary_reader.cpp
+++ b/FieldOpt/Hdf5SummaryReader/tests/test_hdf5_summary_reader.cpp
@@ -12,6 +12,7 @@ namespace {
         virtual void SetUp() {}
         virtual void TearDown() {}
         std::string file_path = "../examples/ADGPRS/5spot/5SPOT.vars.h5";
+        std::string file_path_gpt = "../examples/ADGPRS/5spot/5SPOT-gpt.vars.h5";
     };
 
 
@@ -56,6 +57,23 @@ namespace {
         }
     }
 
+    TEST_F(Hdf5SummaryReaderTest, readSaturation) {
+
+        auto reader_gpt = Hdf5SummaryReader(file_path_gpt);
+          auto soil_gpt = reader_gpt.soil();
+        // std::cout << "soil.size() = " << soil.size() << std::endl;
+        EXPECT_EQ(soil_gpt.size(), 8);
+        EXPECT_EQ(soil_gpt[0].size(), 3600);
+
+        auto reader = Hdf5SummaryReader(file_path);
+         auto  soil = reader.soil();
+        EXPECT_EQ(soil.size(), 8);
+        EXPECT_EQ(soil[0].size(), 3600);
+
+    }
+
+
+
     TEST_F(Hdf5SummaryReaderTest, readReservoirPressure) {
           auto reader = Hdf5SummaryReader(file_path);
         auto pressure = reader.reservoir_pressure();
@@ -71,9 +89,17 @@ namespace {
         // read vector has been correctly resized
         for (int i = 0; i < pressure.size(); ++i) {
             EXPECT_EQ(def_pressure[i], pressure[i][0]);
-        }
 
+            // Uncomment to debug:
+            // std::cout << "pressure[tt=" << ii << "].size() = "
+            //           << pressure[ii].size() << std::endl;
+        }
+        // Uncomment to debug:
+        // for (int rr = 0; rr < 10; ++rr) { // pressure_.size()
+        //      std::cout << "pressure = " << pressure_[0][rr] << std::endl;
+        // }
     }
+
 
     TEST_F(Hdf5SummaryReaderTest, IntegerData) {
         auto reader = Hdf5SummaryReader(file_path);

--- a/FieldOpt/Hdf5SummaryReader/tests/test_hdf5_summary_reader.cpp
+++ b/FieldOpt/Hdf5SummaryReader/tests/test_hdf5_summary_reader.cpp
@@ -33,9 +33,7 @@ namespace {
     }
 
     TEST_F(Hdf5SummaryReaderTest, ActiveCellVector) {
-        auto reader = Hdf5SummaryReader(file_path,
-                                        "cell_data_ON",
-                                        false);
+        auto reader = Hdf5SummaryReader(file_path, true, false);
 
            auto cells_total_num_ = reader.cells_total_num();
           auto cells_num_active_ = reader.cells_num_active();
@@ -57,25 +55,19 @@ namespace {
 
     TEST_F(Hdf5SummaryReaderTest, readSaturation) {
 
-        auto reader_gpt = Hdf5SummaryReader(file_path_gpt,
-                                            "cell_data_ON",
-                                            false);
+        auto reader_gpt = Hdf5SummaryReader(file_path_gpt, true, false);
           auto soil_gpt = reader_gpt.soil();
         EXPECT_EQ(soil_gpt.size(), 8);
         EXPECT_EQ(soil_gpt[0].size(), 3600);
 
-        auto reader = Hdf5SummaryReader(file_path,
-                                        "cell_data_ON",
-                                        false);
+        auto reader = Hdf5SummaryReader(file_path, true, false);
          auto  soil = reader.soil();
         EXPECT_EQ(soil.size(), 8);
         EXPECT_EQ(soil[0].size(), 3600);
     }
 
     TEST_F(Hdf5SummaryReaderTest, readReservoirPressure) {
-          auto reader = Hdf5SummaryReader(file_path,
-                                          "cell_data_ON",
-                                          false);
+          auto reader = Hdf5SummaryReader(file_path, true, false);
           auto pressure = reader.reservoir_pressure();
 
         std::vector<double> def_pressure = {

--- a/FieldOpt/Hdf5SummaryReader/tests/test_hdf5_summary_reader.cpp
+++ b/FieldOpt/Hdf5SummaryReader/tests/test_hdf5_summary_reader.cpp
@@ -33,7 +33,9 @@ namespace {
     }
 
     TEST_F(Hdf5SummaryReaderTest, ActiveCellVector) {
-        auto reader = Hdf5SummaryReader(file_path,true);
+        auto reader = Hdf5SummaryReader(file_path,
+                                        "cell_data_ON",
+                                        false);
 
            auto cells_total_num_ = reader.cells_total_num();
           auto cells_num_active_ = reader.cells_num_active();
@@ -55,23 +57,26 @@ namespace {
 
     TEST_F(Hdf5SummaryReaderTest, readSaturation) {
 
-        auto reader_gpt = Hdf5SummaryReader(file_path_gpt,true);
-       reader_gpt.debug = true;
+        auto reader_gpt = Hdf5SummaryReader(file_path_gpt,
+                                            "cell_data_ON",
+                                            false);
           auto soil_gpt = reader_gpt.soil();
         EXPECT_EQ(soil_gpt.size(), 8);
         EXPECT_EQ(soil_gpt[0].size(), 3600);
 
-        auto reader = Hdf5SummaryReader(file_path,true);
-       reader.debug = true;
+        auto reader = Hdf5SummaryReader(file_path,
+                                        "cell_data_ON",
+                                        false);
          auto  soil = reader.soil();
         EXPECT_EQ(soil.size(), 8);
         EXPECT_EQ(soil[0].size(), 3600);
     }
 
     TEST_F(Hdf5SummaryReaderTest, readReservoirPressure) {
-          auto reader = Hdf5SummaryReader(file_path);
-         reader.debug = true;
-        auto pressure = reader.reservoir_pressure();
+          auto reader = Hdf5SummaryReader(file_path,
+                                          "cell_data_ON",
+                                          false);
+          auto pressure = reader.reservoir_pressure();
 
         std::vector<double> def_pressure = {
             370.555603, 370.55451121327735, 366.80490627652864,

--- a/FieldOpt/Hdf5SummaryReader/tests/test_hdf5_summary_reader.cpp
+++ b/FieldOpt/Hdf5SummaryReader/tests/test_hdf5_summary_reader.cpp
@@ -36,7 +36,7 @@ namespace {
     }
 
     TEST_F(Hdf5SummaryReaderTest, ActiveCellVector) {
-        auto reader = Hdf5SummaryReader(file_path);
+        auto reader = Hdf5SummaryReader(file_path,true);
 
            auto cells_total_num_ = reader.cells_total_num();
           auto cells_num_active_ = reader.cells_num_active();
@@ -59,13 +59,13 @@ namespace {
 
     TEST_F(Hdf5SummaryReaderTest, readSaturation) {
 
-        auto reader_gpt = Hdf5SummaryReader(file_path_gpt);
+        auto reader_gpt = Hdf5SummaryReader(file_path_gpt,true);
           auto soil_gpt = reader_gpt.soil();
         // std::cout << "soil.size() = " << soil.size() << std::endl;
         EXPECT_EQ(soil_gpt.size(), 8);
         EXPECT_EQ(soil_gpt[0].size(), 3600);
 
-        auto reader = Hdf5SummaryReader(file_path);
+        auto reader = Hdf5SummaryReader(file_path,true);
          auto  soil = reader.soil();
         EXPECT_EQ(soil.size(), 8);
         EXPECT_EQ(soil[0].size(), 3600);

--- a/FieldOpt/Hdf5SummaryReader/tests/test_hdf5_summary_reader.cpp
+++ b/FieldOpt/Hdf5SummaryReader/tests/test_hdf5_summary_reader.cpp
@@ -1,6 +1,5 @@
 #include "../hdf5_summary_reader.h"
 #include <gtest/gtest.h>
-#include <hdf5_summary_reader.h>
 
 namespace {
     class Hdf5SummaryReaderTest : public ::testing::Test {
@@ -15,14 +14,12 @@ namespace {
         std::string file_path_gpt = "../examples/ADGPRS/5spot/5SPOT-gpt.vars.h5";
     };
 
-
     TEST_F(Hdf5SummaryReaderTest, Constructor) {
         auto reader = Hdf5SummaryReader(file_path);
         EXPECT_EQ(5, reader.number_of_wells());
         EXPECT_EQ(8, reader.number_of_tsteps());
         EXPECT_EQ(2, reader.number_of_phases());
     }
-
 
     TEST_F(Hdf5SummaryReaderTest, TimeVector) {
         auto reader = Hdf5SummaryReader(file_path);
@@ -51,7 +48,6 @@ namespace {
         EXPECT_EQ(cells_num_inactive_, 0);
 
         for (int i = 0; i < cells_num_active_; ++i) {
-            // std::cout << cells_num_active_[i] << std::endl;
             EXPECT_EQ(cells_active_[i], i);
             EXPECT_EQ(cells_active_idx_[i], i);
         }
@@ -60,22 +56,21 @@ namespace {
     TEST_F(Hdf5SummaryReaderTest, readSaturation) {
 
         auto reader_gpt = Hdf5SummaryReader(file_path_gpt,true);
+       reader_gpt.debug = true;
           auto soil_gpt = reader_gpt.soil();
-        // std::cout << "soil.size() = " << soil.size() << std::endl;
         EXPECT_EQ(soil_gpt.size(), 8);
         EXPECT_EQ(soil_gpt[0].size(), 3600);
 
         auto reader = Hdf5SummaryReader(file_path,true);
+       reader.debug = true;
          auto  soil = reader.soil();
         EXPECT_EQ(soil.size(), 8);
         EXPECT_EQ(soil[0].size(), 3600);
-
     }
-
-
 
     TEST_F(Hdf5SummaryReaderTest, readReservoirPressure) {
           auto reader = Hdf5SummaryReader(file_path);
+         reader.debug = true;
         auto pressure = reader.reservoir_pressure();
 
         std::vector<double> def_pressure = {
@@ -99,7 +94,6 @@ namespace {
         //      std::cout << "pressure = " << pressure_[0][rr] << std::endl;
         // }
     }
-
 
     TEST_F(Hdf5SummaryReaderTest, IntegerData) {
         auto reader = Hdf5SummaryReader(file_path);


### PR DESCRIPTION
Added function that reads saturation data (soil, swat, sgas) from GRIDPROPTIME group in H5 file (if it exists).

This PR was branched off and therefore includes the existing PR: Feature/h5 read reservoir pressure.