### PR TITLE
Feature/add box constraint functions

### DIFF
--- a/FieldOpt/CMakeLists.txt
+++ b/FieldOpt/CMakeLists.txt
@@ -7,8 +7,8 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 # Options 1: Unit tests, example dir ===================================
-option(BUILD_TESTING "Build unit tests"                 OFF)
-option(COPY_EXAMPLES "Copy examples to build directory" OFF)
+option(BUILD_TESTING "Build unit tests"                 ON)
+option(COPY_EXAMPLES "Copy examples to build directory" ON)
 
 if (BUILD_TESTING AND NOT COPY_EXAMPLES)
     message("It is recommended to copy examples when building unit
@@ -20,7 +20,7 @@ endif()
 # Build standalone well index calculator executable
 option(BUILD_WIC_ONLY "Build well index calculator exe" OFF)
 # Build OS-dependent well index calculator (shared) library:
-option(BUILD_WIC_ADGPRS "Build WIC as ADGPRS plugin"    ON)
+option(BUILD_WIC_ADGPRS "Build WIC as ADGPRS plugin"    OFF)
 
 # Qt libraries =========================================================
 if (NOT BUILD_WIC_ONLY)

--- a/FieldOpt/ConstraintMath/README.md
+++ b/FieldOpt/ConstraintMath/README.md
@@ -4,7 +4,6 @@ The library now only consists of a list of functions that can be called.
 
 The following libraries are needed:
 
-
 - RPolyPlusPlus(https://github.com/sweeneychris/RpolyPlusPlus):
 
 Important note. Later versions of RPoly makes WellIndexCalculation unstable.
@@ -12,13 +11,23 @@ Clone the RPoly repo and then checkout an older commit with the following comman
 
 git checkout c79e0ea87922b5d7624e76f9792f5fd915837c19
 
-
 - Eigen3 library (http://eigen.tuxfamily.org/index.php?title=Main_Page)
 
 RPolyPlusPlus depends on the eigen library. However RPolyPlusPlus links
 to a different directory than the standard path for the Eigen library.
 A workaround to make this link work is to simply copy the Eigen library
-into THIS(write path here) path.
+into the path: /usr/lib/Eigen and the include files into: /usr/include/Eigen.
+
+For example, for a Ubuntu distro:
+
+cd /usr/lib/eigen3
+sudo cp -r Eigen/ ../
+
+cd /usr/include/eigen3
+sudo cp -r Eigen/ ../
+
+Note: RpolyPlusPlus appears to need Eigen libraries version 3.3 (Test:
+CompassSearchTest.GetNewCases breaks when using version eigen-3.2.8-4)
 
 - Armadillo library (http://arma.sourceforge.net/)
 

--- a/FieldOpt/ConstraintMath/well_constraint_projections/well_constraint_projections.cpp
+++ b/FieldOpt/ConstraintMath/well_constraint_projections/well_constraint_projections.cpp
@@ -1,242 +1,292 @@
+/******************************************************************************
+   Copyright (C) 2015-2016 Hilmar M. Magnusson <hilmarmag@gmail.com>
+   Additions by M.Bellout (2017) <mathias.bellout@ntnu.no>
+
+   This file and the WellIndexCalculator as a whole is part of the
+   FieldOpt project. However, unlike the rest of FieldOpt, the
+   WellIndexCalculator is provided under the GNU Lesser General Public
+   License.
+
+   WellIndexCalculator is free software: you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public License
+   as published by the Free Software Foundation, either version 3 of
+   the License, or (at your option) any later version.
+
+   WellIndexCalculator is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with WellIndexCalculator.  If not, see
+   <http://www.gnu.org/licenses/>.
+******************************************************************************/
+
 #include "well_constraint_projections.h"
 
 namespace WellConstraintProjections {
-    using namespace Eigen;
+using namespace Eigen;
 
-    Vector3d point_to_cell_shortest(Reservoir::Grid::Cell cell, Vector3d point) {
-        if (cell.EnvelopsPoint(point)) {
-            return point;
-        }
-
-        // Shortest distance so far
-        double minimum = INFINITY;
-        Vector3d closest_point = point;
-
-        for (auto face : cell.faces()) {
-            Vector3d temp_point = point_to_face_shortest(face, point, cell);
-            Vector3d projected_length = point - temp_point;
-            if (projected_length.norm() < minimum) {
-                closest_point = temp_point;
-                minimum = projected_length.norm();
-            }
-        }
-        return closest_point;
+Vector3d point_to_cell_shortest(Reservoir::Grid::Cell cell, Vector3d point) {
+    if (cell.EnvelopsPoint(point)) {
+        return point;
     }
 
-    Vector3d point_to_face_shortest(Reservoir::Grid::Cell::Face face, Vector3d point, Reservoir::Grid::Cell cell) {
-        // Calculate normal vector and normalize
-        auto n_vec = face.normal_vector.normalized();
+    // Shortest distance so far
+    double minimum = INFINITY;
+    Vector3d closest_point = point;
 
-        // Project point onto plane spanned by face
-        Vector3d proj_point = point - n_vec.dot(point - face.corners[0]) * n_vec;
-
-        // Check if the point is inside the face (checking if it is inside the cell is equivalent here)
-        if (cell.EnvelopsPoint(proj_point)) {
-            return proj_point;
+    for (auto face : cell.faces()) {
+        Vector3d temp_point = point_to_face_shortest(face, point, cell);
+        Vector3d projected_length = point - temp_point;
+        if (projected_length.norm() < minimum) {
+            closest_point = temp_point;
+            minimum = projected_length.norm();
         }
+    }
+    return closest_point;
+}
 
-        // If the above is false, then the projected point is outside of the plane defined by face.
-        // If so, then the closest point lies on one of the four lines defining the bound of the cell.
-        // We create an array containing the index for the line segments defining the face, then loop
-        // through the lines to find closest point.
-        //
-        // cell face index ordering:
-        // 0 -- 1
-        // |    |
-        // 2 -- 3
-        // (Double check this is correct; see WIC notes)
-        int line_indices[4][2] = {{0, 1},
-                                  {1, 3},
-                                  {3, 2},
-                                  {2, 0}};
-        double minimum = INFINITY;
-        Vector3d closest_point;
-        for (int ii = 0; ii < 4; ii++) {
-            QList<Vector3d> temp_line({face.corners[line_indices[ii][0]], face.corners[line_indices[ii][1]]});
-            Vector3d temp_point = point_to_line_shortest(temp_line, point);
-            Vector3d projected_length = point - temp_point;
+Vector3d point_to_face_shortest(Reservoir::Grid::Cell::Face face, Vector3d point, Reservoir::Grid::Cell cell) {
+    // Calculate normal vector and normalize
+    auto n_vec = face.normal_vector.normalized();
 
-            if (projected_length.norm() < minimum) {
-                closest_point = temp_point;
-                minimum = projected_length.norm();
-            }
-        }
-        return closest_point;
+    // Project point onto plane spanned by face
+    Vector3d proj_point = point - n_vec.dot(point - face.corners[0]) * n_vec;
+
+    // Check if the point is inside the face (checking if it is inside the cell is equivalent here)
+    if (cell.EnvelopsPoint(proj_point)) {
+        return proj_point;
     }
 
-    Vector3d point_to_line_shortest(QList<Vector3d> line_segment, Vector3d P0) {
-        auto closest_p_q = closest_points_on_lines(P0, P0, line_segment[0], line_segment[1]);
-        return closest_p_q.second;
+    // If the above is false, then the projected point is outside of the plane defined by face.
+    // If so, then the closest point lies on one of the four lines defining the bound of the cell.
+    // We create an array containing the index for the line segments defining the face, then loop
+    // through the lines to find closest point.
+    //
+    // cell face index ordering:
+    // 0 -- 1
+    // |    |
+    // 2 -- 3
+    // (Double check this is correct; see WIC notes)
+    int line_indices[4][2] = {{0, 1},
+                              {1, 3},
+                              {3, 2},
+                              {2, 0}};
+    double minimum = INFINITY;
+    Vector3d closest_point;
+    for (int ii = 0; ii < 4; ii++) {
+        QList<Vector3d> temp_line({face.corners[line_indices[ii][0]], face.corners[line_indices[ii][1]]});
+        Vector3d temp_point = point_to_line_shortest(temp_line, point);
+        Vector3d projected_length = point - temp_point;
+
+        if (projected_length.norm() < minimum) {
+            closest_point = temp_point;
+            minimum = projected_length.norm();
+        }
     }
+    return closest_point;
+}
 
-    Vector3d non_inv_quad_coeffs(Vector3d x, Vector3d n) {
-        Vector3d coeffs;
-        coeffs(0) = n(0) * n(0) + n(1) * n(1) + n(2) * n(2);
-        coeffs(1) = 2 * (x(0) * n(0) + x(1) * n(1) + x(2) * n(2));
-        coeffs(2) = x(0) * x(0) + x(1) * x(1) + x(2) * x(2) - 1;
-        return coeffs;
+Vector3d point_to_line_shortest(QList<Vector3d> line_segment, Vector3d P0) {
+    auto closest_p_q = closest_points_on_lines(P0, P0, line_segment[0], line_segment[1]);
+    return closest_p_q.second;
+}
+
+Vector3d non_inv_quad_coeffs(Vector3d x, Vector3d n) {
+    Vector3d coeffs;
+    coeffs(0) = n(0) * n(0) + n(1) * n(1) + n(2) * n(2);
+    coeffs(1) = 2 * (x(0) * n(0) + x(1) * n(1) + x(2) * n(2));
+    coeffs(2) = x(0) * x(0) + x(1) * x(1) + x(2) * x(2) - 1;
+    return coeffs;
+}
+
+Vector3d rm_entries_eps(Vector3d m, double eps) {
+    for (int ii = 0; ii < 3; ii++) {
+        if (fabs(m[ii]) < eps) {
+            m(ii) = 0;
+        }
     }
+    return m;
+}
 
-    Vector3d rm_entries_eps(Vector3d m, double eps) {
-        for (int ii = 0; ii < 3; ii++) {
-            if (fabs(m[ii]) < eps) {
-                m(ii) = 0;
+Matrix3d rm_entries_eps_matrix(Matrix3d m, double eps) {
+    for (int ii = 0; ii < 3; ii++) {
+        for (int jj = 0; jj < 3; jj++) {
+            if (fabs(m(ii, jj)) < eps) {
+                m(ii, jj) = 0;
             }
         }
-        return m;
     }
+    return m;
+}
 
-    Matrix3d rm_entries_eps_matrix(Matrix3d m, double eps) {
-        for (int ii = 0; ii < 3; ii++) {
-            for (int jj = 0; jj < 3; jj++) {
-                if (fabs(m(ii, jj)) < eps) {
-                    m(ii, jj) = 0;
-                }
-            }
+VectorXd rm_entries_eps_coeffs(VectorXd m, double eps) {
+    for (int ii = 0; ii < 7; ii++) {
+        if (fabs(m[ii]) < eps) {
+            m(ii) = 0;
         }
-        return m;
     }
+    return m;
+}
 
-    VectorXd rm_entries_eps_coeffs(VectorXd m, double eps) {
-        for (int ii = 0; ii < 7; ii++) {
-            if (fabs(m[ii]) < eps) {
-                m(ii) = 0;
-            }
-        }
-        return m;
+
+QList<Vector3d> interwell_constraint_projection(QList<Vector3d> coords, double d) {
+    // If the two line segments already satisfy the interwell distance constraint, return the coordinates.
+    if (shortest_distance(coords) >= d) {
+        return coords;
     }
+    QList<Vector3d> solution_coords, moved_coords, temp_coords;
 
+    /* Iterate through moving points. First try moving 2 points, then 3 points
+     * then 4 points. If problem can be solved moving k points, moving k+1 points
+     * will be a worse solution. Return the best k point solution.
+     */
+    double cost = INFINITY;
 
-    QList<Vector3d> interwell_constraint_projection(QList<Vector3d> coords, double d) {
-        // If the two line segments already satisfy the interwell distance constraint, return the coordinates.
-        if (shortest_distance(coords) >= d) {
-            return coords;
+    // ################## 2 POINT PART ############################
+    // ################ END 2 POINT PART ##########################
+    int two_point_index[4][2] = {{0, 2},
+                                 {0, 3},
+                                 {1, 2},
+                                 {1, 3}};
+
+    for (int ii = 0; ii < 4; ii++) {
+        moved_coords = coords;
+        temp_coords = well_length_projection(coords[two_point_index[ii][0]],
+                                             coords[two_point_index[ii][1]],
+                                             INFINITY, d, 10e-5);
+        moved_coords.replace(two_point_index[ii][0], temp_coords[0]);
+        moved_coords.replace(two_point_index[ii][1], temp_coords[1]);
+        if (shortest_distance(moved_coords) >= d &&
+            movement_cost(coords, moved_coords) < cost) {
+            // If several moves of two points work, save the one with lowest movement cost
+            cost = movement_cost(coords, moved_coords);
+            solution_coords = moved_coords;
         }
-        QList<Vector3d> solution_coords, moved_coords, temp_coords;
+    }
+    // If there were any succesful configurations, return the best one.
+    if (cost < INFINITY) {
+        return solution_coords;
+    }
+    // ################ END 2 POINT PART ##########################
 
-        /* Iterate through moving points. First try moving 2 points, then 3 points
-         * then 4 points. If problem can be solved moving k points, moving k+1 points
-         * will be a worse solution. Return the best k point solution.
-         */
-        double cost = INFINITY;
+    // ################## 3 POINT PART ############################
+    // If no 2 point movements were succesful, try moving 3 points.
+    int three_point_index[4][3] = {{2, 0, 1},
+                                   {3, 0, 1},
+                                   {0, 2, 3},
+                                   {1, 2, 3}};
+    for (int ii = 0; ii < 4; ii++) {
+        // Reset moved coords to initial state
+        moved_coords = coords;
 
-        // ################## 2 POINT PART ############################
-        // ################ END 2 POINT PART ##########################
-        int two_point_index[4][2] = {{0, 2},
-                                     {0, 3},
-                                     {1, 2},
-                                     {1, 3}};
-
-        for (int ii = 0; ii < 4; ii++) {
-            moved_coords = coords;
-            temp_coords = well_length_projection(coords[two_point_index[ii][0]],
-                                                 coords[two_point_index[ii][1]],
-                                                 INFINITY, d, 10e-5);
-            moved_coords.replace(two_point_index[ii][0], temp_coords[0]);
-            moved_coords.replace(two_point_index[ii][1], temp_coords[1]);
-            if (shortest_distance(moved_coords) >= d &&
-                movement_cost(coords, moved_coords) < cost) {
-                // If several moves of two points work, save the one with lowest movement cost
-                cost = movement_cost(coords, moved_coords);
-                solution_coords = moved_coords;
-            }
+        // Choose which 3 points to move. (order is important, second and third entry should belong to same line segment)
+        QList<Vector3d> input_cords_3p;
+        for (int jj = 0; jj < 3; jj++) {
+            input_cords_3p.append(coords.at(three_point_index[ii][jj]));
         }
-        // If there were any succesful configurations, return the best one.
-        if (cost < INFINITY) {
-            return solution_coords;
-        }
-        // ################ END 2 POINT PART ##########################
+        Matrix3d temp_A = build_A_3p(input_cords_3p);
+        Vector3d temp_b = build_b_3p(input_cords_3p, d);
 
-        // ################## 3 POINT PART ############################
-        // If no 2 point movements were succesful, try moving 3 points.
-        int three_point_index[4][3] = {{2, 0, 1},
-                                       {3, 0, 1},
-                                       {0, 2, 3},
-                                       {1, 2, 3}};
-        for (int ii = 0; ii < 4; ii++) {
-            // Reset moved coords to initial state
-            moved_coords = coords;
-
-            // Choose which 3 points to move. (order is important, second and third entry should belong to same line segment)
-            QList<Vector3d> input_cords_3p;
-            for (int jj = 0; jj < 3; jj++) {
-                input_cords_3p.append(coords.at(three_point_index[ii][jj]));
-            }
-            Matrix3d temp_A = build_A_3p(input_cords_3p);
-            Vector3d temp_b = build_b_3p(input_cords_3p, d);
-
-            /* The kkt_eg_solutions solver handles some numerical issues
-             * like A having some values close to machine epsilon and
-             * eigenvalues being close to 0. Just assume that any solution
-             * must be among the ones given in solution candidates. we check
-             * all of them.
-             */
-            QList<Vector3d> solution_candidates = kkt_eq_solutions(temp_A, temp_b);
-
-            for (int sol_num = 0; sol_num < solution_candidates.length(); sol_num++) {
-                // Solution of three point problem
-                temp_coords = move_points_3p(input_cords_3p, d,
-                                             solution_candidates.at(sol_num));
-                if (temp_coords.length() < 1) { temp_coords = input_cords_3p; }
-
-                for (int jj = 0; jj < 3; jj++) {
-                    moved_coords.replace(three_point_index[ii][jj], temp_coords.at(jj));
-                }
-
-                if (shortest_distance(moved_coords) >= d - 0.001 &&
-                    movement_cost(coords, moved_coords) < cost) {
-                    // If several moves of three points work, save the one with lovest movement cost
-                    cost = movement_cost(coords, moved_coords);
-                    solution_coords = moved_coords;
-                }
-            }
-
-        }
-        // If there were any succesful configurations, return the best one.
-        if (cost < INFINITY) {
-            return solution_coords;
-        }
-        // ################## END 3 POINT PART ########################
-
-
-
-        // ################## 4 POINT PART ############################
-        std::cout << "Found no 3-point solution. Try 4 points" << std::endl;
-
-        // Get all candidates for vector s
         /* The kkt_eg_solutions solver handles some numerical issues
          * like A having some values close to machine epsilon and
          * eigenvalues being close to 0. Just assume that any solution
          * must be among the ones given in solution candidates. we check
          * all of them.
          */
-        Matrix3d temp_A = build_A_4p(coords);
-        Vector3d temp_b = build_b_4p(coords, d);
         QList<Vector3d> solution_candidates = kkt_eq_solutions(temp_A, temp_b);
 
-        // Go through candidates s and pick the best one
         for (int sol_num = 0; sol_num < solution_candidates.length(); sol_num++) {
+            // Solution of three point problem
+            temp_coords = move_points_3p(input_cords_3p, d,
+                                         solution_candidates.at(sol_num));
+            if (temp_coords.length() < 1) { temp_coords = input_cords_3p; }
 
-            moved_coords = move_points_4p(coords, d, solution_candidates.at(sol_num));
+            for (int jj = 0; jj < 3; jj++) {
+                moved_coords.replace(three_point_index[ii][jj], temp_coords.at(jj));
+            }
+
             if (shortest_distance(moved_coords) >= d - 0.001 &&
                 movement_cost(coords, moved_coords) < cost) {
-                // If several candidates for s work, save the one with lovest movement cost
+                // If several moves of three points work, save the one with lovest movement cost
                 cost = movement_cost(coords, moved_coords);
                 solution_coords = moved_coords;
             }
         }
 
-        if (solution_coords.length() == 0)
-            std::cout << "Found no solution to interwell projection problem" << std::endl;
+    }
+    // If there were any succesful configurations, return the best one.
+    if (cost < INFINITY) {
         return solution_coords;
     }
+    // ################## END 3 POINT PART ########################
 
-    double shortest_distance_n_wells(QList<QList<Vector3d>> wells, int n) {
-        double distance = INFINITY;
 
+
+    // ################## 4 POINT PART ############################
+    std::cout << "Found no 3-point solution. Try 4 points" << std::endl;
+
+    // Get all candidates for vector s
+    /* The kkt_eg_solutions solver handles some numerical issues
+     * like A having some values close to machine epsilon and
+     * eigenvalues being close to 0. Just assume that any solution
+     * must be among the ones given in solution candidates. we check
+     * all of them.
+     */
+    Matrix3d temp_A = build_A_4p(coords);
+    Vector3d temp_b = build_b_4p(coords, d);
+    QList<Vector3d> solution_candidates = kkt_eq_solutions(temp_A, temp_b);
+
+    // Go through candidates s and pick the best one
+    for (int sol_num = 0; sol_num < solution_candidates.length(); sol_num++) {
+
+        moved_coords = move_points_4p(coords, d, solution_candidates.at(sol_num));
+        if (shortest_distance(moved_coords) >= d - 0.001 &&
+            movement_cost(coords, moved_coords) < cost) {
+            // If several candidates for s work, save the one with lovest movement cost
+            cost = movement_cost(coords, moved_coords);
+            solution_coords = moved_coords;
+        }
+    }
+
+    if (solution_coords.length() == 0)
+        std::cout << "Found no solution to interwell projection problem" << std::endl;
+    return solution_coords;
+}
+
+double shortest_distance_n_wells(QList<QList<Vector3d>> wells, int n) {
+    double distance = INFINITY;
+
+    // for all pairs of wells (i,j) i != j
+    for (int i = 0; i < n; i++) {
+        for (int j = i + 1; j < n; j++) {
+            // Create QList with current pair of wells
+            QList<Vector3d> current_pair;
+            current_pair.append(wells[i][0]);
+            current_pair.append(wells[i][1]);
+            current_pair.append(wells[j][0]);
+            current_pair.append(wells[j][1]);
+
+            if (shortest_distance(current_pair) < distance) {
+                distance = shortest_distance(current_pair);
+            }
+        }
+    }
+    return distance;
+}
+
+QList<QList<Vector3d>> interwell_constraint_multiple_wells(QList<QList<Vector3d>> wells, double d, double tol) {
+    double shortest_distance = 0;
+
+    // Loop through all wells as long as some pair of wells violate inter-well distance
+    // constraint. Tolerance tol added for quicker convergence.
+    int max_iter = 10000;
+    int iter = 0;
+    while (shortest_distance < d - tol && iter < max_iter) {
         // for all pairs of wells (i,j) i != j
-        for (int i = 0; i < n; i++) {
-            for (int j = i + 1; j < n; j++) {
+        for (int i = 0; i < wells.length(); i++) {
+            for (int j = i + 1; j < wells.length(); j++) {
                 // Create QList with current pair of wells
                 QList<Vector3d> current_pair;
                 current_pair.append(wells[i][0]);
@@ -244,567 +294,541 @@ namespace WellConstraintProjections {
                 current_pair.append(wells[j][0]);
                 current_pair.append(wells[j][1]);
 
-                if (shortest_distance(current_pair) < distance) {
-                    distance = shortest_distance(current_pair);
-                }
+                // Project pair of wells
+                current_pair = interwell_constraint_projection(current_pair, d);
+
+                // Replace initial well pair with projected pair.
+                wells[i].replace(0, current_pair[0]);
+                wells[i].replace(1, current_pair[1]);
+                wells[j].replace(0, current_pair[2]);
+                wells[j].replace(1, current_pair[3]);
             }
         }
-        return distance;
+        shortest_distance = shortest_distance_n_wells(wells, wells.length());
+        iter += 1;
     }
+    if (iter == max_iter)
+        std::cout << "No convergence in interwell distance constraints after max iterations "
+                  << iter << " reached" << std::endl;
 
-    QList<QList<Vector3d>> interwell_constraint_multiple_wells(QList<QList<Vector3d>> wells, double d, double tol) {
-        double shortest_distance = 0;
+    return wells;
+}
 
-        // Loop through all wells as long as some pair of wells violate inter-well distance
-        // constraint. Tolerance tol added for quicker convergence.
-        int max_iter = 10000;
-        int iter = 0;
-        while (shortest_distance < d - tol && iter < max_iter) {
-            // for all pairs of wells (i,j) i != j
-            for (int i = 0; i < wells.length(); i++) {
-                for (int j = i + 1; j < wells.length(); j++) {
-                    // Create QList with current pair of wells
-                    QList<Vector3d> current_pair;
-                    current_pair.append(wells[i][0]);
-                    current_pair.append(wells[i][1]);
-                    current_pair.append(wells[j][0]);
-                    current_pair.append(wells[j][1]);
-
-                    // Project pair of wells
-                    current_pair = interwell_constraint_projection(current_pair, d);
-
-                    // Replace initial well pair with projected pair.
-                    wells[i].replace(0, current_pair[0]);
-                    wells[i].replace(1, current_pair[1]);
-                    wells[j].replace(0, current_pair[2]);
-                    wells[j].replace(1, current_pair[3]);
-                }
-            }
-            shortest_distance = shortest_distance_n_wells(wells, wells.length());
-            iter += 1;
-        }
-        if (iter == max_iter)
-            std::cout << "No convergence in interwell distance constraints after max iterations "
-            << iter << " reached" << std::endl;
-
-        return wells;
+QList<QList<Vector3d> > well_length_constraint_multiple_wells(QList<QList<Vector3d> > wells,
+                                                              double max, double min, double epsilon) {
+    QList<QList<Vector3d>> projected_wells;
+    for (int i = 0; i < wells.length(); i++) {
+        Vector3d current_heel = wells[i][0];
+        Vector3d current_toe = wells[i][1];
+        projected_wells.append(well_length_projection(current_heel, current_toe, max, min, epsilon));
     }
+    return projected_wells;
+}
 
-    QList<QList<Vector3d> > well_length_constraint_multiple_wells(QList<QList<Vector3d> > wells,
-                                                                  double max, double min, double epsilon) {
-        QList<QList<Vector3d>> projected_wells;
-        for (int i = 0; i < wells.length(); i++) {
-            Vector3d current_heel = wells[i][0];
-            Vector3d current_toe = wells[i][1];
-            projected_wells.append(well_length_projection(current_heel, current_toe, max, min, epsilon));
-        }
-        return projected_wells;
-    }
+bool feasible_well_length(QList<QList<Vector3d>> wells, double max, double min, double tol) {
+    bool is_feasible = true;
+    for (int i = 0; i < wells.length(); i++) {
+        double current_well_length;
+        current_well_length = (wells[i][0] - wells[i][1]).norm();
 
-    bool feasible_well_length(QList<QList<Vector3d>> wells, double max, double min, double tol) {
-        bool is_feasible = true;
-        for (int i = 0; i < wells.length(); i++) {
-            double current_well_length;
-            current_well_length = (wells[i][0] - wells[i][1]).norm();
-
-            // If smaller than min or larger than max (with tolerance tol). not feasible
-            if (current_well_length < min - tol || current_well_length > max + tol) {
-                is_feasible = false;
-            }
-        }
-        return is_feasible;
-    }
-
-    bool feasible_interwell_distance(QList<QList<Vector3d>> wells, double d, double tol) {
-        // Number of wells
-        bool is_feasible = true;
-        if (shortest_distance_n_wells(wells, wells.length()) < d - tol) {
+        // If smaller than min or larger than max (with tolerance tol). not feasible
+        if (current_well_length < min - tol || current_well_length > max + tol) {
             is_feasible = false;
         }
-        return is_feasible;
     }
+    return is_feasible;
+}
 
-    QList<QList<Vector3d> > both_constraints_multiple_wells(QList<QList<Vector3d> > wells, double d,
-                                                            double tol, double max, double min, double epsilon) {
-        int iter = 0;
-
-        // While at least one of the constraints is violated, continue projecting
-        while (!feasible_interwell_distance(wells, d, 3 * tol) ||
-               !feasible_well_length(wells, max, min, tol)) {
-            wells = well_length_constraint_multiple_wells(wells, max, min, epsilon);
-            wells = interwell_constraint_multiple_wells(wells, d, tol);
-
-            iter += 1;
-            if (iter > 100) {
-                std::cout << "In both_both_constraints_multiple_wells: above max number of iterations" << std::endl;
-                return wells;
-            }
-        }
-        return wells;
+bool feasible_interwell_distance(QList<QList<Vector3d>> wells, double d, double tol) {
+    // Number of wells
+    bool is_feasible = true;
+    if (shortest_distance_n_wells(wells, wells.length()) < d - tol) {
+        is_feasible = false;
     }
+    return is_feasible;
+}
 
-    Vector3d well_domain_constraint(Vector3d point, QList<Reservoir::Grid::Cell> cells) {
-        double minimum = INFINITY;
-        Vector3d best_point;
+QList<QList<Vector3d> > both_constraints_multiple_wells(QList<QList<Vector3d> > wells, double d,
+                                                        double tol, double max, double min, double epsilon) {
+    int iter = 0;
 
-        for (auto cell : cells) {
-            Vector3d temp_point = point_to_cell_shortest(cell, point);
-            Vector3d projected_length = point - temp_point;
+    // While at least one of the constraints is violated, continue projecting
+    while (!feasible_interwell_distance(wells, d, 3 * tol) ||
+        !feasible_well_length(wells, max, min, tol)) {
+        wells = well_length_constraint_multiple_wells(wells, max, min, epsilon);
+        wells = interwell_constraint_multiple_wells(wells, d, tol);
 
-            if (projected_length.norm() < minimum) {
-                best_point = temp_point;
-                minimum = projected_length.norm();
-            }
+        iter += 1;
+        if (iter > 100) {
+            std::cout << "In both_both_constraints_multiple_wells: above max number of iterations" << std::endl;
+            return wells;
         }
-        return best_point;
     }
+    return wells;
+}
 
-    Vector3d well_domain_constraint_indices(Vector3d point, Reservoir::Grid::Grid *grid, QList<int> index_list) {
-        QList<Reservoir::Grid::Cell> cells;
-        for (int index : index_list) {
-            cells.append(grid->GetCell(index));
+Vector3d well_domain_constraint(Vector3d point, QList<Reservoir::Grid::Cell> cells) {
+    double minimum = INFINITY;
+    Vector3d best_point;
+
+    for (auto cell : cells) {
+        Vector3d temp_point = point_to_cell_shortest(cell, point);
+        Vector3d projected_length = point - temp_point;
+
+        if (projected_length.norm() < minimum) {
+            best_point = temp_point;
+            minimum = projected_length.norm();
         }
-        return well_domain_constraint(point, cells);
     }
+    return best_point;
+}
 
-    double shortest_distance(QList<Vector3d> coords) {
-        auto closest_p_q = closest_points_on_lines(coords[0], coords[1], coords[2], coords[3]);
-        Vector3d closest_distance_vec = closest_p_q.second - closest_p_q.first;
-        double distance = sqrt(closest_distance_vec.transpose() * closest_distance_vec);
-        return distance;
+Vector3d well_domain_constraint_indices(Vector3d point, Reservoir::Grid::Grid *grid, QList<int> index_list) {
+    QList<Reservoir::Grid::Cell> cells;
+    for (int index : index_list) {
+        cells.append(grid->GetCell(index));
     }
+    return well_domain_constraint(point, cells);
+}
 
-    QList<Vector3d> well_length_projection(Vector3d heel, Vector3d toe, double max, double min, double epsilon) {
-        QList<Vector3d> projected_points;
-        Vector3d moved_heel;
-        Vector3d moved_toe;
-        Vector3d heel_to_toe_vec = toe - heel;
-        double d = heel_to_toe_vec.norm();
+double shortest_distance(QList<Vector3d> coords) {
+    auto closest_p_q = closest_points_on_lines(coords[0], coords[1], coords[2], coords[3]);
+    Vector3d closest_distance_vec = closest_p_q.second - closest_p_q.first;
+    double distance = sqrt(closest_distance_vec.transpose() * closest_distance_vec);
+    return distance;
+}
 
-        // If heel and toe same point, all directions are equally good.
-        if (d == 0) {
-            Vector3d unit_vector = Vector3d(1,0,0);
-            moved_heel = heel + (min / 2) * unit_vector;
-            moved_toe = heel - (min / 2) * unit_vector;
-            projected_points.append(moved_heel);
-            projected_points.append(moved_toe);
-            return projected_points;
-        }
-        // Normalize vector to get correct distance
-        heel_to_toe_vec.normalize();
+QList<Vector3d> well_length_projection(Vector3d heel, Vector3d toe, double max, double min, double epsilon) {
+    QList<Vector3d> projected_points;
+    Vector3d moved_heel;
+    Vector3d moved_toe;
+    Vector3d heel_to_toe_vec = toe - heel;
+    double d = heel_to_toe_vec.norm();
 
-        if (d <= max && d >= min) { // Trivial case
-            projected_points.append(heel);
-            projected_points.append(toe);
-        }
-        else if (d > max) { // Distance too long
-            double move_distance = 0.5 * (d - max + (epsilon / 2));
-            moved_heel = heel + move_distance * heel_to_toe_vec;
-            moved_toe = toe - move_distance * heel_to_toe_vec;
-            projected_points.append(moved_heel);
-            projected_points.append(moved_toe);
-        }
-        else { // Distance too short
-            double move_distance = 0.5 * (d - min - (epsilon / 2));
-            moved_heel = heel + move_distance * heel_to_toe_vec;
-            moved_toe = toe - move_distance * heel_to_toe_vec;
-            projected_points.append(moved_heel);
-            projected_points.append(moved_toe);
-        }
+    // If heel and toe same point, all directions are equally good.
+    if (d == 0) {
+        Vector3d unit_vector = Vector3d(1,0,0);
+        moved_heel = heel + (min / 2) * unit_vector;
+        moved_toe = heel - (min / 2) * unit_vector;
+        projected_points.append(moved_heel);
+        projected_points.append(moved_toe);
         return projected_points;
     }
+    // Normalize vector to get correct distance
+    heel_to_toe_vec.normalize();
 
-    QList<Vector3d> non_inv_solution(Matrix3d A, Vector3d b) {
-        QList<Vector3d> solution_vectors;
-        // Compute full pivotal LU decomposition of A
-        FullPivLU<Matrix3d> lu(A);
-        Vector3d x = A.fullPivLu().solve(b);
+    if (d <= max && d >= min) { // Trivial case
+        projected_points.append(heel);
+        projected_points.append(toe);
+    }
+    else if (d > max) { // Distance too long
+        double move_distance = 0.5 * (d - max + (epsilon / 2));
+        moved_heel = heel + move_distance * heel_to_toe_vec;
+        moved_toe = toe - move_distance * heel_to_toe_vec;
+        projected_points.append(moved_heel);
+        projected_points.append(moved_toe);
+    }
+    else { // Distance too short
+        double move_distance = 0.5 * (d - min - (epsilon / 2));
+        moved_heel = heel + move_distance * heel_to_toe_vec;
+        moved_toe = toe - move_distance * heel_to_toe_vec;
+        projected_points.append(moved_heel);
+        projected_points.append(moved_toe);
+    }
+    return projected_points;
+}
 
-        MatrixXd nu = lu.kernel();
-        Vector3d null_space;
-        if (nu.cols() > 1) {
-            null_space << nu(0, 0), nu(1, 0), nu(2, 0);
-        }
-        else null_space = nu;
+QList<Vector3d> non_inv_solution(Matrix3d A, Vector3d b) {
+    QList<Vector3d> solution_vectors;
+    // Compute full pivotal LU decomposition of A
+    FullPivLU<Matrix3d> lu(A);
+    Vector3d x = A.fullPivLu().solve(b);
 
-        // \todo Hilmar, check this (the 4 next lines). Its to avoid problems if the polynomial is a constant.
-        auto coeffs = non_inv_quad_coeffs(x, null_space);
-        if (coeffs[0] == 0.0 && coeffs[1] == 0.0) {
-            return solution_vectors;
-        }
+    MatrixXd nu = lu.kernel();
+    Vector3d null_space;
+    if (nu.cols() > 1) {
+        null_space << nu(0, 0), nu(1, 0), nu(2, 0);
+    }
+    else null_space = nu;
 
-        VectorXd real_roots, complex_roots;
-        rpoly_plus_plus::FindPolynomialRootsJenkinsTraub(coeffs, &real_roots, &complex_roots);
-
-
-        if (complex_roots(0) == 0) {
-            Vector3d s0 = x + real_roots(0) * null_space;
-            solution_vectors.append(s0);
-        }
-        if (complex_roots(1) == 0) {
-            Vector3d s1 = x + real_roots(1) * null_space;
-            solution_vectors.append(s1);
-        }
-
+    // \todo Hilmar, check this (the 4 next lines). Its to avoid problems if the polynomial is a constant.
+    auto coeffs = non_inv_quad_coeffs(x, null_space);
+    if (coeffs[0] == 0.0 && coeffs[1] == 0.0) {
         return solution_vectors;
     }
 
-    bool solution_existence(Matrix3d A, Vector3d b) {
-        Vector3d x = A.fullPivLu().solve(b);
-        return ((A * x).isApprox(b));
+    VectorXd real_roots, complex_roots;
+    rpoly_plus_plus::FindPolynomialRootsJenkinsTraub(coeffs, &real_roots, &complex_roots);
+
+
+    if (complex_roots(0) == 0) {
+        Vector3d s0 = x + real_roots(0) * null_space;
+        solution_vectors.append(s0);
+    }
+    if (complex_roots(1) == 0) {
+        Vector3d s1 = x + real_roots(1) * null_space;
+        solution_vectors.append(s1);
     }
 
-    Matrix3d build_A_4p(QList<Vector3d> coords) {
-        Vector3d vec1 = coords.at(0);
-        Vector3d vec2 = coords.at(1);
-        Vector3d vec3 = coords.at(2);
-        Vector3d vec4 = coords.at(3);
-        Vector3d avg_vec = 0.25 * (vec1 + vec2 + vec3 + vec4);
-        vec1 = vec1 - avg_vec;
-        vec2 = vec2 - avg_vec;
-        vec3 = vec3 - avg_vec;
-        vec4 = vec4 - avg_vec;
+    return solution_vectors;
+}
 
-        return vec1 * vec1.transpose() + vec2 * vec2.transpose() + vec3 * vec3.transpose() +
-               vec4 * vec4.transpose();
+bool solution_existence(Matrix3d A, Vector3d b) {
+    Vector3d x = A.fullPivLu().solve(b);
+    return ((A * x).isApprox(b));
+}
+
+Matrix3d build_A_4p(QList<Vector3d> coords) {
+    Vector3d vec1 = coords.at(0);
+    Vector3d vec2 = coords.at(1);
+    Vector3d vec3 = coords.at(2);
+    Vector3d vec4 = coords.at(3);
+    Vector3d avg_vec = 0.25 * (vec1 + vec2 + vec3 + vec4);
+    vec1 = vec1 - avg_vec;
+    vec2 = vec2 - avg_vec;
+    vec3 = vec3 - avg_vec;
+    vec4 = vec4 - avg_vec;
+
+    return vec1 * vec1.transpose() + vec2 * vec2.transpose() + vec3 * vec3.transpose() +
+        vec4 * vec4.transpose();
+}
+
+Vector3d build_b_4p(QList<Vector3d> coords, double d) {
+    Vector3d vec1 = coords.at(0);
+    Vector3d vec2 = coords.at(1);
+    Vector3d vec3 = coords.at(2);
+    Vector3d vec4 = coords.at(3);
+    Vector3d avg_vec = 0.25 * (vec1 + vec2 + vec3 + vec4);
+    vec1 = vec1 - avg_vec;
+    vec2 = vec2 - avg_vec;
+    vec3 = vec3 - avg_vec;
+    vec4 = vec4 - avg_vec;
+
+    return 0.5 * d * (vec1 + vec2 - vec3 - vec4);
+}
+
+Matrix3d build_A_3p(QList<Vector3d> coords) {
+    Vector3d vec1 = coords.at(0);
+    Vector3d vec2 = coords.at(1);
+    Vector3d vec3 = coords.at(2);
+    Vector3d avg_vec = (1.0 / 3) * (vec1 + vec2 + vec3);
+
+    vec1 = vec1 - avg_vec;
+    vec2 = vec2 - avg_vec;
+    vec3 = vec3 - avg_vec;
+    return vec1 * vec1.transpose() + vec2 * vec2.transpose() + vec3 * vec3.transpose();
+}
+
+Vector3d build_b_3p(QList<Vector3d> coords, double d) {
+    Vector3d vec1 = coords.at(0);
+    Vector3d vec2 = coords.at(1);
+    Vector3d vec3 = coords.at(2);
+    Vector3d avg_vec = (1.0 / 3) * (vec1 + vec2 + vec3);
+    vec1 = vec1 - avg_vec;
+    vec2 = vec2 - avg_vec;
+    vec3 = vec3 - avg_vec;
+
+    return (2.0 / 3) * d * (vec1) - (1.0 / 3) * d * (vec2 + vec3);
+}
+
+VectorXd coeff_vector(Vector3d D, Matrix3d Qinv, Vector3d b) {
+    double D1 = D(0);
+    double D2 = D(1);
+    double D3 = D(2);
+    double sum_i = D1 + D2 + D3;
+    double sum_ij = D1*D2 + D2*D3 + D3*D1;
+    double prod_i = D1*D2*D3;
+    double Qtb_1 = Qinv.row(0) * b * (Qinv.row(0) * b);
+    double Qtb_2 = Qinv.row(1) * b * (Qinv.row(1) * b);
+    double Qtb_3 = Qinv.row(2) * b * (Qinv.row(2) * b);
+
+    VectorXd lambda(7);
+    lambda(0) = 1;
+    lambda(1) = -2 * sum_i;
+    lambda(2) = 2 * sum_ij + sum_i * sum_i - (Qtb_1 + Qtb_2 + Qtb_3);
+    lambda(3) = -2 * prod_i - 2 * sum_i * sum_ij - Qtb_1 * (-2 * D2 - 2 * D3)
+        - Qtb_2 * (-2 * D3 - 2 * D1)
+        - Qtb_3 * (-2 * D1 - 2 * D2);
+    lambda(4) = 2 * sum_i * prod_i + sum_ij * sum_ij - Qtb_1 * (D2 * D2 + D3 * D3 + 4 * D2 * D3)
+        - Qtb_2 * (D3 * D3 + D1 * D1 + 4 * D3 * D1)
+        - Qtb_3 * (D1 * D1 + D2 * D2 + 4 * D1 * D2);
+    lambda(5) = -2 * sum_ij * prod_i - Qtb_1 * (-2 * D2 * D3 * D3 - 2 * D3 * D2 * D2)
+        - Qtb_2 * (-2 * D3 * D1 * D1 - 2 * D1 * D3 * D3)
+        - Qtb_3 * (-2 * D1 * D2 * D2 - 2 * D2 * D1 * D1);
+    lambda(6) = prod_i * prod_i - Qtb_1 * (D2 * D2 * D3 * D3)
+        - Qtb_2 * (D3 * D3 * D1 * D1)
+        - Qtb_3 * (D1 * D1 * D2 * D2);
+
+    return lambda;
+}
+
+double movement_cost(QList<Vector3d> old_coords, QList<Vector3d> new_coords) {
+    double n_of_points = old_coords.length();
+    if (new_coords.length() != n_of_points) {
+        throw std::runtime_error("Error in movement_cost: Lists of points are not the same length");
     }
-
-    Vector3d build_b_4p(QList<Vector3d> coords, double d) {
-        Vector3d vec1 = coords.at(0);
-        Vector3d vec2 = coords.at(1);
-        Vector3d vec3 = coords.at(2);
-        Vector3d vec4 = coords.at(3);
-        Vector3d avg_vec = 0.25 * (vec1 + vec2 + vec3 + vec4);
-        vec1 = vec1 - avg_vec;
-        vec2 = vec2 - avg_vec;
-        vec3 = vec3 - avg_vec;
-        vec4 = vec4 - avg_vec;
-
-        return 0.5 * d * (vec1 + vec2 - vec3 - vec4);
+    double cost_squares = 0;
+    for (int ii = 0; ii < n_of_points; ii++) {
+        cost_squares += (old_coords.at(ii) - new_coords.at(ii)).squaredNorm();
     }
+    return cost_squares;
+}
 
-    Matrix3d build_A_3p(QList<Vector3d> coords) {
-        Vector3d vec1 = coords.at(0);
-        Vector3d vec2 = coords.at(1);
-        Vector3d vec3 = coords.at(2);
-        Vector3d avg_vec = (1.0 / 3) * (vec1 + vec2 + vec3);
+QList<Vector3d> move_points_4p(QList<Vector3d> coords, double d, Vector3d s) {
+    // Normalize s in case it is not of unit length
+    s.normalize();
+    Vector3d avg_point = 0.25 * (coords.at(0) + coords.at(1) + coords.at(2) + coords.at(3));
+    Vector3d top_plane_point = avg_point + (d / 2) * (s);
+    Vector3d bot_plane_point = avg_point - (d / 2) * (s);
 
-        vec1 = vec1 - avg_vec;
-        vec2 = vec2 - avg_vec;
-        vec3 = vec3 - avg_vec;
-        return vec1 * vec1.transpose() + vec2 * vec2.transpose() + vec3 * vec3.transpose();
-    }
+    Vector3d x0moved = project_point_to_plane(coords.at(0), s, top_plane_point);
+    Vector3d x1moved = project_point_to_plane(coords.at(1), s, top_plane_point);
+    Vector3d x2moved = project_point_to_plane(coords.at(2), s, bot_plane_point);
+    Vector3d x3moved = project_point_to_plane(coords.at(3), s, bot_plane_point);
 
-    Vector3d build_b_3p(QList<Vector3d> coords, double d) {
-        Vector3d vec1 = coords.at(0);
-        Vector3d vec2 = coords.at(1);
-        Vector3d vec3 = coords.at(2);
-        Vector3d avg_vec = (1.0 / 3) * (vec1 + vec2 + vec3);
-        vec1 = vec1 - avg_vec;
-        vec2 = vec2 - avg_vec;
-        vec3 = vec3 - avg_vec;
+    return QList<Vector3d>({x0moved, x1moved, x2moved, x3moved});
+}
 
-        return (2.0 / 3) * d * (vec1) - (1.0 / 3) * d * (vec2 + vec3);
-    }
+QList<Vector3d> move_points_3p(QList<Vector3d> coords, double d, Vector3d s) {
+    // Normalize s in case it is not of unit length
+    s.normalize();
+    Vector3d avg_point = (1.0 / 3) * (coords.at(0) + coords.at(1) + coords.at(2));
+    Vector3d top_plane_point = avg_point + (2.0 * d / 3) * (s);
+    Vector3d bot_plane_point = avg_point - (1.0 * d / 3) * (s);
 
-    VectorXd coeff_vector(Vector3d D, Matrix3d Qinv, Vector3d b) {
-        double D1 = D(0);
-        double D2 = D(1);
-        double D3 = D(2);
-        double sum_i = D1 + D2 + D3;
-        double sum_ij = D1*D2 + D2*D3 + D3*D1;
-        double prod_i = D1*D2*D3;
-        double Qtb_1 = Qinv.row(0) * b * (Qinv.row(0) * b);
-        double Qtb_2 = Qinv.row(1) * b * (Qinv.row(1) * b);
-        double Qtb_3 = Qinv.row(2) * b * (Qinv.row(2) * b);
+    Vector3d x0moved = project_point_to_plane(coords.at(0), s, top_plane_point);
+    Vector3d x1moved = project_point_to_plane(coords.at(1), s, bot_plane_point);
+    Vector3d x2moved = project_point_to_plane(coords.at(2), s, bot_plane_point);
 
-        VectorXd lambda(7);
-        lambda(0) = 1;
-        lambda(1) = -2 * sum_i;
-        lambda(2) = 2 * sum_ij + sum_i * sum_i - (Qtb_1 + Qtb_2 + Qtb_3);
-        lambda(3) = -2 * prod_i - 2 * sum_i * sum_ij - Qtb_1 * (-2 * D2 - 2 * D3)
-                    - Qtb_2 * (-2 * D3 - 2 * D1)
-                    - Qtb_3 * (-2 * D1 - 2 * D2);
-        lambda(4) = 2 * sum_i * prod_i + sum_ij * sum_ij - Qtb_1 * (D2 * D2 + D3 * D3 + 4 * D2 * D3)
-                    - Qtb_2 * (D3 * D3 + D1 * D1 + 4 * D3 * D1)
-                    - Qtb_3 * (D1 * D1 + D2 * D2 + 4 * D1 * D2);
-        lambda(5) = -2 * sum_ij * prod_i - Qtb_1 * (-2 * D2 * D3 * D3 - 2 * D3 * D2 * D2)
-                    - Qtb_2 * (-2 * D3 * D1 * D1 - 2 * D1 * D3 * D3)
-                    - Qtb_3 * (-2 * D1 * D2 * D2 - 2 * D2 * D1 * D1);
-        lambda(6) = prod_i * prod_i - Qtb_1 * (D2 * D2 * D3 * D3)
-                    - Qtb_2 * (D3 * D3 * D1 * D1)
-                    - Qtb_3 * (D1 * D1 * D2 * D2);
+    return QList<Vector3d>({x0moved, x1moved, x2moved});
+}
 
-        return lambda;
-    }
+Vector3d project_point_to_plane(Vector3d point, Vector3d normal_vector, Vector3d plane_point) {
+    Vector3d proj_point = point - normal_vector * ((point - plane_point).transpose() * normal_vector);
+    return proj_point;
+}
 
-    double movement_cost(QList<Vector3d> old_coords, QList<Vector3d> new_coords) {
-        double n_of_points = old_coords.length();
-        if (new_coords.length() != n_of_points) {
-            throw std::runtime_error("Error in movement_cost: Lists of points are not the same length");
+QList<Vector3d> kkt_eq_solutions(Matrix3d A, Vector3d b) {
+    QList<Vector3d> candidate_solutions;
+
+    // Assume that A-\mu I has an inverse - find it and solve a sixth degree eq. for \mu
+    A = rm_entries_eps_matrix(A, 10e-12);
+    SelfAdjointEigenSolver<Matrix3d> A_es(A);
+
+    // Remove eigenvalues that are aproximately 0
+    Vector3d eigenvalues = rm_entries_eps(A_es.eigenvalues(), 10e-12);
+
+    // Compute coefficients of 6th degree polynomial
+    VectorXd coeffs = coeff_vector(eigenvalues, A_es.eigenvectors().inverse(), b);
+
+    /* There is an issue where coefficients should be zero but are not. Because of numerical issues
+     * these need to be handled manually. Set all whise fabs(x) < 10e-12 to zero. */
+    coeffs = rm_entries_eps_coeffs(coeffs, 10e-12);
+
+    // Compute roots of polynomial
+    VectorXd realroots(6);
+    VectorXd comproots(6);
+    rpoly_plus_plus::FindPolynomialRootsJenkinsTraub(coeffs, &realroots, &comproots);
+
+    for (int ii = 0; ii < 6; ii++) {
+        // Root may not be complex or an eigenvalue of A
+        if (comproots[ii] == 0 && eigenvalues[0] != realroots[ii] &&
+            eigenvalues[1] != realroots[ii] && eigenvalues[2] != realroots[ii]) {
+
+            // We have found a valid root. Get vector s.
+            double cur_root = realroots[ii];
+            Vector3d cur_root_vec;
+            cur_root_vec << cur_root, cur_root, cur_root;
+            Matrix3d invmatr = (eigenvalues - cur_root_vec).asDiagonal();
+            Vector3d s = A_es.eigenvectors() * invmatr.inverse() * A_es.eigenvectors().inverse() * b;
+            candidate_solutions.append(s);
         }
-        double cost_squares = 0;
-        for (int ii = 0; ii < n_of_points; ii++) {
-            cost_squares += (old_coords.at(ii) - new_coords.at(ii)).squaredNorm();
+    }
+
+    /* Now for the second part assume that A-\mu I is not invertible, i.e. \mu is an eigenvalue of A. Then
+     * we either have an infinite amount of solutions of (A-\mu I)s = b. Require s have length 1 to find
+     * at most two solutions as long as all points are not on the same line. */
+    for (int i = 0; i < 3; i++) { // Loop through all 3 eigenvalues of A
+        QList<Vector3d> eigenvalue_solutions;
+
+        // Create linear system (A-\my I)s = b
+        Matrix3d A_eig = A - eigenvalues[i] * Matrix3d::Identity();
+        Vector3d b_eig = b;
+
+        if (solution_existence(A_eig, b_eig)) { // Check for existence of solution
+            eigenvalue_solutions = non_inv_solution(A_eig, b_eig);
         }
-        return cost_squares;
+        for (auto solution : eigenvalue_solutions) { // If any solutions, add them to solution_vectors
+            candidate_solutions.append(solution);
+        }
     }
+    return candidate_solutions;
+}
 
-    QList<Vector3d> move_points_4p(QList<Vector3d> coords, double d, Vector3d s) {
-        // Normalize s in case it is not of unit length
-        s.normalize();
-        Vector3d avg_point = 0.25 * (coords.at(0) + coords.at(1) + coords.at(2) + coords.at(3));
-        Vector3d top_plane_point = avg_point + (d / 2) * (s);
-        Vector3d bot_plane_point = avg_point - (d / 2) * (s);
+QPair<Vector3d, Vector3d> closest_points_on_lines(Vector3d P0, Vector3d P1, Vector3d Q0, Vector3d Q1) {
+    /* Function runs through all possible combinations of where the two closest points could be located.
+     * This function is a slightly edited version of the one from:
+     * http://www.geometrictools.com/GTEngine/Include/Mathematics/GteDistSegmentSegmentExact.h
+     *
+     * David Eberly, Geometric Tools, Redmond WA 98052
+     * Copyright (c) 1998-2016
+     * Distributed under the Boost Software License, Version 1.0.
+     * http://www.boost.org/LICENSE_1_0.txt
+     * http://www.geometrictools.com/License/Boost/LICENSE_1_0.txt
+     * File Version: 2.1.0 (2016/01/25)d
+     */
+    Vector3d P1mP0 = P1 - P0;
+    Vector3d Q1mQ0 = Q1 - Q0;
+    Vector3d P0mQ0 = P0 - Q0;
 
-        Vector3d x0moved = project_point_to_plane(coords.at(0), s, top_plane_point);
-        Vector3d x1moved = project_point_to_plane(coords.at(1), s, top_plane_point);
-        Vector3d x2moved = project_point_to_plane(coords.at(2), s, bot_plane_point);
-        Vector3d x3moved = project_point_to_plane(coords.at(3), s, bot_plane_point);
+    double a = P1mP0.transpose() * P1mP0;
+    double b = P1mP0.transpose() * Q1mQ0;
+    double c = Q1mQ0.transpose() * Q1mQ0;
+    double d = P1mP0.transpose() * P0mQ0;
+    double e = Q1mQ0.transpose() * P0mQ0;
+    double const zero = 0;
+    double const one = 1;
+    double det = a * c - b * b;
+    double s, t, nd, bmd, bte, ctd, bpe, ate, btd;
 
-        return QList<Vector3d>({x0moved, x1moved, x2moved, x3moved});
-    }
-
-    QList<Vector3d> move_points_3p(QList<Vector3d> coords, double d, Vector3d s) {
-        // Normalize s in case it is not of unit length
-        s.normalize();
-        Vector3d avg_point = (1.0 / 3) * (coords.at(0) + coords.at(1) + coords.at(2));
-        Vector3d top_plane_point = avg_point + (2.0 * d / 3) * (s);
-        Vector3d bot_plane_point = avg_point - (1.0 * d / 3) * (s);
-
-        Vector3d x0moved = project_point_to_plane(coords.at(0), s, top_plane_point);
-        Vector3d x1moved = project_point_to_plane(coords.at(1), s, bot_plane_point);
-        Vector3d x2moved = project_point_to_plane(coords.at(2), s, bot_plane_point);
-
-        return QList<Vector3d>({x0moved, x1moved, x2moved});
-    }
-
-    Vector3d project_point_to_plane(Vector3d point, Vector3d normal_vector, Vector3d plane_point) {
-        Vector3d proj_point = point - normal_vector * ((point - plane_point).transpose() * normal_vector);
-        return proj_point;
-    }
-
-    QList<Vector3d> kkt_eq_solutions(Matrix3d A, Vector3d b) {
-        QList<Vector3d> candidate_solutions;
-
-        // Assume that A-\mu I has an inverse - find it and solve a sixth degree eq. for \mu
-        A = rm_entries_eps_matrix(A, 10e-12);
-        SelfAdjointEigenSolver<Matrix3d> A_es(A);
-
-        // Remove eigenvalues that are aproximately 0
-        Vector3d eigenvalues = rm_entries_eps(A_es.eigenvalues(), 10e-12);
-
-        // Compute coefficients of 6th degree polynomial
-        VectorXd coeffs = coeff_vector(eigenvalues, A_es.eigenvectors().inverse(), b);
-
-        /* There is an issue where coefficients should be zero but are not. Because of numerical issues
-         * these need to be handled manually. Set all whise fabs(x) < 10e-12 to zero. */
-        coeffs = rm_entries_eps_coeffs(coeffs, 10e-12);
-
-        // Compute roots of polynomial
-        VectorXd realroots(6);
-        VectorXd comproots(6);
-        rpoly_plus_plus::FindPolynomialRootsJenkinsTraub(coeffs, &realroots, &comproots);
-
-        for (int ii = 0; ii < 6; ii++) {
-            // Root may not be complex or an eigenvalue of A
-            if (comproots[ii] == 0 && eigenvalues[0] != realroots[ii] &&
-                eigenvalues[1] != realroots[ii] && eigenvalues[2] != realroots[ii]) {
-
-                // We have found a valid root. Get vector s.
-                double cur_root = realroots[ii];
-                Vector3d cur_root_vec;
-                cur_root_vec << cur_root, cur_root, cur_root;
-                Matrix3d invmatr = (eigenvalues - cur_root_vec).asDiagonal();
-                Vector3d s = A_es.eigenvectors() * invmatr.inverse() * A_es.eigenvectors().inverse() * b;
-                candidate_solutions.append(s);
+    if (det > zero) {
+        bte = b * e;
+        ctd = c * d;
+        if (bte <= ctd) {  // s <= 0
+            s = zero;
+            if (e <= zero) { // t <= 0, region 6
+                t = zero;
+                nd = -d;
+                if (nd >= a)
+                    s = one;
+                else if (nd > zero)
+                    s = nd / a;
+                // else: s is already zero
+            }
+            else if (e < c) { // 0 < t < 1, region 5
+                t = e / c;
+            }
+            else { // t >= 1, region 4
+                t = one;
+                bmd = b - d;
+                if (bmd >= a)
+                    s = one;
+                else if (bmd > zero)
+                    s = bmd / a;
+                // else:  s is already zero
             }
         }
-
-        /* Now for the second part assume that A-\mu I is not invertible, i.e. \mu is an eigenvalue of A. Then
-         * we either have an infinite amount of solutions of (A-\mu I)s = b. Require s have length 1 to find
-         * at most two solutions as long as all points are not on the same line. */
-        for (int i = 0; i < 3; i++) { // Loop through all 3 eigenvalues of A
-            QList<Vector3d> eigenvalue_solutions;
-
-            // Create linear system (A-\my I)s = b
-            Matrix3d A_eig = A - eigenvalues[i] * Matrix3d::Identity();
-            Vector3d b_eig = b;
-
-            if (solution_existence(A_eig, b_eig)) { // Check for existence of solution
-                eigenvalue_solutions = non_inv_solution(A_eig, b_eig);
-            }
-            for (auto solution : eigenvalue_solutions) { // If any solutions, add them to solution_vectors
-                candidate_solutions.append(solution);
-            }
-        }
-        return candidate_solutions;
-    }
-
-    QPair<Vector3d, Vector3d> closest_points_on_lines(Vector3d P0, Vector3d P1, Vector3d Q0, Vector3d Q1) {
-        /* Function runs through all possible combinations of where the two closest points could be located.
-         * This function is a slightly edited version of the one from:
-         * http://www.geometrictools.com/GTEngine/Include/Mathematics/GteDistSegmentSegmentExact.h
-         *
-         * David Eberly, Geometric Tools, Redmond WA 98052
-         * Copyright (c) 1998-2016
-         * Distributed under the Boost Software License, Version 1.0.
-         * http://www.boost.org/LICENSE_1_0.txt
-         * http://www.geometrictools.com/License/Boost/LICENSE_1_0.txt
-         * File Version: 2.1.0 (2016/01/25)d
-         */
-        Vector3d P1mP0 = P1 - P0;
-        Vector3d Q1mQ0 = Q1 - Q0;
-        Vector3d P0mQ0 = P0 - Q0;
-
-        double a = P1mP0.transpose() * P1mP0;
-        double b = P1mP0.transpose() * Q1mQ0;
-        double c = Q1mQ0.transpose() * Q1mQ0;
-        double d = P1mP0.transpose() * P0mQ0;
-        double e = Q1mQ0.transpose() * P0mQ0;
-        double const zero = 0;
-        double const one = 1;
-        double det = a * c - b * b;
-        double s, t, nd, bmd, bte, ctd, bpe, ate, btd;
-
-        if (det > zero) {
-            bte = b * e;
-            ctd = c * d;
-            if (bte <= ctd) {  // s <= 0
-                s = zero;
-                if (e <= zero) { // t <= 0, region 6
+        else { // s > 0
+            s = bte - ctd;
+            if (s >= det) { // s >= 1
+                s = one; // s = 1
+                bpe = b + e;
+                if (bpe <= zero) { // t <= 0, region 8
                     t = zero;
                     nd = -d;
-                    if (nd >= a)
-                        s = one;
-                    else if (nd > zero)
+                    if (nd <= zero)
+                        s = zero;
+                    else if (nd < a)
                         s = nd / a;
-                    // else: s is already zero
+                    // else: s is already one
                 }
-                else if (e < c) { // 0 < t < 1, region 5
-                    t = e / c;
+                else if (bpe < c) { // 0 < t < 1, region 1
+                    t = bpe / c;
                 }
-                else { // t >= 1, region 4
+                else { // t >= 1, region 2
                     t = one;
                     bmd = b - d;
-                    if (bmd >= a)
-                        s = one;
-                    else if (bmd > zero)
+                    if (bmd <= zero)
+                        s = zero;
+                    else if (bmd < a)
                         s = bmd / a;
-                    // else:  s is already zero
+                    // else:  s is already one
                 }
             }
-            else { // s > 0
-                s = bte - ctd;
-                if (s >= det) { // s >= 1
-                    s = one; // s = 1
-                    bpe = b + e;
-                    if (bpe <= zero) { // t <= 0, region 8
-                        t = zero;
-                        nd = -d;
-                        if (nd <= zero)
-                            s = zero;
-                        else if (nd < a)
-                            s = nd / a;
-                        // else: s is already one
-                    }
-                    else if (bpe < c) { // 0 < t < 1, region 1
-                        t = bpe / c;
-                    }
-                    else { // t >= 1, region 2
+            else { // 0 < s < 1
+                ate = a * e;
+                btd = b * d;
+                if (ate <= btd) { // t <= 0, region 7
+                    t = zero;
+                    nd = -d;
+                    if (nd <= zero)
+                        s = zero;
+                    else if (nd >= a)
+                        s = one;
+                    else
+                        s = nd / a;
+                }
+                else { // t > 0
+                    t = ate - btd;
+                    if (t >= det) { // t >= 1, region 3
                         t = one;
                         bmd = b - d;
                         if (bmd <= zero)
                             s = zero;
-                        else if (bmd < a)
-                            s = bmd / a;
-                        // else:  s is already one
-                    }
-                }
-                else { // 0 < s < 1
-                    ate = a * e;
-                    btd = b * d;
-                    if (ate <= btd) { // t <= 0, region 7
-                        t = zero;
-                        nd = -d;
-                        if (nd <= zero)
-                            s = zero;
-                        else if (nd >= a)
+                        else if (bmd >= a)
                             s = one;
                         else
-                            s = nd / a;
+                            s = bmd / a;
                     }
-                    else { // t > 0
-                        t = ate - btd;
-                        if (t >= det) { // t >= 1, region 3
-                            t = one;
-                            bmd = b - d;
-                            if (bmd <= zero)
-                                s = zero;
-                            else if (bmd >= a)
-                                s = one;
-                            else
-                                s = bmd / a;
-                        }
-                        else { // 0 < t < 1, region 0
-                            s /= det;
-                            t /= det;
-                        }
+                    else { // 0 < t < 1, region 0
+                        s /= det;
+                        t /= det;
                     }
                 }
             }
         }
-        else {
-            // The segments are parallel.  The quadratic factors to R(s,t) =
-            // a*(s-(b/a)*t)^2 + 2*d*(s - (b/a)*t) + f, where a*c = b^2,
-            // e = b*d/a, f = |P0-Q0|^2, and b is not zero.  R is constant along
-            // lines of the form s-(b/a)*t = k, and the minimum of R occurs on the
-            // line a*s - b*t + d = 0.  This line must intersect both the s-axis
-            // and the t-axis because 'a' and 'b' are not zero.  Because of
-            // parallelism, the line is also represented by -b*s + c*t - e = 0.
-            //
-            // The code determines an edge of the domain [0,1]^2 that intersects
-            // the minimum line, or if none of the edges intersect, it determines
-            // the closest corner to the minimum line.  The conditionals are
-            // designed to test first for intersection with the t-axis (s = 0)
-            // using -b*s + c*t - e = 0 and then with the s-axis (t = 0) using
-            // a*s - b*t + d = 0.
-
-            // When s = 0, solve c*t - e = 0 (t = e/c).
-            if (e <= zero) { // t <= 0
-                // Now solve a*s - b*t + d = 0 for t = 0 (s = -d/a).
-                t = zero;
-                nd = -d;
-                if (nd <= zero) // s <= 0, region 6
-                    s = zero;
-                else if (nd >= a) // s >= 1, region 8
-                    s = one;
-                else // 0 < s < 1, region 7
-                    s = nd / a;
-            }
-            else if (e >= c) { // t >= 1
-                // Now solve a*s - b*t + d = 0 for t = 1 (s = (b-d)/a).
-                t = one;
-                bmd = b - d;
-                if (bmd <= zero) // s <= 0, region 4
-                    s = zero;
-                else if (bmd >= a) // s >= 1, region 2
-                    s = one;
-                else // 0 < s < 1, region 3
-                    s = bmd / a;
-            }
-            else { // 0 < t < 1
-                // The point (0,e/c) is on the line and domain, so we have one
-                // point at which R is a minimum.
-                s = zero;
-                t = e / c;
-            }
-        }
-
-        Vector3d closest_P = P0 + s * P1mP0;
-        Vector3d closest_Q = Q0 + t * Q1mQ0;
-        return QPair<Eigen::Vector3d, Eigen::Vector3d>(closest_P, closest_Q);
     }
+    else {
+        // The segments are parallel.  The quadratic factors to R(s,t) =
+        // a*(s-(b/a)*t)^2 + 2*d*(s - (b/a)*t) + f, where a*c = b^2,
+        // e = b*d/a, f = |P0-Q0|^2, and b is not zero.  R is constant along
+        // lines of the form s-(b/a)*t = k, and the minimum of R occurs on the
+        // line a*s - b*t + d = 0.  This line must intersect both the s-axis
+        // and the t-axis because 'a' and 'b' are not zero.  Because of
+        // parallelism, the line is also represented by -b*s + c*t - e = 0.
+        //
+        // The code determines an edge of the domain [0,1]^2 that intersects
+        // the minimum line, or if none of the edges intersect, it determines
+        // the closest corner to the minimum line.  The conditionals are
+        // designed to test first for intersection with the t-axis (s = 0)
+        // using -b*s + c*t - e = 0 and then with the s-axis (t = 0) using
+        // a*s - b*t + d = 0.
+
+        // When s = 0, solve c*t - e = 0 (t = e/c).
+        if (e <= zero) { // t <= 0
+            // Now solve a*s - b*t + d = 0 for t = 0 (s = -d/a).
+            t = zero;
+            nd = -d;
+            if (nd <= zero) // s <= 0, region 6
+                s = zero;
+            else if (nd >= a) // s >= 1, region 8
+                s = one;
+            else // 0 < s < 1, region 7
+                s = nd / a;
+        }
+        else if (e >= c) { // t >= 1
+            // Now solve a*s - b*t + d = 0 for t = 1 (s = (b-d)/a).
+            t = one;
+            bmd = b - d;
+            if (bmd <= zero) // s <= 0, region 4
+                s = zero;
+            else if (bmd >= a) // s >= 1, region 2
+                s = one;
+            else // 0 < s < 1, region 3
+                s = bmd / a;
+        }
+        else { // 0 < t < 1
+            // The point (0,e/c) is on the line and domain, so we have one
+            // point at which R is a minimum.
+            s = zero;
+            t = e / c;
+        }
+    }
+
+    Vector3d closest_P = P0 + s * P1mP0;
+    Vector3d closest_Q = Q0 + t * Q1mQ0;
+    return QPair<Eigen::Vector3d, Eigen::Vector3d>(closest_P, closest_Q);
+}
 
 
 }

--- a/FieldOpt/ConstraintMath/well_constraint_projections/well_constraint_projections.cpp
+++ b/FieldOpt/ConstraintMath/well_constraint_projections/well_constraint_projections.cpp
@@ -35,9 +35,16 @@ namespace WellConstraintProjections {
             return proj_point;
         }
 
-        // If the above is false, projected point is outside face, The closest point lies on one of the four lines.
-        // We create an array containing the index for line segments in the face, and loop through the lines to
-        // find best point.
+        // If the above is false, then the projected point is outside of the plane defined by face.
+        // If so, then the closest point lies on one of the four lines defining the bound of the cell.
+        // We create an array containing the index for the line segments defining the face, then loop
+        // through the lines to find closest point.
+        //
+        // cell face index ordering:
+        // 0 -- 1
+        // |    |
+        // 2 -- 3
+        // (Double check this is correct; see WIC notes)
         int line_indices[4][2] = {{0, 1},
                                   {1, 3},
                                   {3, 2},

--- a/FieldOpt/Model/tests/test_resource_variable_property_container.h
+++ b/FieldOpt/Model/tests/test_resource_variable_property_container.h
@@ -1,6 +1,21 @@
-//
-// Created by einar on 5/27/16.
-//
+/******************************************************************************
+   Copyright (C) 2015-2016 Einar J.M. Baumann <einar.baumann@gmail.com>
+
+   This file is part of the FieldOpt project.
+
+   FieldOpt is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   FieldOpt is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with FieldOpt.  If not, see <http://www.gnu.org/licenses/>.
+******************************************************************************/
 
 #ifndef FIELDOPT_TEST_RESOURCE_VARIABLE_PROPERTY_LIST_H
 #define FIELDOPT_TEST_RESOURCE_VARIABLE_PROPERTY_LIST_H
@@ -20,12 +35,12 @@ namespace TestResources {
             prod_toe_x_ = new ContinousProperty(12);
             prod_toe_y_ = new ContinousProperty(120.1);
             prod_toe_z_ = new ContinousProperty(300.0);
-            prod_heel_x_->setName("SplinePoint#PRODUCER#heel#x");
-            prod_heel_y_->setName("SplinePoint#PRODUCER#heel#y");
-            prod_heel_z_->setName("SplinePoint#PRODUCER#heel#z");
-            prod_toe_x_->setName("SplinePoint#PRODUCER#toe#x");
-            prod_toe_y_->setName("SplinePoint#PRODUCER#toe#y");
-            prod_toe_z_->setName("SplinePoint#PRODUCER#toe#z");
+            prod_heel_x_->setName("SplinePoint#TESTW#heel#x");
+            prod_heel_y_->setName("SplinePoint#TESTW#heel#y");
+            prod_heel_z_->setName("SplinePoint#TESTW#heel#z");
+            prod_toe_x_->setName("SplinePoint#TESTW#toe#x");
+            prod_toe_y_->setName("SplinePoint#TESTW#toe#y");
+            prod_toe_z_->setName("SplinePoint#TESTW#toe#z");
             varcont_prod_spline_ = new VariablePropertyContainer();
             varcont_prod_spline_->AddVariable(prod_heel_x_);
             varcont_prod_spline_->AddVariable(prod_heel_y_);

--- a/FieldOpt/Model/tests/wells/test_control.cpp
+++ b/FieldOpt/Model/tests/wells/test_control.cpp
@@ -39,7 +39,7 @@ TEST_F(ControlTest, ProducerControl) {
     EXPECT_EQ(0, entry_.time_step);
     EXPECT_TRUE(all_controls_.first()->open());
     EXPECT_EQ(::Settings::Model::ControlMode::BHPControl, all_controls_.first()->mode());
-    EXPECT_FLOAT_EQ(2000, all_controls_.first()->bhp());
+    EXPECT_FLOAT_EQ(100, all_controls_.first()->bhp());
 }
 
 TEST_F(ControlTest, InjectorControl) {

--- a/FieldOpt/Optimization/case.cpp
+++ b/FieldOpt/Optimization/case.cpp
@@ -1,3 +1,22 @@
+/******************************************************************************
+   Copyright (C) 2015-2016 Einar J.M. Baumann <einar.baumann@gmail.com>
+
+   This file is part of the FieldOpt project.
+
+   FieldOpt is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   FieldOpt is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with FieldOpt.  If not, see <http://www.gnu.org/licenses/>.
+******************************************************************************/
+
 #include "case.h"
 
 namespace Optimization {

--- a/FieldOpt/Optimization/constraints/constraint_handler.cpp
+++ b/FieldOpt/Optimization/constraints/constraint_handler.cpp
@@ -2,67 +2,67 @@
 #include <iostream>
 
 namespace Optimization {
-    namespace Constraints {
+namespace Constraints {
 
-        ConstraintHandler::ConstraintHandler(QList<Settings::Optimizer::Constraint> constraints,
-                                             Model::Properties::VariablePropertyContainer *variables,
-                                             Reservoir::Grid::Grid *grid)
-        {
-            for (Settings::Optimizer::Constraint constraint : constraints) {
-                switch (constraint.type) {
-                    case Settings::Optimizer::ConstraintType::BHP:
-                        constraints_.append(new BhpConstraint(constraint, variables));
-                        break;
-                    case Settings::Optimizer::ConstraintType::Rate:
-                        constraints_.append(new RateConstraint(constraint, variables));
-                        break;
-                    case Settings::Optimizer::ConstraintType::WellSplineLength:
-                        constraints_.append(new WellSplineLength(constraint, variables));
-                        break;
-                    case Settings::Optimizer::ConstraintType::WellSplineInterwellDistance:
-                        constraints_.append(new InterwellDistance(constraint, variables));
-                        break;
-                    case Settings::Optimizer::ConstraintType::CombinedWellSplineLengthInterwellDistance:
-                        constraints_.append(new CombinedSplineLengthInterwellDistance(constraint, variables));
-                        break;
-                    case Settings::Optimizer::ConstraintType::
-                        CombinedWellSplineLengthInterwellDistanceReservoirBoundary:
-                        constraints_.append(new CombinedSplineLengthInterwellDistanceReservoirBoundary
-                                                    (constraint, variables, grid));
-                        break;
-                    case Settings::Optimizer::ConstraintType::ReservoirBoundary:
-                        constraints_.append(new ReservoirBoundary(constraint, variables, grid));
-                        break;
+ConstraintHandler::ConstraintHandler(QList<Settings::Optimizer::Constraint> constraints,
+                                     Model::Properties::VariablePropertyContainer *variables,
+                                     Reservoir::Grid::Grid *grid)
+{
+    for (Settings::Optimizer::Constraint constraint : constraints) {
+        switch (constraint.type) {
+            case Settings::Optimizer::ConstraintType::BHP:
+                constraints_.append(new BhpConstraint(constraint, variables));
+                break;
+            case Settings::Optimizer::ConstraintType::Rate:
+                constraints_.append(new RateConstraint(constraint, variables));
+                break;
+            case Settings::Optimizer::ConstraintType::WellSplineLength:
+                constraints_.append(new WellSplineLength(constraint, variables));
+                break;
+            case Settings::Optimizer::ConstraintType::WellSplineInterwellDistance:
+                constraints_.append(new InterwellDistance(constraint, variables));
+                break;
+            case Settings::Optimizer::ConstraintType::CombinedWellSplineLengthInterwellDistance:
+                constraints_.append(new CombinedSplineLengthInterwellDistance(constraint, variables));
+                break;
+            case Settings::Optimizer::ConstraintType::
+                CombinedWellSplineLengthInterwellDistanceReservoirBoundary:
+                constraints_.append(new CombinedSplineLengthInterwellDistanceReservoirBoundary
+                                        (constraint, variables, grid));
+                break;
+            case Settings::Optimizer::ConstraintType::ReservoirBoundary:
+                constraints_.append(new ReservoirBoundary(constraint, variables, grid));
+                break;
 #ifdef WITH_EXPERIMENTAL_CONSTRAINTS
-                        // Cases for constraints in the experimental_constraints directory go here
+                // Cases for constraints in the experimental_constraints directory go here
 #endif
-                    default:
-                        break;
-                }
-            }
-#ifdef WITH_EXPERIMENTAL_CONSTRAINTS
-            std::cout << "Using experimental constraints" << std::endl;
-#else
-            std::cout << "Not using experimental constraints" << std::endl;
-#endif
+            default:
+                break;
         }
-
-        bool ConstraintHandler::CaseSatisfiesConstraints(Case *c)
-        {
-            for (Constraint *constraint : constraints_) {
-                if (!constraint->CaseSatisfiesConstraint(c)) {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        void ConstraintHandler::SnapCaseToConstraints(Case *c)
-        {
-            for (Constraint *constraint : constraints_) {
-                constraint->SnapCaseToConstraints(c);
-            }
-        }
-
     }
+#ifdef WITH_EXPERIMENTAL_CONSTRAINTS
+    std::cout << "Using experimental constraints" << std::endl;
+#else
+    std::cout << "Not using experimental constraints" << std::endl;
+#endif
+}
+
+bool ConstraintHandler::CaseSatisfiesConstraints(Case *c)
+{
+    for (Constraint *constraint : constraints_) {
+        if (!constraint->CaseSatisfiesConstraint(c)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void ConstraintHandler::SnapCaseToConstraints(Case *c)
+{
+    for (Constraint *constraint : constraints_) {
+        constraint->SnapCaseToConstraints(c);
+    }
+}
+
+}
 }

--- a/FieldOpt/Optimization/constraints/constraint_handler.h
+++ b/FieldOpt/Optimization/constraints/constraint_handler.h
@@ -1,3 +1,22 @@
+/******************************************************************************
+   Copyright (C) 2015-2016 Einar J.M. Baumann <einar.baumann@gmail.com>
+
+   This file is part of the FieldOpt project.
+
+   FieldOpt is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   FieldOpt is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with FieldOpt.  If not, see <http://www.gnu.org/licenses/>.
+******************************************************************************/
+
 #ifndef CONSTRAINTHANDLER_H
 #define CONSTRAINTHANDLER_H
 #include "constraint.h"
@@ -22,7 +41,8 @@ namespace Optimization {
     namespace Constraints {
 
         /*!
-         * \brief The ConstraintHandler class facilitiates the initialization and usage of multiple constraints.
+         * \brief The ConstraintHandler class facilitates the
+         * initialization and usage of multiple constraints.
          */
         class ConstraintHandler
         {

--- a/FieldOpt/Optimization/constraints/rate_constraint.h
+++ b/FieldOpt/Optimization/constraints/rate_constraint.h
@@ -1,3 +1,22 @@
+/******************************************************************************
+   Copyright (C) 2015-2016 Einar J.M. Baumann <einar.baumann@gmail.com>
+
+   This file is part of the FieldOpt project.
+
+   FieldOpt is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   FieldOpt is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with FieldOpt.  If not, see <http://www.gnu.org/licenses/>.
+******************************************************************************/
+
 #ifndef FIELDOPT_RATE_CONSTRAINT_H
 #define FIELDOPT_RATE_CONSTRAINT_H
 
@@ -7,7 +26,8 @@ namespace Optimization {
     namespace Constraints {
         class RateConstraint : public Constraint {
         public:
-            RateConstraint(Settings::Optimizer::Constraint settings, Model::Properties::VariablePropertyContainer *variables);
+            RateConstraint(Settings::Optimizer::Constraint settings,
+                           Model::Properties::VariablePropertyContainer *variables);
 
         // Constraint interface
         public:

--- a/FieldOpt/Optimization/constraints/reservoir_boundary.cpp
+++ b/FieldOpt/Optimization/constraints/reservoir_boundary.cpp
@@ -21,15 +21,205 @@ ReservoirBoundary::ReservoirBoundary(
     affected_well_ = initializeWell(variables->GetWellSplineVariables(settings.well));
 
     // QList with indices of box edge cells
-    index_list_edge_ = getListOfBoxEdgeCellIndices();
+    index_list_edge_ = getIndicesOfEdgeCells();
 
 }
 
-/* \brief Function getListOfBoxEdgeCellIndices uses the limits
- * defining the box constraint to find the cells that make up
- * the edges of the box
+
+void ReservoirBoundary::findCornerCells() {
+
+    //GENERAL
+
+    // box plane / cell face index ordering (viewed from above):
+
+    //   2___3    6___7
+    //   |   |    |   |
+    //   |___|    |___|
+    //   0   1    4   5
+
+    // Comment: this appears to be the correct index ordering for
+    // a grid cell. Check this ordering is consistent with the ordering
+    // used in:
+    // /ConstraintMath/well_constraint_projections/well_constraint_projections.cpp
+
+    // If now, how do the orderings correlate?
+
+    // TODO:
+    // move the output messages from here to the unit test of this function.
+
+    // ===============
+    // UPPER BOX PLANE
+    // ===============
+
+    // UPPER BOX PLANE: LEFT EDGE
+    std::cout << std::setfill('-') << std::setw(80) << "-" << std::endl;
+    //        2___3
+    //  -->   |   |
+    //  -->   |___|
+    //        0   1
+
+    // Get corner cells of box
+    QList<Eigen::Vector3d> upper_plane_left_bottom_cell_xyz = grid_->GetCell(imin_, jmin_, kmax_).corners();
+    QList<Eigen::Vector3d> upper_plane_left_top_cell_xyz = grid_->GetCell(imin_, jmax_, kmax_).corners();
+    // Get cell vertex amounting to true box corner
+    Eigen::Vector3d upper_plane_left_bottom_corner_xyz = upper_plane_left_bottom_cell_xyz[0];
+    Eigen::Vector3d upper_plane_left_top_corner_xyz = upper_plane_left_top_cell_xyz[2];
+    // Print coordinates
+    printCornerXYZ("upper plane, left edge, bottom corner: ", upper_plane_left_bottom_corner_xyz);
+    printCornerXYZ("upper plane, left edge, top corner:    ", upper_plane_left_top_corner_xyz);
+
+    // UPPER BOX PLANE: RIGHT EDGE
+    std::cout << std::setfill('-') << std::setw(80) << "-" << std::endl;
+    //        2___3
+    //        |   |  <--
+    //        |___|  <--
+    //        0   1
+
+    // Get corner cells of box
+    QList<Eigen::Vector3d> upper_plane_right_bottom_cell_xyz = grid_->GetCell(imax_, jmin_, kmax_).corners();
+    QList<Eigen::Vector3d> upper_plane_right_top_cell_xyz = grid_->GetCell(imax_, jmax_, kmax_).corners();
+    // Get cell vertex amounting to true box corner
+    Eigen::Vector3d upper_plane_right_bottom_corner_xyz = upper_plane_right_bottom_cell_xyz[1];
+    Eigen::Vector3d upper_plane_right_top_corner_xyz = upper_plane_right_top_cell_xyz[3];
+    // Print coordinates
+    printCornerXYZ("upper plane, right edge, bottom corner:", upper_plane_right_bottom_corner_xyz);
+    printCornerXYZ("upper plane, right edge, top corner:   ", upper_plane_right_top_corner_xyz);
+
+    // UPPER BOX PLANE: BOTTOM EDGE
+    std::cout << std::setfill('-') << std::setw(80) << "-" << std::endl;
+    //        2___3
+    //        |   |
+    //        |___|
+    //        0   1
+
+    //         ^ ^
+    //         | |
+
+    // Get corner cells of box
+    QList<Eigen::Vector3d> upper_plane_bottom_left_cell_xyz = grid_->GetCell(imin_, jmin_, kmax_).corners();
+    QList<Eigen::Vector3d> upper_plane_bottom_right_cell_xyz = grid_->GetCell(imax_, jmin_, kmax_).corners();
+    // Get cell vertex amounting to true box corner
+    Eigen::Vector3d upper_plane_bottom_left_corner_xyz = upper_plane_bottom_left_cell_xyz[0];
+    Eigen::Vector3d upper_plane_bottom_right_corner_xyz = upper_plane_bottom_right_cell_xyz[1];
+    // Print coordinates
+    printCornerXYZ("upper plane, bottom edge, left corner: ", upper_plane_bottom_left_corner_xyz);
+    printCornerXYZ("upper plane, bottom edge, right corner:", upper_plane_bottom_right_corner_xyz);
+
+    // UPPER BOX PLANE: TOP EDGE
+    std::cout << std::setfill('-') << std::setw(80) << "-" << std::endl;
+    //         | |
+    //         v v
+
+    //        2___3
+    //        |   |
+    //        |___|
+    //        0   1
+
+    // Get corner cells of box
+    QList<Eigen::Vector3d> upper_plane_top_left_cell_xyz = grid_->GetCell(imin_, jmax_, kmax_).corners();
+    QList<Eigen::Vector3d> upper_plane_top_right_cell_xyz = grid_->GetCell(imax_, jmax_, kmax_).corners();
+    // Get cell vertex amounting to true box corner
+    Eigen::Vector3d upper_plane_top_left_corner_xyz = upper_plane_top_left_cell_xyz[2];
+    Eigen::Vector3d upper_plane_top_right_corner_xyz = upper_plane_top_right_cell_xyz[3];
+    // Print coordinates
+    printCornerXYZ("upper plane, top edge, left corner:    ", upper_plane_top_left_corner_xyz);
+    printCornerXYZ("upper plane, top edge, right corner:   ", upper_plane_top_right_corner_xyz);
+
+    // ===============
+    // LOWER BOX PLANE
+    // ===============
+
+    // LOWER BOX PLANE: LEFT EDGE
+    std::cout << std::setfill('-') << std::setw(80) << "-" << std::endl;
+    //        6___7
+    //  -->   |   |
+    //  -->   |___|
+    //        4   5
+
+    // Get corner cells of box
+    QList<Eigen::Vector3d> lower_plane_left_bottom_cell_xyz = grid_->GetCell(imin_, jmin_, kmin_).corners();
+    QList<Eigen::Vector3d> lower_plane_left_top_cell_xyz = grid_->GetCell(imin_, jmax_, kmin_).corners();
+    // Get cell vertex amounting to true box corner
+    Eigen::Vector3d lower_plane_left_bottom_corner_xyz = lower_plane_left_bottom_cell_xyz[4];
+    Eigen::Vector3d lower_plane_left_top_corner_xyz = lower_plane_left_top_cell_xyz[6];
+    // Print coordinates
+    printCornerXYZ("lower plane, left edge, bottom corner: ", lower_plane_left_bottom_corner_xyz);
+    printCornerXYZ("lower plane, left edge, top corner:    ", lower_plane_left_top_corner_xyz);
+
+    // LOWER BOX PLANE: RIGHT EDGE
+    std::cout << std::setfill('-') << std::setw(80) << "-" << std::endl;
+    //        6___7
+    //        |   |  <--
+    //        |___|  <--
+    //        4   5
+
+    // Get corner cells of box
+    QList<Eigen::Vector3d> lower_plane_right_bottom_cell_xyz = grid_->GetCell(imax_, jmin_, kmin_).corners();
+    QList<Eigen::Vector3d> lower_plane_right_top_cell_xyz = grid_->GetCell(imax_, jmax_, kmin_).corners();
+    // Get cell vertex amounting to true box corner
+    Eigen::Vector3d lower_plane_right_bottom_corner_xyz = lower_plane_right_bottom_cell_xyz[5];
+    Eigen::Vector3d lower_plane_right_top_corner_xyz = lower_plane_right_top_cell_xyz[7];
+    // Print coordinates
+    printCornerXYZ("lower plane, right edge, bottom corner:", lower_plane_right_bottom_corner_xyz);
+    printCornerXYZ("lower plane, right edge, top corner:   ", lower_plane_right_top_corner_xyz);
+
+    // LOWER BOX PLANE: BOTTOM EDGE
+    std::cout << std::setfill('-') << std::setw(80) << "-" << std::endl;
+    //        6___7
+    //        |   |
+    //        |___|
+    //        4   5
+
+    //         ^ ^
+    //         | |
+
+    // Get corner cells of box
+    QList<Eigen::Vector3d> lower_plane_bottom_left_cell_xyz = grid_->GetCell(imin_, jmin_, kmin_).corners();
+    QList<Eigen::Vector3d> lower_plane_bottom_right_cell_xyz = grid_->GetCell(imax_, jmin_, kmin_).corners();
+    // Get cell vertex amounting to true box corner
+    Eigen::Vector3d lower_plane_bottom_left_corner_xyz = lower_plane_bottom_left_cell_xyz[4];
+    Eigen::Vector3d lower_plane_bottom_right_corner_xyz = lower_plane_bottom_right_cell_xyz[5];
+    // Print coordinates
+    printCornerXYZ("lower plane, bottom edge, left corner: ", lower_plane_bottom_left_corner_xyz);
+    printCornerXYZ("lower plane, bottom edge, right corner:", lower_plane_bottom_right_corner_xyz);
+
+    // LOWER BOX PLANE: TOP EDGE
+    std::cout << std::setfill('-') << std::setw(80) << "-" << std::endl;
+    //         | |
+    //         v v
+
+    //        6___7
+    //        |   |
+    //        |___|
+    //        4   5
+
+    // Get corner cells of box
+    QList<Eigen::Vector3d> lower_plane_top_left_cell_xyz = grid_->GetCell(imin_, jmax_, kmin_).corners();
+    QList<Eigen::Vector3d> lower_plane_top_right_cell_xyz = grid_->GetCell(imax_, jmax_, kmin_).corners();
+    // Get cell vertex amounting to true box corner
+    Eigen::Vector3d lower_plane_top_left_corner_xyz = lower_plane_top_left_cell_xyz[6];
+    Eigen::Vector3d lower_plane_top_right_corner_xyz = lower_plane_top_right_cell_xyz[7];
+    // Print coordinates
+    printCornerXYZ("lower plane, top edge, left corner:    ", lower_plane_top_left_corner_xyz);
+    printCornerXYZ("lower plane, top edge, right corner:   ", lower_plane_top_right_corner_xyz);
+
+    std::cout << std::setfill('-') << std::setw(80) << "-" << std::endl;
+}
+
+void ReservoirBoundary::printCornerXYZ(std::string str_out, Eigen::Vector3d vector_xyz) {
+    std::cout << std::setfill(' ') << str_out ;
+    for( int i=0, size=vector_xyz.size(); i < size; i++ )
+    {
+        std::cout << std::setw(8) << vector_xyz[i] << "\t";
+    }
+    std::cout << std::endl;
+}
+
+/* \brief Function getIndicesOfEdgeCells uses the limits
+ * defining the box constraint to find the cells that make
+ * up the edges of the box
  */
-QList<int> ReservoirBoundary::getListOfBoxEdgeCellIndices() {
+QList<int> ReservoirBoundary::getIndicesOfEdgeCells() {
     QList<int> box_edge_cells_;
 
     QList<int> upper_face_left_edge_;
@@ -37,9 +227,13 @@ QList<int> ReservoirBoundary::getListOfBoxEdgeCellIndices() {
     QList<int> upper_face_right_edge_;
     QList<int> upper_face_top_edge_;
 
+    QList<Eigen::Vector3d> upper_face_left_edge_xyz;
+    QList<Eigen::Vector3d> upper_face_left_edge_xyz_max_min;
+
     // UPPER CELL FACE: LEFT EDGE
     for (int j = jmin_; j <= jmax_; j++) {
         upper_face_left_edge_.append(grid_->GetCell(imin_, j, kmax_).global_index());
+        upper_face_left_edge_xyz.append(grid_->GetCell(imin_, j, kmax_).corners());
     }
 
     // UPPER CELL FACE: BOTTOM EDGE

--- a/FieldOpt/Optimization/constraints/reservoir_boundary.cpp
+++ b/FieldOpt/Optimization/constraints/reservoir_boundary.cpp
@@ -59,8 +59,8 @@ void ReservoirBoundary::findCornerCells() {
     //        0   1
 
     // Get corner cells of box
-    QList<Eigen::Vector3d> upper_plane_left_bottom_cell_xyz = grid_->GetCell(imin_, jmin_, kmax_).corners();
-    QList<Eigen::Vector3d> upper_plane_left_top_cell_xyz = grid_->GetCell(imin_, jmax_, kmax_).corners();
+    std::vector<Eigen::Vector3d> upper_plane_left_bottom_cell_xyz = grid_->GetCell(imin_, jmin_, kmax_).corners();
+    std::vector<Eigen::Vector3d> upper_plane_left_top_cell_xyz = grid_->GetCell(imin_, jmax_, kmax_).corners();
     // Get cell vertex amounting to true box corner
     Eigen::Vector3d upper_plane_left_bottom_corner_xyz = upper_plane_left_bottom_cell_xyz[0];
     Eigen::Vector3d upper_plane_left_top_corner_xyz = upper_plane_left_top_cell_xyz[2];
@@ -76,8 +76,8 @@ void ReservoirBoundary::findCornerCells() {
     //        0   1
 
     // Get corner cells of box
-    QList<Eigen::Vector3d> upper_plane_right_bottom_cell_xyz = grid_->GetCell(imax_, jmin_, kmax_).corners();
-    QList<Eigen::Vector3d> upper_plane_right_top_cell_xyz = grid_->GetCell(imax_, jmax_, kmax_).corners();
+    std::vector<Eigen::Vector3d> upper_plane_right_bottom_cell_xyz = grid_->GetCell(imax_, jmin_, kmax_).corners();
+    std::vector<Eigen::Vector3d> upper_plane_right_top_cell_xyz = grid_->GetCell(imax_, jmax_, kmax_).corners();
     // Get cell vertex amounting to true box corner
     Eigen::Vector3d upper_plane_right_bottom_corner_xyz = upper_plane_right_bottom_cell_xyz[1];
     Eigen::Vector3d upper_plane_right_top_corner_xyz = upper_plane_right_top_cell_xyz[3];
@@ -96,8 +96,8 @@ void ReservoirBoundary::findCornerCells() {
     //         | |
 
     // Get corner cells of box
-    QList<Eigen::Vector3d> upper_plane_bottom_left_cell_xyz = grid_->GetCell(imin_, jmin_, kmax_).corners();
-    QList<Eigen::Vector3d> upper_plane_bottom_right_cell_xyz = grid_->GetCell(imax_, jmin_, kmax_).corners();
+    std::vector<Eigen::Vector3d> upper_plane_bottom_left_cell_xyz = grid_->GetCell(imin_, jmin_, kmax_).corners();
+    std::vector<Eigen::Vector3d> upper_plane_bottom_right_cell_xyz = grid_->GetCell(imax_, jmin_, kmax_).corners();
     // Get cell vertex amounting to true box corner
     Eigen::Vector3d upper_plane_bottom_left_corner_xyz = upper_plane_bottom_left_cell_xyz[0];
     Eigen::Vector3d upper_plane_bottom_right_corner_xyz = upper_plane_bottom_right_cell_xyz[1];
@@ -116,8 +116,8 @@ void ReservoirBoundary::findCornerCells() {
     //        0   1
 
     // Get corner cells of box
-    QList<Eigen::Vector3d> upper_plane_top_left_cell_xyz = grid_->GetCell(imin_, jmax_, kmax_).corners();
-    QList<Eigen::Vector3d> upper_plane_top_right_cell_xyz = grid_->GetCell(imax_, jmax_, kmax_).corners();
+    std::vector<Eigen::Vector3d> upper_plane_top_left_cell_xyz = grid_->GetCell(imin_, jmax_, kmax_).corners();
+    std::vector<Eigen::Vector3d> upper_plane_top_right_cell_xyz = grid_->GetCell(imax_, jmax_, kmax_).corners();
     // Get cell vertex amounting to true box corner
     Eigen::Vector3d upper_plane_top_left_corner_xyz = upper_plane_top_left_cell_xyz[2];
     Eigen::Vector3d upper_plane_top_right_corner_xyz = upper_plane_top_right_cell_xyz[3];
@@ -137,8 +137,8 @@ void ReservoirBoundary::findCornerCells() {
     //        4   5
 
     // Get corner cells of box
-    QList<Eigen::Vector3d> lower_plane_left_bottom_cell_xyz = grid_->GetCell(imin_, jmin_, kmin_).corners();
-    QList<Eigen::Vector3d> lower_plane_left_top_cell_xyz = grid_->GetCell(imin_, jmax_, kmin_).corners();
+    std::vector<Eigen::Vector3d> lower_plane_left_bottom_cell_xyz = grid_->GetCell(imin_, jmin_, kmin_).corners();
+    std::vector<Eigen::Vector3d> lower_plane_left_top_cell_xyz = grid_->GetCell(imin_, jmax_, kmin_).corners();
     // Get cell vertex amounting to true box corner
     Eigen::Vector3d lower_plane_left_bottom_corner_xyz = lower_plane_left_bottom_cell_xyz[4];
     Eigen::Vector3d lower_plane_left_top_corner_xyz = lower_plane_left_top_cell_xyz[6];
@@ -154,8 +154,8 @@ void ReservoirBoundary::findCornerCells() {
     //        4   5
 
     // Get corner cells of box
-    QList<Eigen::Vector3d> lower_plane_right_bottom_cell_xyz = grid_->GetCell(imax_, jmin_, kmin_).corners();
-    QList<Eigen::Vector3d> lower_plane_right_top_cell_xyz = grid_->GetCell(imax_, jmax_, kmin_).corners();
+    std::vector<Eigen::Vector3d> lower_plane_right_bottom_cell_xyz = grid_->GetCell(imax_, jmin_, kmin_).corners();
+    std::vector<Eigen::Vector3d> lower_plane_right_top_cell_xyz = grid_->GetCell(imax_, jmax_, kmin_).corners();
     // Get cell vertex amounting to true box corner
     Eigen::Vector3d lower_plane_right_bottom_corner_xyz = lower_plane_right_bottom_cell_xyz[5];
     Eigen::Vector3d lower_plane_right_top_corner_xyz = lower_plane_right_top_cell_xyz[7];
@@ -174,8 +174,8 @@ void ReservoirBoundary::findCornerCells() {
     //         | |
 
     // Get corner cells of box
-    QList<Eigen::Vector3d> lower_plane_bottom_left_cell_xyz = grid_->GetCell(imin_, jmin_, kmin_).corners();
-    QList<Eigen::Vector3d> lower_plane_bottom_right_cell_xyz = grid_->GetCell(imax_, jmin_, kmin_).corners();
+    std::vector<Eigen::Vector3d> lower_plane_bottom_left_cell_xyz = grid_->GetCell(imin_, jmin_, kmin_).corners();
+    std::vector<Eigen::Vector3d> lower_plane_bottom_right_cell_xyz = grid_->GetCell(imax_, jmin_, kmin_).corners();
     // Get cell vertex amounting to true box corner
     Eigen::Vector3d lower_plane_bottom_left_corner_xyz = lower_plane_bottom_left_cell_xyz[4];
     Eigen::Vector3d lower_plane_bottom_right_corner_xyz = lower_plane_bottom_right_cell_xyz[5];
@@ -194,8 +194,8 @@ void ReservoirBoundary::findCornerCells() {
     //        4   5
 
     // Get corner cells of box
-    QList<Eigen::Vector3d> lower_plane_top_left_cell_xyz = grid_->GetCell(imin_, jmax_, kmin_).corners();
-    QList<Eigen::Vector3d> lower_plane_top_right_cell_xyz = grid_->GetCell(imax_, jmax_, kmin_).corners();
+    std::vector<Eigen::Vector3d> lower_plane_top_left_cell_xyz = grid_->GetCell(imin_, jmax_, kmin_).corners();
+    std::vector<Eigen::Vector3d> lower_plane_top_right_cell_xyz = grid_->GetCell(imax_, jmax_, kmin_).corners();
     // Get cell vertex amounting to true box corner
     Eigen::Vector3d lower_plane_top_left_corner_xyz = lower_plane_top_left_cell_xyz[6];
     Eigen::Vector3d lower_plane_top_right_corner_xyz = lower_plane_top_right_cell_xyz[7];
@@ -230,10 +230,16 @@ QList<int> ReservoirBoundary::getIndicesOfEdgeCells() {
     QList<Eigen::Vector3d> upper_face_left_edge_xyz;
     QList<Eigen::Vector3d> upper_face_left_edge_xyz_max_min;
 
+    // Testing
+    std::vector<Eigen::Matrix<double,3,1,0,3,1>> upper_face_left_edge_xyz;
+    std::vector<Eigen::Matrix<double,3,1,0,3,1>> upper_face_left_edge_xyz_max_min;
+
     // UPPER CELL FACE: LEFT EDGE
     for (int j = jmin_; j <= jmax_; j++) {
         upper_face_left_edge_.append(grid_->GetCell(imin_, j, kmax_).global_index());
         upper_face_left_edge_xyz.append(grid_->GetCell(imin_, j, kmax_).corners());
+        // Testing
+        // upper_face_left_edge_xyz.push_back(grid_->GetCell(imin_, j, kmax_).corners());
     }
 
     // UPPER CELL FACE: BOTTOM EDGE

--- a/FieldOpt/Optimization/constraints/reservoir_boundary.cpp
+++ b/FieldOpt/Optimization/constraints/reservoir_boundary.cpp
@@ -1,5 +1,6 @@
 #include "reservoir_boundary.h"
 #include "ConstraintMath/well_constraint_projections/well_constraint_projections.h"
+#include <iomanip>
 
 namespace Optimization {
 namespace Constraints {
@@ -231,13 +232,13 @@ QList<int> ReservoirBoundary::getIndicesOfEdgeCells() {
     QList<Eigen::Vector3d> upper_face_left_edge_xyz_max_min;
 
     // Testing
-    std::vector<Eigen::Matrix<double,3,1,0,3,1>> upper_face_left_edge_xyz;
-    std::vector<Eigen::Matrix<double,3,1,0,3,1>> upper_face_left_edge_xyz_max_min;
+//    std::vector<Eigen::Matrix<double,3,1,0,3,1>> upper_face_left_edge_xyz;
+//    std::vector<Eigen::Matrix<double,3,1,0,3,1>> upper_face_left_edge_xyz_max_min;
 
     // UPPER CELL FACE: LEFT EDGE
     for (int j = jmin_; j <= jmax_; j++) {
         upper_face_left_edge_.append(grid_->GetCell(imin_, j, kmax_).global_index());
-        upper_face_left_edge_xyz.append(grid_->GetCell(imin_, j, kmax_).corners());
+//        upper_face_left_edge_xyz.append(grid_->GetCell(imin_, j, kmax_).corners());
         // Testing
         // upper_face_left_edge_xyz.push_back(grid_->GetCell(imin_, j, kmax_).corners());
     }

--- a/FieldOpt/Optimization/constraints/reservoir_boundary.cpp
+++ b/FieldOpt/Optimization/constraints/reservoir_boundary.cpp
@@ -2,95 +2,95 @@
 #include "ConstraintMath/well_constraint_projections/well_constraint_projections.h"
 
 namespace Optimization {
-    namespace Constraints {
+namespace Constraints {
 
-        ReservoirBoundary::ReservoirBoundary(
-                const Settings::Optimizer::Constraint &settings,
-                Model::Properties::VariablePropertyContainer *variables,
-                Reservoir::Grid::Grid *grid)
-        {
-            imin_ = settings.box_imin;
-            imax_ = settings.box_imax;
-            jmin_ = settings.box_jmin;
-            jmax_ = settings.box_jmax;
-            kmin_ = settings.box_kmin;
-            kmax_ = settings.box_kmax;
-            grid_ = grid;
-            index_list_ = getListOfCellIndices();
-            affected_well_ = initializeWell(variables->GetWellSplineVariables(settings.well));
+ReservoirBoundary::ReservoirBoundary(
+    const Settings::Optimizer::Constraint &settings,
+    Model::Properties::VariablePropertyContainer *variables,
+    Reservoir::Grid::Grid *grid)
+{
+    imin_ = settings.box_imin;
+    imax_ = settings.box_imax;
+    jmin_ = settings.box_jmin;
+    jmax_ = settings.box_jmax;
+    kmin_ = settings.box_kmin;
+    kmax_ = settings.box_kmax;
+    grid_ = grid;
+    index_list_ = getListOfCellIndices();
+    affected_well_ = initializeWell(variables->GetWellSplineVariables(settings.well));
+}
+
+bool ReservoirBoundary::CaseSatisfiesConstraint(Case *c) {
+
+    double heel_x_val = c->real_variables()[affected_well_.heel.x];
+    double heel_y_val = c->real_variables()[affected_well_.heel.y];
+    double heel_z_val = c->real_variables()[affected_well_.heel.z];
+
+    double toe_x_val = c->real_variables()[affected_well_.toe.x];
+    double toe_y_val = c->real_variables()[affected_well_.toe.y];
+    double toe_z_val = c->real_variables()[affected_well_.toe.z];
+
+    bool heel_feasible = false;
+    bool toe_feasible = false;
+
+    for (int ii=0; ii<index_list_.length(); ii++){
+        if (grid_->GetCell(index_list_[ii]).EnvelopsPoint(
+            Eigen::Vector3d(heel_x_val, heel_y_val, heel_z_val))) {
+            heel_feasible = true;
         }
-
-        bool ReservoirBoundary::CaseSatisfiesConstraint(Case *c) {
-
-            double heel_x_val = c->real_variables()[affected_well_.heel.x];
-            double heel_y_val = c->real_variables()[affected_well_.heel.y];
-            double heel_z_val = c->real_variables()[affected_well_.heel.z];
-
-            double toe_x_val = c->real_variables()[affected_well_.toe.x];
-            double toe_y_val = c->real_variables()[affected_well_.toe.y];
-            double toe_z_val = c->real_variables()[affected_well_.toe.z];
-
-            bool heel_feasible = false;
-            bool toe_feasible = false;
-
-            for (int ii=0; ii<index_list_.length(); ii++){
-                if (grid_->GetCell(index_list_[ii]).EnvelopsPoint(
-                        Eigen::Vector3d(heel_x_val, heel_y_val, heel_z_val))) {
-                    heel_feasible = true;
-                }
-                if (grid_->GetCell(index_list_[ii]).EnvelopsPoint(
-                        Eigen::Vector3d(toe_x_val, toe_y_val, toe_z_val))) {
-                    toe_feasible = true;
-                }
-            }
-
-            return heel_feasible && toe_feasible;
+        if (grid_->GetCell(index_list_[ii]).EnvelopsPoint(
+            Eigen::Vector3d(toe_x_val, toe_y_val, toe_z_val))) {
+            toe_feasible = true;
         }
-
-        void ReservoirBoundary::SnapCaseToConstraints(Case *c) {
-
-            double heel_x_val = c->real_variables()[affected_well_.heel.x];
-            double heel_y_val = c->real_variables()[affected_well_.heel.y];
-            double heel_z_val = c->real_variables()[affected_well_.heel.z];
-
-            double toe_x_val = c->real_variables()[affected_well_.toe.x];
-            double toe_y_val = c->real_variables()[affected_well_.toe.y];
-            double toe_z_val = c->real_variables()[affected_well_.toe.z];
-
-            Eigen::Vector3d projected_heel =
-                    WellConstraintProjections::well_domain_constraint_indices(
-                    Eigen::Vector3d(heel_x_val, heel_y_val, heel_z_val),
-                    grid_,
-                    index_list_
-            );
-            Eigen::Vector3d projected_toe =
-                    WellConstraintProjections::well_domain_constraint_indices(
-                    Eigen::Vector3d(toe_x_val, toe_y_val, toe_z_val),
-                    grid_,
-                    index_list_
-            );
-
-            c->set_real_variable_value(affected_well_.heel.x, projected_heel(0));
-            c->set_real_variable_value(affected_well_.heel.y, projected_heel(1));
-            c->set_real_variable_value(affected_well_.heel.z, projected_heel(2));
-
-            c->set_real_variable_value(affected_well_.toe.x, projected_toe(0));
-            c->set_real_variable_value(affected_well_.toe.y, projected_toe(1));
-            c->set_real_variable_value(affected_well_.toe.z, projected_toe(2));
-        }
-
-        QList<int> ReservoirBoundary::getListOfCellIndices() {
-            QList<int> index_list;
-
-            for (int i = imin_; i <= imax_; i++){
-                for (int j = jmin_; j <= jmax_; j++){
-                    for (int k = kmin_; k <= kmax_; k++){
-                        index_list.append(grid_->GetCell(i, j, k).global_index());
-                    }
-                }
-            }
-            return index_list;
-        }
-
     }
+
+    return heel_feasible && toe_feasible;
+}
+
+void ReservoirBoundary::SnapCaseToConstraints(Case *c) {
+
+    double heel_x_val = c->real_variables()[affected_well_.heel.x];
+    double heel_y_val = c->real_variables()[affected_well_.heel.y];
+    double heel_z_val = c->real_variables()[affected_well_.heel.z];
+
+    double toe_x_val = c->real_variables()[affected_well_.toe.x];
+    double toe_y_val = c->real_variables()[affected_well_.toe.y];
+    double toe_z_val = c->real_variables()[affected_well_.toe.z];
+
+    Eigen::Vector3d projected_heel =
+        WellConstraintProjections::well_domain_constraint_indices(
+            Eigen::Vector3d(heel_x_val, heel_y_val, heel_z_val),
+            grid_,
+            index_list_
+        );
+    Eigen::Vector3d projected_toe =
+        WellConstraintProjections::well_domain_constraint_indices(
+            Eigen::Vector3d(toe_x_val, toe_y_val, toe_z_val),
+            grid_,
+            index_list_
+        );
+
+    c->set_real_variable_value(affected_well_.heel.x, projected_heel(0));
+    c->set_real_variable_value(affected_well_.heel.y, projected_heel(1));
+    c->set_real_variable_value(affected_well_.heel.z, projected_heel(2));
+
+    c->set_real_variable_value(affected_well_.toe.x, projected_toe(0));
+    c->set_real_variable_value(affected_well_.toe.y, projected_toe(1));
+    c->set_real_variable_value(affected_well_.toe.z, projected_toe(2));
+}
+
+QList<int> ReservoirBoundary::getListOfCellIndices() {
+    QList<int> index_list;
+
+    for (int i = imin_; i <= imax_; i++){
+        for (int j = jmin_; j <= jmax_; j++){
+            for (int k = kmin_; k <= kmax_; k++){
+                index_list.append(grid_->GetCell(i, j, k).global_index());
+            }
+        }
+    }
+    return index_list;
+}
+
+}
 }

--- a/FieldOpt/Optimization/constraints/reservoir_boundary.cpp
+++ b/FieldOpt/Optimization/constraints/reservoir_boundary.cpp
@@ -16,9 +16,13 @@ ReservoirBoundary::ReservoirBoundary(
     kmin_ = settings.box_kmin;
     kmax_ = settings.box_kmax;
     grid_ = grid;
+
     index_list_ = getListOfCellIndices();
-    index_list_edge_ = getListOfBoxEdgeCellIndices();
     affected_well_ = initializeWell(variables->GetWellSplineVariables(settings.well));
+
+    // QList with indices of box edge cells
+    index_list_edge_ = getListOfBoxEdgeCellIndices();
+
 }
 
 /* \brief Function getListOfBoxEdgeCellIndices uses the limits

--- a/FieldOpt/Optimization/constraints/reservoir_boundary.cpp
+++ b/FieldOpt/Optimization/constraints/reservoir_boundary.cpp
@@ -17,7 +17,80 @@ ReservoirBoundary::ReservoirBoundary(
     kmax_ = settings.box_kmax;
     grid_ = grid;
     index_list_ = getListOfCellIndices();
+    index_list_edge_ = getListOfBoxEdgeCellIndices();
     affected_well_ = initializeWell(variables->GetWellSplineVariables(settings.well));
+}
+
+/* \brief Function getListOfBoxEdgeCellIndices uses the limits
+ * defining the box constraint to find the cells that make up
+ * the edges of the box
+ */
+QList<int> ReservoirBoundary::getListOfBoxEdgeCellIndices() {
+    QList<int> box_edge_cells_;
+
+    QList<int> upper_face_left_edge_;
+    QList<int> upper_face_bottom_edge_;
+    QList<int> upper_face_right_edge_;
+    QList<int> upper_face_top_edge_;
+
+    // UPPER CELL FACE: LEFT EDGE
+    for (int j = jmin_; j <= jmax_; j++) {
+        upper_face_left_edge_.append(grid_->GetCell(imin_, j, kmax_).global_index());
+    }
+
+    // UPPER CELL FACE: BOTTOM EDGE
+    for (int i = imin_; i <= imax_; i++) {
+        upper_face_bottom_edge_.append(grid_->GetCell(i, jmin_, kmax_).global_index());
+    }
+
+    // UPPER CELL FACE: RIGHT EDGE
+    for (int j = jmin_; j <= jmax_; j++) {
+        upper_face_right_edge_.append(grid_->GetCell(imax_, j, kmax_).global_index());
+    }
+
+    // UPPER CELL FACE: TOP EDGE
+    for (int i = imin_; i <= imax_; i++) {
+        upper_face_top_edge_.append(grid_->GetCell(i, jmax_, kmax_).global_index());
+    }
+
+    // APPEND UPPER EDGE CELLS TO box_edge_cells_ LIST
+    box_edge_cells_.append(upper_face_left_edge_);
+    box_edge_cells_.append(upper_face_bottom_edge_);
+    box_edge_cells_.append(upper_face_right_edge_);
+    box_edge_cells_.append(upper_face_top_edge_);
+
+    QList<int> lower_face_left_edge_;
+    QList<int> lower_face_bottom_edge_;
+    QList<int> lower_face_right_edge_;
+    QList<int> lower_face_top_edge_;
+
+    // LOWER CELL FACE: LEFT EDGE
+    for (int j = jmin_; j <= jmax_; j++) {
+        lower_face_left_edge_.append(grid_->GetCell(imin_, j, kmin_).global_index());
+    }
+
+    // LOWER CELL FACE: BOTTOM EDGE
+    for (int i = imin_; i <= imax_; i++) {
+        lower_face_bottom_edge_.append(grid_->GetCell(i, jmin_, kmin_).global_index());
+    }
+
+    // LOWER CELL FACE: RIGHT EDGE
+    for (int j = jmin_; j <= jmax_; j++) {
+        lower_face_right_edge_.append(grid_->GetCell(imax_, j, kmin_).global_index());
+    }
+
+    // LOWER CELL FACE: TOP EDGE
+    for (int i = imin_; i <= imax_; i++) {
+        lower_face_top_edge_.append(grid_->GetCell(i, jmax_, kmin_).global_index());
+    }
+
+    // APPEND LOWER EDGE CELLS TO box_edge_cells_ LIST
+    box_edge_cells_.append(lower_face_left_edge_);
+    box_edge_cells_.append(lower_face_bottom_edge_);
+    box_edge_cells_.append(lower_face_right_edge_);
+    box_edge_cells_.append(lower_face_top_edge_);
+
+    return box_edge_cells_;
 }
 
 bool ReservoirBoundary::CaseSatisfiesConstraint(Case *c) {

--- a/FieldOpt/Optimization/constraints/reservoir_boundary.h
+++ b/FieldOpt/Optimization/constraints/reservoir_boundary.h
@@ -17,6 +17,20 @@ namespace Constraints {
  *  coordinates. It can check wether or not a single
  *  well is inside the given box domain and, if needed,
  *  project the well onto the domain.
+ *
+ *  \todo Figure out a more effective way to enforce
+ *  the box constraints
+ *
+ *  Suggested teps:
+ *  -find the edge cells of the box,
+ *  -get the corner points for each of the cells,
+ *  -find the corner points of the entire box (assuming then
+ *  the box is a parallelogram, which may not be true for the
+ *  top and bottom planes)
+ *  -print the box data to log for external visualization
+ *  -figure out if the current point is inside or outside
+ *  the box, e.g., create a BoxEnvelopsPoint function
+ *  -if outside, project point onto nearest point on plane
  */
 class ReservoirBoundary : public Constraint, WellSplineConstraint
 {

--- a/FieldOpt/Optimization/constraints/reservoir_boundary.h
+++ b/FieldOpt/Optimization/constraints/reservoir_boundary.h
@@ -1,3 +1,22 @@
+/******************************************************************************
+   Copyright (C) 2015-2016 Einar J.M. Baumann <einar.baumann@gmail.com>
+
+   This file is part of the FieldOpt project.
+
+   FieldOpt is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   FieldOpt is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with FieldOpt.  If not, see <http://www.gnu.org/licenses/>.
+******************************************************************************/
+
 #ifndef FIELDOPT_RESERVOIRBOUNDARY_H
 #define FIELDOPT_RESERVOIRBOUNDARY_H
 
@@ -44,6 +63,9 @@ class ReservoirBoundary : public Constraint, WellSplineConstraint
   bool CaseSatisfiesConstraint(Case *c);
   void SnapCaseToConstraints(Case *c);
 
+  // Def. function that outputs box_edge_cells_ for testing
+  QList<int> returnListOfBoxEdgeCellIndices() const { return index_list_edge_; }
+
  private:
   int imin_, imax_, jmin_, jmax_, kmin_, kmax_;
   QList<int> index_list_;
@@ -53,7 +75,6 @@ class ReservoirBoundary : public Constraint, WellSplineConstraint
 
   QList<int> getListOfBoxEdgeCellIndices();
   QList<int> index_list_edge_;
-  QList<int> box_edge_cells_;
 
 };
 }

--- a/FieldOpt/Optimization/constraints/reservoir_boundary.h
+++ b/FieldOpt/Optimization/constraints/reservoir_boundary.h
@@ -6,36 +6,43 @@
 #include "Reservoir/grid/grid.h"
 
 namespace Optimization {
-    namespace Constraints {
+namespace Constraints {
 
-        /*!
-         * \brief The ReservoirBoundary class deals with imposing and checking reservoir boundary constraints
-         *
-         *  The class takes a boundary as input in the form of i,j and k min,max, i.e. a 'box' in
-         *  the grid i,j,k coordinates. It can check wether or not a single well is inside the
-         *  given box domain and, if needed, project the well onto the domain.
-         */
-        class ReservoirBoundary : public Constraint, WellSplineConstraint
-        {
-        public:
-            ReservoirBoundary(const Settings::Optimizer::Constraint &settings,
-                              Model::Properties::VariablePropertyContainer *variables, Reservoir::Grid::Grid *grid);
+/*!
+ * \brief The ReservoirBoundary class deals with
+ * imposing and checking reservoir boundary constraints
+ *
+ *  The class takes a boundary as input in the form of
+ *  i,j and k min,max, i.e. a 'box' in the grid i,j,k
+ *  coordinates. It can check wether or not a single
+ *  well is inside the given box domain and, if needed,
+ *  project the well onto the domain.
+ */
+class ReservoirBoundary : public Constraint, WellSplineConstraint
+{
+ public:
+  ReservoirBoundary(const Settings::Optimizer::Constraint &settings,
+                    Model::Properties::VariablePropertyContainer *variables,
+                    Reservoir::Grid::Grid *grid);
 
-            // Constraint interface
-        public:
-            bool CaseSatisfiesConstraint(Case *c);
-            void SnapCaseToConstraints(Case *c);
+  // Constraint interface
+ public:
+  bool CaseSatisfiesConstraint(Case *c);
+  void SnapCaseToConstraints(Case *c);
 
-        private:
-            int imin_, imax_, jmin_, jmax_, kmin_, kmax_;
-            QList<int> index_list_;
-            Reservoir::Grid::Grid *grid_;
-            Well affected_well_;
-            QList<int> getListOfCellIndices();
+ private:
+  int imin_, imax_, jmin_, jmax_, kmin_, kmax_;
+  QList<int> index_list_;
+  Reservoir::Grid::Grid *grid_;
+  Well affected_well_;
+  QList<int> getListOfCellIndices();
 
-        };
-    }
+  QList<int> getListOfBoxEdgeCellIndices();
+  QList<int> index_list_edge_;
+  QList<int> box_edge_cells_;
+
+};
 }
-
+}
 
 #endif //FIELDOPT_RESERVOIRBOUNDARY_H

--- a/FieldOpt/Optimization/constraints/reservoir_boundary.h
+++ b/FieldOpt/Optimization/constraints/reservoir_boundary.h
@@ -90,7 +90,7 @@ class ReservoirBoundary : public Constraint, WellSplineConstraint
   Well affected_well_;
   QList<int> getListOfCellIndices();
 
-  QList<int> getListOfBoxEdgeCellIndices();
+  QList<int> getIndicesOfEdgeCells();
   QList<int> index_list_edge_;
 
   void printCornerXYZ(std::string str_out, Eigen::Vector3d vector_xyz);

--- a/FieldOpt/Optimization/constraints/reservoir_boundary.h
+++ b/FieldOpt/Optimization/constraints/reservoir_boundary.h
@@ -38,18 +38,29 @@ namespace Constraints {
  *  project the well onto the domain.
  *
  *  \todo Figure out a more effective way to enforce
- *  the box constraints
+ *  the box constraints (TASK A), then figure out way
+ *  boundary constraints for non-box (parallelogram)
+ *  shapes (TASK B); finally, define this constraint
+ *  (out of ReservoirBoundary) as a standalone
+ *  constraint (call it Box) (TASK C)
  *
- *  Suggested teps:
- *  -find the edge cells of the box,
- *  -get the corner points for each of the cells,
- *  -find the corner points of the entire box (assuming then
- *  the box is a parallelogram, which may not be true for the
- *  top and bottom planes)
- *  -print the box data to log for external visualization
- *  -figure out if the current point is inside or outside
+ *  Steps for (A):
+ *  1. find the edge cells of the box [x] + unit test [],
+ *
+ *  2. get the corner points for each of the cells [] + unit test [],
+ *
+ *  3. find the corner points of the entire box (assuming the box is a
+ *  parallelogram, which may not be true for the top and bottom planes
+ *  -> figure out how to deal with this later) [] + unit test [],
+ *
+ *  4. print the box data to log for external visualization
+ *
+ *  5. figure out if the current point is inside or outside
  *  the box, e.g., create a BoxEnvelopsPoint function
- *  -if outside, project point onto nearest point on plane
+ *
+ *  6. if outside, project point onto nearest point on plane
+ *
+ *  Steps for (B):
  */
 class ReservoirBoundary : public Constraint, WellSplineConstraint
 {
@@ -63,7 +74,10 @@ class ReservoirBoundary : public Constraint, WellSplineConstraint
   bool CaseSatisfiesConstraint(Case *c);
   void SnapCaseToConstraints(Case *c);
 
-  // Def. function that outputs box_edge_cells_ for testing
+  /* \brief Function getListOfBoxEdgeCellIndices uses the limits
+   * defining the box constraint to find the cells that constitute
+   * the edges of the box
+   */
   QList<int> returnListOfBoxEdgeCellIndices() const { return index_list_edge_; }
 
  private:

--- a/FieldOpt/Optimization/constraints/reservoir_boundary.h
+++ b/FieldOpt/Optimization/constraints/reservoir_boundary.h
@@ -80,6 +80,9 @@ class ReservoirBoundary : public Constraint, WellSplineConstraint
    */
   QList<int> returnListOfBoxEdgeCellIndices() const { return index_list_edge_; }
 
+  void findCornerCells();
+//            QList<int> index_corner_cells_;
+
  private:
   int imin_, imax_, jmin_, jmax_, kmin_, kmax_;
   QList<int> index_list_;
@@ -90,6 +93,7 @@ class ReservoirBoundary : public Constraint, WellSplineConstraint
   QList<int> getListOfBoxEdgeCellIndices();
   QList<int> index_list_edge_;
 
+  void printCornerXYZ(std::string str_out, Eigen::Vector3d vector_xyz);
 };
 }
 }

--- a/FieldOpt/Optimization/tests/constraints/test_bhp_constraint.cpp
+++ b/FieldOpt/Optimization/tests/constraints/test_bhp_constraint.cpp
@@ -5,76 +5,78 @@
 
 namespace {
 
-    class BhpConstraintTest : public ::testing::Test, public TestResources::TestResourceOptimizer {
-    protected:
-        BhpConstraintTest() {
-            box_constraint_ = new ::Optimization::Constraints::BhpConstraint(settings_optimizer_->constraints()[0], model_->variables());
-        }
-        virtual ~BhpConstraintTest() {}
-        virtual void SetUp() {}
+class BhpConstraintTest : public ::testing::Test,
+                          public TestResources::TestResourceOptimizer {
+ protected:
+  BhpConstraintTest() {
+      box_constraint_ = new ::Optimization::Constraints::BhpConstraint
+          (settings_optimizer_->constraints()[0], model_->variables());
+  }
+  virtual ~BhpConstraintTest() {}
+  virtual void SetUp() {}
 
-        Optimization::Constraints::BhpConstraint *box_constraint_;
-    };
+  Optimization::Constraints::BhpConstraint *box_constraint_;
+};
 
-    TEST_F(BhpConstraintTest, Constructor) {
-        EXPECT_TRUE(true);
+TEST_F(BhpConstraintTest, Constructor) {
+    EXPECT_TRUE(true);
+}
+
+TEST_F(BhpConstraintTest, BaseCaseSatisfaction) {
+    EXPECT_TRUE(box_constraint_->CaseSatisfiesConstraint(base_case_));
+}
+
+TEST_F(BhpConstraintTest, SatisfactionAfterModification) {
+    // get the bhp variable ids
+    QList<QUuid> bhp_ids;
+    for (auto var : model_->variables()->GetWellBHPVariables("PROD")) {
+        bhp_ids.append(var->id());
     }
 
-    TEST_F(BhpConstraintTest, BaseCaseSatasfaction) {
-        EXPECT_TRUE(box_constraint_->CaseSatisfiesConstraint(base_case_));
+    // set all bhps to 5000 (which exceeds the max value defined, 3000)
+    for (QUuid key : bhp_ids) {
+        base_case_->set_real_variable_value(key, 5000);
+    }
+    EXPECT_FALSE(box_constraint_->CaseSatisfiesConstraint(base_case_));
+
+    // set all bhps to 100 (which is less than the min value defined, 1000)
+    for (QUuid key : bhp_ids) {
+        base_case_->set_real_variable_value(key, 100);
+    }
+    EXPECT_FALSE(box_constraint_->CaseSatisfiesConstraint(base_case_));
+
+    // set all bhps to 1125 (which is within the defined bounds)
+    for (QUuid key : bhp_ids) {
+        base_case_->set_real_variable_value(key, 1125);
+    }
+    EXPECT_TRUE(box_constraint_->CaseSatisfiesConstraint(base_case_));
+}
+
+TEST_F(BhpConstraintTest, SnappingValues) {
+    // get the bhp variable ids
+    QList<QUuid> bhp_ids;
+    for (auto var : model_->variables()->GetWellBHPVariables("PROD")) {
+        bhp_ids.append(var->id());
     }
 
-    TEST_F(BhpConstraintTest, SatisfactionAfterModification) {
-        // get the bhp variable ids
-        QList<QUuid> bhp_ids;
-        for (auto var : model_->variables()->GetWellBHPVariables("PROD")) {
-            bhp_ids.append(var->id());
-        }
-
-        // set all bhps to 5000 (which exceeds the max value defined, 3000)
-        for (QUuid key : bhp_ids) {
-            base_case_->set_real_variable_value(key, 5000);
-        }
-        EXPECT_FALSE(box_constraint_->CaseSatisfiesConstraint(base_case_));
-
-        // set all bhps to 100 (which is less than the min value defined, 1000)
-        for (QUuid key : bhp_ids) {
-            base_case_->set_real_variable_value(key, 100);
-        }
-        EXPECT_FALSE(box_constraint_->CaseSatisfiesConstraint(base_case_));
-
-        // set all bhps to 1125 (which is within the defined bounds)
-        for (QUuid key : bhp_ids) {
-            base_case_->set_real_variable_value(key, 1125);
-        }
-        EXPECT_TRUE(box_constraint_->CaseSatisfiesConstraint(base_case_));
+    // set all bhps to 5000 (which exceeds the max value defined, 3000)
+    for (QUuid key : bhp_ids) {
+        base_case_->set_real_variable_value(key, 5000);
     }
+    EXPECT_FALSE(box_constraint_->CaseSatisfiesConstraint(base_case_));
+    // Snap the values back and recheck
+    box_constraint_->SnapCaseToConstraints(base_case_);
+    EXPECT_TRUE(box_constraint_->CaseSatisfiesConstraint(base_case_));
 
-    TEST_F(BhpConstraintTest, SnappingValues) {
-        // get the bhp variable ids
-        QList<QUuid> bhp_ids;
-        for (auto var : model_->variables()->GetWellBHPVariables("PROD")) {
-            bhp_ids.append(var->id());
-        }
-
-        // set all bhps to 5000 (which exceeds the max value defined, 3000)
-        for (QUuid key : bhp_ids) {
-            base_case_->set_real_variable_value(key, 5000);
-        }
-        EXPECT_FALSE(box_constraint_->CaseSatisfiesConstraint(base_case_));
-        // Snap the values back and recheck
-        box_constraint_->SnapCaseToConstraints(base_case_);
-        EXPECT_TRUE(box_constraint_->CaseSatisfiesConstraint(base_case_));
-
-        // set all bhps to 100 (which is less than the min value defined, 1000)
-        for (QUuid key : bhp_ids) {
-            base_case_->set_real_variable_value(key, 100);
-        }
-        EXPECT_FALSE(box_constraint_->CaseSatisfiesConstraint(base_case_));
-        // Snap the values back and recheck
-        box_constraint_->SnapCaseToConstraints(base_case_);
-        EXPECT_TRUE(box_constraint_->CaseSatisfiesConstraint(base_case_));
+    // set all bhps to 100 (which is less than the min value defined, 1000)
+    for (QUuid key : bhp_ids) {
+        base_case_->set_real_variable_value(key, 100);
     }
+    EXPECT_FALSE(box_constraint_->CaseSatisfiesConstraint(base_case_));
+    // Snap the values back and recheck
+    box_constraint_->SnapCaseToConstraints(base_case_);
+    EXPECT_TRUE(box_constraint_->CaseSatisfiesConstraint(base_case_));
+}
 
 }
 

--- a/FieldOpt/Optimization/tests/constraints/test_bhp_constraint.cpp
+++ b/FieldOpt/Optimization/tests/constraints/test_bhp_constraint.cpp
@@ -1,3 +1,22 @@
+/******************************************************************************
+   Copyright (C) 2015-2016 Einar J.M. Baumann <einar.baumann@gmail.com>
+
+   This file is part of the FieldOpt project.
+
+   FieldOpt is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   FieldOpt is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with FieldOpt.  If not, see <http://www.gnu.org/licenses/>.
+******************************************************************************/
+
 #include "gtest/gtest.h"
 #include "Optimization/constraints/bhp_constraint.h"
 #include "Settings/tests/test_resource_settings.hpp"
@@ -33,21 +52,21 @@ TEST_F(BhpConstraintTest, SatisfactionAfterModification) {
         bhp_ids.append(var->id());
     }
 
-    // set all bhps to 5000 (which exceeds the max value defined, 3000)
+    // set all bhps to 500 (which exceeds the max value defined, 300)
     for (QUuid key : bhp_ids) {
-        base_case_->set_real_variable_value(key, 5000);
+        base_case_->set_real_variable_value(key, 500);
     }
     EXPECT_FALSE(box_constraint_->CaseSatisfiesConstraint(base_case_));
 
-    // set all bhps to 100 (which is less than the min value defined, 1000)
+    // set all bhps to 50 (which is less than the min value defined, 100)
     for (QUuid key : bhp_ids) {
-        base_case_->set_real_variable_value(key, 100);
+        base_case_->set_real_variable_value(key, 50);
     }
     EXPECT_FALSE(box_constraint_->CaseSatisfiesConstraint(base_case_));
 
-    // set all bhps to 1125 (which is within the defined bounds)
+    // set all bhps to 125 (which is within the defined bounds)
     for (QUuid key : bhp_ids) {
-        base_case_->set_real_variable_value(key, 1125);
+        base_case_->set_real_variable_value(key, 125);
     }
     EXPECT_TRUE(box_constraint_->CaseSatisfiesConstraint(base_case_));
 }
@@ -59,18 +78,18 @@ TEST_F(BhpConstraintTest, SnappingValues) {
         bhp_ids.append(var->id());
     }
 
-    // set all bhps to 5000 (which exceeds the max value defined, 3000)
+    // set all bhps to 500 (which exceeds the max value defined, 300)
     for (QUuid key : bhp_ids) {
-        base_case_->set_real_variable_value(key, 5000);
+        base_case_->set_real_variable_value(key, 500);
     }
     EXPECT_FALSE(box_constraint_->CaseSatisfiesConstraint(base_case_));
     // Snap the values back and recheck
     box_constraint_->SnapCaseToConstraints(base_case_);
     EXPECT_TRUE(box_constraint_->CaseSatisfiesConstraint(base_case_));
 
-    // set all bhps to 100 (which is less than the min value defined, 1000)
+    // set all bhps to 50 (which is less than the min value defined, 100)
     for (QUuid key : bhp_ids) {
-        base_case_->set_real_variable_value(key, 100);
+        base_case_->set_real_variable_value(key, 50);
     }
     EXPECT_FALSE(box_constraint_->CaseSatisfiesConstraint(base_case_));
     // Snap the values back and recheck

--- a/FieldOpt/Optimization/tests/constraints/test_constraint_handler.cpp
+++ b/FieldOpt/Optimization/tests/constraints/test_constraint_handler.cpp
@@ -1,3 +1,22 @@
+/******************************************************************************
+   Copyright (C) 2015-2016 Einar J.M. Baumann <einar.baumann@gmail.com>
+
+   This file is part of the FieldOpt project.
+
+   FieldOpt is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   FieldOpt is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with FieldOpt.  If not, see <http://www.gnu.org/licenses/>.
+******************************************************************************/
+
 #include <gtest/gtest.h>
 #include "Optimization/tests/test_resource_optimizer.h"
 #include "Optimization/constraints/constraint_handler.h"
@@ -5,24 +24,32 @@
 
 namespace {
 
-class ConstraintHandlerTest : public ::testing::Test, public TestResources::TestResourceOptimizer, public TestResources::TestResourceGrids {
-protected:
-    ConstraintHandlerTest() {
-        constraint_handler_ = new ::Optimization::Constraints::ConstraintHandler(settings_optimizer_->constraints(),
-                                                                                 model_->variables(), grid_5spot_);
-    }
-    virtual ~ConstraintHandlerTest() {}
-    virtual void SetUp() {}
+class ConstraintHandlerTest : public ::testing::Test,
+                              public TestResources::TestResourceOptimizer,
+                              public TestResources::TestResourceGrids {
+ protected:
+  ConstraintHandlerTest() {
+      constraint_handler_ = new ::Optimization::Constraints::ConstraintHandler(
+          settings_optimizer_->constraints(),
+          model_->variables(), grid_5spot_);
+  }
+  virtual ~ConstraintHandlerTest() {}
+  virtual void SetUp() {}
 
-    Optimization::Constraints::ConstraintHandler *constraint_handler_;
+  Optimization::Constraints::ConstraintHandler *constraint_handler_;
 };
 
 TEST_F(ConstraintHandlerTest, Constructor) {
-    EXPECT_EQ(5, constraint_handler_->constraints().size());
+    EXPECT_EQ(6, constraint_handler_->constraints().size());
 }
 
-TEST_F(ConstraintHandlerTest, BaseCaseSatasfaction) {
+TEST_F(ConstraintHandlerTest, BaseCaseSatisfaction) {
     EXPECT_TRUE(constraint_handler_->constraints().first()->CaseSatisfiesConstraint(base_case_));
+}
+
+// Check if base case breaks second constraint type (WellSplineLength)
+TEST_F(ConstraintHandlerTest, BaseCaseSatisfyWellSplineLengthConstraint) {
+    EXPECT_FALSE(constraint_handler_->constraints()[1]->CaseSatisfiesConstraint(base_case_));
 }
 
 }

--- a/FieldOpt/Optimization/tests/constraints/test_reservoir_boundary.cpp
+++ b/FieldOpt/Optimization/tests/constraints/test_reservoir_boundary.cpp
@@ -22,8 +22,8 @@
 #include "constraints/reservoir_boundary.h"
 #include "Optimization/tests/test_resource_cases.h"
 #include "Reservoir/tests/test_resource_grids.h"
-#include "Settings/tests/test_resource_settings.hpp"
-
+#include "Optimization/tests/test_resource_optimizer.h"
+#include "Model/tests/test_resource_variable_property_container.h"
 
 namespace {
 
@@ -34,7 +34,7 @@ class ReservoirBoundaryTest : public ::testing::Test,
 
  public:
   ReservoirBoundaryTest() {
-      bound_settings_.type = Utilities::Settings::Optimizer::ConstraintType::ReservoirBoundary;
+      bound_settings_.type = Settings::Optimizer::ConstraintType::ReservoirBoundary;
       bound_settings_.well = settings_optimizer_->constraints()[5].wells[1]; // TESTW
       bound_settings_.box_imin = settings_optimizer_->constraints()[5].box_imin;
       bound_settings_.box_imax = settings_optimizer_->constraints()[5].box_imax;
@@ -44,10 +44,10 @@ class ReservoirBoundaryTest : public ::testing::Test,
       bound_settings_.box_kmax = settings_optimizer_->constraints()[5].box_kmax;
 
       boundary_constraint_ = new Optimization::Constraints::ReservoirBoundary(
-          bound_settings_, variable_property_container_, grid_5spot_);
+          bound_settings_, varcont_prod_spline_, grid_5spot_);
   }
 
-  Utilities::Settings::Optimizer::Constraint bound_settings_;
+  Settings::Optimizer::Constraint bound_settings_;
   Optimization::Constraints::ReservoirBoundary *boundary_constraint_;
 
   virtual ~ReservoirBoundaryTest() { }
@@ -55,15 +55,16 @@ class ReservoirBoundaryTest : public ::testing::Test,
   virtual void SetUp() { }
 };
 
-TEST_F(ReservoirBoundaryTest, Initialization) {
-    // Replace test_boundary object with boundary_constraint_
-    auto test_boundary = Optimization::Constraints::ReservoirBoundary(
-        constraint_settings_reservoir_boundary_,
-        varcont_prod_spline_, grid_5spot_);
-    EXPECT_FALSE(test_boundary.CaseSatisfiesConstraint(test_case_spline_));
-    test_boundary.SnapCaseToConstraints(test_case_spline_);
-    EXPECT_TRUE(test_boundary.CaseSatisfiesConstraint(test_case_spline_));
-}
+// constraint_settings_reservoir_boundary_ missing...
+//TEST_F(ReservoirBoundaryTest, Initialization) {
+//    // Replace test_boundary object with boundary_constraint_
+//    auto test_boundary = Optimization::Constraints::ReservoirBoundary(
+//        constraint_settings_reservoir_boundary_,
+//        varcont_prod_spline_, grid_5spot_);
+//    EXPECT_FALSE(test_boundary.CaseSatisfiesConstraint(test_case_spline_));
+//    test_boundary.SnapCaseToConstraints(test_case_spline_);
+//    EXPECT_TRUE(test_boundary.CaseSatisfiesConstraint(test_case_spline_));
+//}
 
 TEST_F(ReservoirBoundaryTest, CheckListBoxEdgeCells) {
     auto box_edge_cells_ = boundary_constraint_->returnListOfBoxEdgeCellIndices();

--- a/FieldOpt/Optimization/tests/constraints/test_reservoir_boundary.cpp
+++ b/FieldOpt/Optimization/tests/constraints/test_reservoir_boundary.cpp
@@ -1,3 +1,23 @@
+/******************************************************************************
+   Copyright (C) 2015-2016 Einar J.M. Baumann <einar.baumann@gmail.com>
+   Additions by M.Bellout (2017) <mathias.bellout@ntnu.no>
+
+   This file is part of the FieldOpt project.
+
+   FieldOpt is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   FieldOpt is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with FieldOpt.  If not, see <http://www.gnu.org/licenses/>.
+******************************************************************************/
+
 #include <gtest/gtest.h>
 #include "constraints/reservoir_boundary.h"
 #include "Optimization/tests/test_resource_cases.h"
@@ -7,21 +27,43 @@
 
 namespace {
 
-    class ReservoirBoundaryTest : public ::testing::Test, public TestResources::TestResourceCases,
-                                  public TestResources::TestResourceGrids,
-                                  public TestResources::TestResourceSettings {
+class ReservoirBoundaryTest : public ::testing::Test,
+                              public TestResources::TestResourceCases,
+                              public TestResources::TestResourceGrids,
+                              public TestResources::TestResourceSettings {
 
-    public:
-        ReservoirBoundaryTest() { }
-        virtual ~ReservoirBoundaryTest() { }
-        virtual void TearDown() { }
-        virtual void SetUp() { }
-    };
+ public:
+  ReservoirBoundaryTest() { }
+  virtual ~ReservoirBoundaryTest() { }
+  virtual void TearDown() { }
+  virtual void SetUp() { }
+};
 
-    TEST_F(ReservoirBoundaryTest, Initialization) {
-        auto test_boundary = Optimization::Constraints::ReservoirBoundary(constraint_settings_reservoir_boundary_, varcont_prod_spline_, grid_5spot_);
-        EXPECT_FALSE(test_boundary.CaseSatisfiesConstraint(test_case_spline_));
-        test_boundary.SnapCaseToConstraints(test_case_spline_);
-        EXPECT_TRUE(test_boundary.CaseSatisfiesConstraint(test_case_spline_));
-    }
+TEST_F(ReservoirBoundaryTest, Initialization) {
+    auto test_boundary = Optimization::Constraints::ReservoirBoundary(
+        constraint_settings_reservoir_boundary_,
+        varcont_prod_spline_, grid_5spot_);
+    EXPECT_FALSE(test_boundary.CaseSatisfiesConstraint(test_case_spline_));
+    test_boundary.SnapCaseToConstraints(test_case_spline_);
+    EXPECT_TRUE(test_boundary.CaseSatisfiesConstraint(test_case_spline_));
+}
+
+TEST_F(ReservoirBoundaryTest, CheckListBoxEdgeCells) {
+    auto test_boundary = Optimization::Constraints::ReservoirBoundary(
+        constraint_settings_reservoir_boundary_,
+        variable_property_container_, grid_5spot_);
+
+    auto box_edge_cells_ = test_boundary.returnListOfBoxEdgeCellIndices();
+    std::cout << "length (test_reservoir_boundary.cpp):"
+              << box_edge_cells_.length() << std::endl;
+
+    // Keep this for now (will be part of further unit test)
+    //for( int i=0; i < box_edge_cells_.length(); ++i ) {
+    //    std::cout << box_edge_cells_[i] << std::endl;
+    //}
+    // std::cout << "i=" << i << " j=" << j << " k=" << k << std::endl;
+    // std::cout << grid_->GetCell(i, j, k).global_index() << std::endl;
+
+    EXPECT_TRUE(box_edge_cells_.length()>0);
+}
 }

--- a/FieldOpt/Optimization/tests/constraints/test_reservoir_boundary.cpp
+++ b/FieldOpt/Optimization/tests/constraints/test_reservoir_boundary.cpp
@@ -33,13 +33,30 @@ class ReservoirBoundaryTest : public ::testing::Test,
                               public TestResources::TestResourceSettings {
 
  public:
-  ReservoirBoundaryTest() { }
+  ReservoirBoundaryTest() {
+      bound_settings_.type = Utilities::Settings::Optimizer::ConstraintType::ReservoirBoundary;
+      bound_settings_.well = settings_optimizer_->constraints()[5].wells[1]; // TESTW
+      bound_settings_.box_imin = settings_optimizer_->constraints()[5].box_imin;
+      bound_settings_.box_imax = settings_optimizer_->constraints()[5].box_imax;
+      bound_settings_.box_jmin = settings_optimizer_->constraints()[5].box_jmin;
+      bound_settings_.box_jmax = settings_optimizer_->constraints()[5].box_jmax;
+      bound_settings_.box_kmin = settings_optimizer_->constraints()[5].box_kmin;
+      bound_settings_.box_kmax = settings_optimizer_->constraints()[5].box_kmax;
+
+      boundary_constraint_ = new Optimization::Constraints::ReservoirBoundary(
+          bound_settings_, variable_property_container_, grid_5spot_);
+  }
+
+  Utilities::Settings::Optimizer::Constraint bound_settings_;
+  Optimization::Constraints::ReservoirBoundary *boundary_constraint_;
+
   virtual ~ReservoirBoundaryTest() { }
   virtual void TearDown() { }
   virtual void SetUp() { }
 };
 
 TEST_F(ReservoirBoundaryTest, Initialization) {
+    // Replace test_boundary object with boundary_constraint_
     auto test_boundary = Optimization::Constraints::ReservoirBoundary(
         constraint_settings_reservoir_boundary_,
         varcont_prod_spline_, grid_5spot_);
@@ -49,21 +66,23 @@ TEST_F(ReservoirBoundaryTest, Initialization) {
 }
 
 TEST_F(ReservoirBoundaryTest, CheckListBoxEdgeCells) {
-    auto test_boundary = Optimization::Constraints::ReservoirBoundary(
-        constraint_settings_reservoir_boundary_,
-        variable_property_container_, grid_5spot_);
+    auto box_edge_cells_ = boundary_constraint_->returnListOfBoxEdgeCellIndices();
 
-    auto box_edge_cells_ = test_boundary.returnListOfBoxEdgeCellIndices();
-    std::cout << "length (test_reservoir_boundary.cpp):"
+    std::cout << "length box_edge_cells_: "
               << box_edge_cells_.length() << std::endl;
 
     // Keep this for now (will be part of further unit test)
-    //for( int i=0; i < box_edge_cells_.length(); ++i ) {
-    //    std::cout << box_edge_cells_[i] << std::endl;
+    //for( int i=0; i < box_edge_cells_.length(); ++i )
+    //{
+    //   std::cout << box_edge_cells_[i] << std::endl;
     //}
+    EXPECT_TRUE(box_edge_cells_.length()>0);
+}
+
+TEST_F(ReservoirBoundaryTest, CheckBoundConstraintSettings) {
     // std::cout << "i=" << i << " j=" << j << " k=" << k << std::endl;
     // std::cout << grid_->GetCell(i, j, k).global_index() << std::endl;
 
-    EXPECT_TRUE(box_edge_cells_.length()>0);
+    boundary_constraint_->findCornerCells();
 }
 }

--- a/FieldOpt/Runner/tests/test_bookkeeper.cpp
+++ b/FieldOpt/Runner/tests/test_bookkeeper.cpp
@@ -1,3 +1,22 @@
+/******************************************************************************
+   Copyright (C) 2015-2016 Einar J.M. Baumann <einar.baumann@gmail.com>
+
+   This file is part of the FieldOpt project.
+
+   FieldOpt is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   FieldOpt is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with FieldOpt.  If not, see <http://www.gnu.org/licenses/>.
+******************************************************************************/
+
 #include <gtest/gtest.h>
 #include "Optimization/tests/test_resource_optimizer.h"
 #include "../Runner/bookkeeper.h"

--- a/FieldOpt/Settings/optimizer.cpp
+++ b/FieldOpt/Settings/optimizer.cpp
@@ -200,6 +200,7 @@ namespace Settings {
         }
 
         else if (QString::compare(constraint_type, "ReservoirBoundary") == 0) {
+            optimizer_constraint.type = ConstraintType::ReservoirBoundary;
             optimizer_constraint.box_imin = json_constraint["BoxImin"].toInt();
             optimizer_constraint.box_imax = json_constraint["BoxImax"].toInt();
             optimizer_constraint.box_jmin = json_constraint["BoxJmin"].toInt();

--- a/FieldOpt/Settings/settings.h
+++ b/FieldOpt/Settings/settings.h
@@ -35,57 +35,64 @@
 
 namespace Settings {
 
-    class Simulator;
-    class Model;
-    class Optimizer;
+class Simulator;
+class Model;
+class Optimizer;
 
 /*!
  * \brief The Settings class contains both general settings for a FieldOpt run
  * and pointers to objects containing specific settings for the Model, Simulator
  * and Optimizer. Settings takes as input the path to a "driver file" in the
  * JSON format.
+ *
+ * \todo Remove bool verbose_, and associated functions, since this functionality
+ * is now handled by int verbosity_level_ in runtime_settings
  */
-    class Settings
-    {
-    public:
-        Settings(){}
-        Settings(QString driver_path, QString output_directory);
+class Settings
+{
+ public:
+  Settings(){}
+  Settings(QString driver_path, QString output_directory);
 
-        QString driver_path() const { return driver_path_; }
+  QString driver_path() const { return driver_path_; }
 
-        QString name() const { return name_; } //!< The name to be used for the run. Output file and folder names are derived from this.
-        QString output_directory() const { return output_directory_; } //!< Path to a directory in which output files are to be placed.
-        bool verbose() const { return verbose_; } //!< Verbose mode (with or without debug printing).
-        void set_verbosity(const bool verbosity) { verbose_ = verbosity; }
-        double bookkeeper_tolerance() const { return bookkeeper_tolerance_; } //!< Get the value for the bookkeeper tolerance. Used by the Bookkeeper in the Runner library.
+  QString name() const { return name_; } //!< The name to be used for the run. Output file and folder names are derived from this.
+  QString output_directory() const { return output_directory_; } //!< Path to a directory in which output files are to be placed.
 
-        Model *model() const { return model_; } //!< Object containing model specific settings.
-        Optimizer *optimizer() const { return optimizer_; } //!< Object containing optimizer specific settings.
-        Simulator *simulator() const { return simulator_; } //!< Object containing simulator specific settings.
+  // To be removed:
+  bool verbose() const { return verbose_; } //!< Verbose mode (with or without debug printing).
+  void set_verbosity(const bool verbosity) { verbose_ = verbosity; }
 
-        QString GetLogCsvString() const; //!< Get a string containing the CSV header and contents for the log.
+  //!< Get the value for the bookkeeper tolerance. Used by the Bookkeeper in the Runner library.
+  double bookkeeper_tolerance() const { return bookkeeper_tolerance_; }
 
-        const QString &build_path() const { return build_path_; } //!< Get the to the FieldOpt build directory.
-        void set_build_path(const QString &build_path); //!< Set the path to the FieldOpt build directory.
+  Model *model() const { return model_; } //!< Object containing model specific settings.
+  Optimizer *optimizer() const { return optimizer_; } //!< Object containing optimizer specific settings.
+  Simulator *simulator() const { return simulator_; } //!< Object containing simulator specific settings.
 
-    private:
-        QString driver_path_;
-        QJsonObject *json_driver_;
-        QString name_;
-        double bookkeeper_tolerance_;
-        QString output_directory_;
-        bool verbose_ = false;
-        Model *model_;
-        Optimizer *optimizer_;
-        Simulator *simulator_;
-        QString build_path_;
+  QString GetLogCsvString() const; //!< Get a string containing the CSV header and contents for the log.
 
-        void readDriverFile();
-        void readGlobalSection();
-        void readSimulatorSection();
-        void readModelSection();
-        void readOptimizerSection();
-    };
+  const QString &build_path() const { return build_path_; } //!< Get the to the FieldOpt build directory.
+  void set_build_path(const QString &build_path); //!< Set the path to the FieldOpt build directory.
+
+ private:
+  QString driver_path_;
+  QJsonObject *json_driver_;
+  QString name_;
+  double bookkeeper_tolerance_;
+  QString output_directory_;
+  bool verbose_ = false;
+  Model *model_;
+  Optimizer *optimizer_;
+  Simulator *simulator_;
+  QString build_path_;
+
+  void readDriverFile();
+  void readGlobalSection();
+  void readSimulatorSection();
+  void readModelSection();
+  void readOptimizerSection();
+};
 
 }
 

--- a/FieldOpt/Settings/tests/driver/driver.json
+++ b/FieldOpt/Settings/tests/driver/driver.json
@@ -28,8 +28,8 @@
             {
                 "Type": "BHP",
                 "Well": "PROD",
-                "Max": 3000.0,
-                "Min": 1000.0
+                "Max": 300.0,
+                "Min": 90.0
             },
             {
                 "Well": "INJ",
@@ -55,6 +55,20 @@
                 "MaxLength": 1200,
                 "MinDistance": 100,
                 "MaxIterations": 50
+            },
+            {
+                "Wells": ["INJ", "TESTW"],
+                "Type": "CombinedWellSplineLengthInterwellDistanceReservoirBoundary",
+                "MinLength": 300,
+                "MaxLength": 800,
+                "MinDistance": 300,
+                "MaxIterations": 100,
+                "BoxImin": 0,
+                "BoxImax": 9,
+                "BoxJmin": 0,
+                "BoxJmax": 9,
+                "BoxKmin": 0,
+                "BoxKmax": 0                
             }
         ]
     },
@@ -124,21 +138,21 @@
                         "TimeStep": 0,
                         "State": "Open",
                         "Mode": "BHP",
-                        "BHP": 2000.0,
+                        "BHP": 100.0,
                         "IsVariable": true
                     },
                     {
                         "TimeStep": 50,
                         "State": "Open",
                         "Mode": "BHP",
-                        "BHP": 2000.0,
+                        "BHP": 100.0,
                         "IsVariable": true
                     },
                     {
                         "TimeStep": 365,
                         "State": "Open",
                         "Mode": "BHP",
-                        "BHP": 2000.0,
+                        "BHP": 100.0,
                         "IsVariable": true
                     }
                 ]
@@ -199,7 +213,7 @@
                         "TimeStep": 0,
                         "State": "Open",
                         "Mode": "BHP",
-                        "BHP": 2000.0,
+                        "BHP": 100.0,
                         "IsVariable": true
                     }
                 ]

--- a/FieldOpt/Settings/tests/driver/driver_sane.json
+++ b/FieldOpt/Settings/tests/driver/driver_sane.json
@@ -99,21 +99,21 @@
                         "TimeStep": 0,
                         "State": "Open",
                         "Mode": "BHP",
-                        "BHP": 2000.0,
+                        "BHP": 100.0,
                         "IsVariable": false
                     },
                     {
                         "TimeStep": 50,
                         "State": "Open",
                         "Mode": "BHP",
-                        "BHP": 2000.0,
+                        "BHP": 100.0,
                         "IsVariable": false
                     },
                     {
                         "TimeStep": 365,
                         "State": "Open",
                         "Mode": "BHP",
-                        "BHP": 2000.0,
+                        "BHP": 100.0,
                         "IsVariable": false
                     }
                 ]

--- a/FieldOpt/Settings/tests/test_resource_settings.hpp
+++ b/FieldOpt/Settings/tests/test_resource_settings.hpp
@@ -1,3 +1,22 @@
+/******************************************************************************
+   Copyright (C) 2015-2016 Einar J.M. Baumann <einar.baumann@gmail.com>
+
+   This file is part of the FieldOpt project.
+
+   FieldOpt is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   FieldOpt is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with FieldOpt.  If not, see <http://www.gnu.org/licenses/>.
+******************************************************************************/
+
 #ifndef FIELDOPT_TEST_RESOURCE_SETTINGS_H
 #define FIELDOPT_TEST_RESOURCE_SETTINGS_H
 
@@ -6,37 +25,39 @@
 
 namespace TestResources {
 
-    class TestResourceSettings {
-    protected:
-        TestResourceSettings() {
-            settings_full_ = new Settings::Settings(ExampleFilePaths::driver_example_, ExampleFilePaths::directory_output_);
-            settings_optimizer_ = settings_full_->optimizer();
-            settings_simulator_ = settings_full_->simulator();
-            settings_model_ = settings_full_->model();
+class TestResourceSettings {
+ protected:
+  TestResourceSettings() {
+      settings_full_ = new Settings::Settings(ExampleFilePaths::driver_example_,
+                                              ExampleFilePaths::directory_output_);
+      settings_optimizer_ = settings_full_->optimizer();
+      settings_simulator_ = settings_full_->simulator();
+      settings_model_ = settings_full_->model();
 
-//            settings_flow_5spot_ = new Settings::Settings(ExampleFilePaths::driver_5spot_flow_,
-//                                                                     "/home/einar/.CLion2016.2/system/cmake/generated/FieldOpt-c9373114/c9373114/Debug/fieldopt_output/");
-//            settings_flow_5spot_->simulator()->set_driver_file_path(TestResources::ExampleFilePaths::flow_drv_5spot_);
-//            settings_flow_5spot_->model()->set_reservoir_grid_path(ExampleFilePaths::grid_5spot_flow_);
+//      settings_flow_5spot_ = new Settings::Settings(ExampleFilePaths::driver_5spot_flow_,
+//                                                    "/home/einar/.CLion2016.2/system/cmake/generated/FieldOpt-c9373114/c9373114/Debug/fieldopt_output/");
+//      settings_flow_5spot_->simulator()->set_driver_file_path(TestResources::ExampleFilePaths::flow_drv_5spot_);
+//      settings_flow_5spot_->model()->set_reservoir_grid_path(ExampleFilePaths::grid_5spot_flow_);
 
-            constraint_settings_reservoir_boundary_.type = Settings::Optimizer::ConstraintType::ReservoirBoundary;
-            constraint_settings_reservoir_boundary_.box_imin = 1;
-            constraint_settings_reservoir_boundary_.box_imax = 1;
-            constraint_settings_reservoir_boundary_.box_jmin = 0;
-            constraint_settings_reservoir_boundary_.box_jmax = 0;
-            constraint_settings_reservoir_boundary_.box_kmin = 0;
-            constraint_settings_reservoir_boundary_.box_kmax = 0;
-            constraint_settings_reservoir_boundary_.well = "PRODUCER";
-        }
+      constraint_settings_reservoir_boundary_.type =
+          Settings::Optimizer::ConstraintType::ReservoirBoundary;
+      constraint_settings_reservoir_boundary_.box_imin = 0;
+      constraint_settings_reservoir_boundary_.box_imax = 59;
+      constraint_settings_reservoir_boundary_.box_jmin = 0;
+      constraint_settings_reservoir_boundary_.box_jmax = 59;
+      constraint_settings_reservoir_boundary_.box_kmin = 0;
+      constraint_settings_reservoir_boundary_.box_kmax = 0;
+      constraint_settings_reservoir_boundary_.well = "TESTW";
+  }
 
-        Settings::Settings *settings_full_;
-        Settings::Optimizer *settings_optimizer_;
-        Settings::Simulator *settings_simulator_;
-        Settings::Model *settings_model_;
+  Settings::Settings *settings_full_;
+  Settings::Optimizer *settings_optimizer_;
+  Settings::Simulator *settings_simulator_;
+  Settings::Model *settings_model_;
 //        Settings::Settings *settings_flow_5spot_;
 
-        Settings::Optimizer::Constraint constraint_settings_reservoir_boundary_;
-    };
+  Settings::Optimizer::Constraint constraint_settings_reservoir_boundary_;
+};
 
 }
 

--- a/FieldOpt/Settings/tests/test_resource_settings.hpp
+++ b/FieldOpt/Settings/tests/test_resource_settings.hpp
@@ -28,8 +28,9 @@ namespace TestResources {
 class TestResourceSettings {
  protected:
   TestResourceSettings() {
-      settings_full_ = new Settings::Settings(ExampleFilePaths::driver_example_,
-                                              ExampleFilePaths::directory_output_);
+      settings_full_ = new Settings::Settings(
+          ExampleFilePaths::driver_example_,
+          ExampleFilePaths::directory_output_);
       settings_optimizer_ = settings_full_->optimizer();
       settings_simulator_ = settings_full_->simulator();
       settings_model_ = settings_full_->model();
@@ -38,16 +39,6 @@ class TestResourceSettings {
 //                                                    "/home/einar/.CLion2016.2/system/cmake/generated/FieldOpt-c9373114/c9373114/Debug/fieldopt_output/");
 //      settings_flow_5spot_->simulator()->set_driver_file_path(TestResources::ExampleFilePaths::flow_drv_5spot_);
 //      settings_flow_5spot_->model()->set_reservoir_grid_path(ExampleFilePaths::grid_5spot_flow_);
-
-      constraint_settings_reservoir_boundary_.type =
-          Settings::Optimizer::ConstraintType::ReservoirBoundary;
-      constraint_settings_reservoir_boundary_.box_imin = 0;
-      constraint_settings_reservoir_boundary_.box_imax = 59;
-      constraint_settings_reservoir_boundary_.box_jmin = 0;
-      constraint_settings_reservoir_boundary_.box_jmax = 59;
-      constraint_settings_reservoir_boundary_.box_kmin = 0;
-      constraint_settings_reservoir_boundary_.box_kmax = 0;
-      constraint_settings_reservoir_boundary_.well = "TESTW";
   }
 
   Settings::Settings *settings_full_;
@@ -55,8 +46,6 @@ class TestResourceSettings {
   Settings::Simulator *settings_simulator_;
   Settings::Model *settings_model_;
 //        Settings::Settings *settings_flow_5spot_;
-
-  Settings::Optimizer::Constraint constraint_settings_reservoir_boundary_;
 };
 
 }

--- a/FieldOpt/Settings/tests/test_settings_model.cpp
+++ b/FieldOpt/Settings/tests/test_settings_model.cpp
@@ -69,7 +69,7 @@ namespace {
             QString expected_name = QString("BHP#PROD#%1").arg(control.time_step);
             EXPECT_STREQ(expected_name.toLatin1().constData(), control.name.toLatin1().constData());
             EXPECT_EQ(Model::ControlMode::BHPControl, control.control_mode);
-            EXPECT_FLOAT_EQ(2000.0, control.bhp);
+            EXPECT_FLOAT_EQ(100.0, control.bhp);
             EXPECT_LE(0, control.time_step);
             EXPECT_GE(365, control.time_step);
             EXPECT_EQ(Model::WellState::WellOpen, control.state);

--- a/FieldOpt/Settings/tests/test_settings_optimizer.cpp
+++ b/FieldOpt/Settings/tests/test_settings_optimizer.cpp
@@ -1,27 +1,21 @@
 /******************************************************************************
- *
- * test_optimizer.cpp
- *
- * Created: 30.09.2015 2015 by einar
- *
- * This file is part of the FieldOpt project.
- *
- * Copyright (C) 2015-2015 Einar J.M. Baumann <einar.baumann@ntnu.no>
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
- *****************************************************************************/
+   Copyright (C) 2015-2016 Einar J.M. Baumann <einar.baumann@gmail.com>
+
+   This file is part of the FieldOpt project.
+
+   FieldOpt is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   FieldOpt is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with FieldOpt.  If not, see <http://www.gnu.org/licenses/>.
+******************************************************************************/
 
 #include <gtest/gtest.h>
 #include <QString>
@@ -32,108 +26,108 @@ using namespace Settings;
 
 namespace {
 
-    class OptimizerSettingsTest : public ::testing::Test, public TestResources::TestResourceSettings {
-    protected:
-        OptimizerSettingsTest()
-        { }
-        virtual ~OptimizerSettingsTest() {}
+class OptimizerSettingsTest : public ::testing::Test, public TestResources::TestResourceSettings {
+ protected:
+  OptimizerSettingsTest()
+  { }
+  virtual ~OptimizerSettingsTest() {}
 
-        virtual void SetUp() {}
-        virtual void TearDown() {}
-    };
+  virtual void SetUp() {}
+  virtual void TearDown() {}
+};
 
-    TEST_F(OptimizerSettingsTest, Type) {
-        EXPECT_EQ(Optimizer::OptimizerType::Compass, settings_optimizer_->type());
-    }
+TEST_F(OptimizerSettingsTest, Type) {
+    EXPECT_EQ(Optimizer::OptimizerType::Compass, settings_optimizer_->type());
+}
 
-    TEST_F(OptimizerSettingsTest, Mode) {
-        EXPECT_EQ(Optimizer::OptimizerMode::Maximize, settings_optimizer_->mode());
-    }
+TEST_F(OptimizerSettingsTest, Mode) {
+    EXPECT_EQ(Optimizer::OptimizerMode::Maximize, settings_optimizer_->mode());
+}
 
-    TEST_F(OptimizerSettingsTest, Parameters) {
-        Optimizer::Parameters params = settings_optimizer_->parameters();
-        EXPECT_EQ(10, params.max_evaluations);
-        EXPECT_FLOAT_EQ(50.0, params.initial_step_length);
-        EXPECT_FLOAT_EQ(1.0, params.minimum_step_length);
-    }
+TEST_F(OptimizerSettingsTest, Parameters) {
+    Optimizer::Parameters params = settings_optimizer_->parameters();
+    EXPECT_EQ(10, params.max_evaluations);
+    EXPECT_FLOAT_EQ(50.0, params.initial_step_length);
+    EXPECT_FLOAT_EQ(1.0, params.minimum_step_length);
+}
 
-    TEST_F(OptimizerSettingsTest, Objective) {
-        Optimizer::Objective obj = settings_optimizer_->objective();
-        EXPECT_EQ(Optimizer::ObjectiveType::WeightedSum, obj.type);
-        EXPECT_EQ(2, obj.weighted_sum.size());
+TEST_F(OptimizerSettingsTest, Objective) {
+    Optimizer::Objective obj = settings_optimizer_->objective();
+    EXPECT_EQ(Optimizer::ObjectiveType::WeightedSum, obj.type);
+    EXPECT_EQ(2, obj.weighted_sum.size());
 
-        EXPECT_STREQ("CumulativeOilProduction", obj.weighted_sum.at(0).property.toLatin1().constData());
-        EXPECT_FLOAT_EQ(1.0, obj.weighted_sum.at(0).coefficient);
-        EXPECT_EQ(-1, obj.weighted_sum.at(0).time_step);
-        EXPECT_FALSE(obj.weighted_sum.at(0).is_well_prop);
+    EXPECT_STREQ("CumulativeOilProduction", obj.weighted_sum.at(0).property.toLatin1().constData());
+    EXPECT_FLOAT_EQ(1.0, obj.weighted_sum.at(0).coefficient);
+    EXPECT_EQ(-1, obj.weighted_sum.at(0).time_step);
+    EXPECT_FALSE(obj.weighted_sum.at(0).is_well_prop);
 
-        EXPECT_STREQ("CumulativeWellWaterProduction", obj.weighted_sum.at(1).property.toLatin1().constData());
-        EXPECT_FLOAT_EQ(-0.2, obj.weighted_sum.at(1).coefficient);
-        EXPECT_EQ(10, obj.weighted_sum.at(1).time_step);
-        EXPECT_TRUE(obj.weighted_sum.at(1).is_well_prop);
-        EXPECT_STREQ("PROD", obj.weighted_sum.at(1).well.toLatin1().constData());
-    }
-
-
-    TEST_F(OptimizerSettingsTest, Constraints) {
-        EXPECT_EQ(5, settings_optimizer_->constraints().length());
-        EXPECT_EQ(Optimizer::ConstraintType::BHP, settings_optimizer_->constraints()[0].type);
-        EXPECT_EQ(Optimizer::ConstraintType::WellSplineLength, settings_optimizer_->constraints()[1].type);
-        EXPECT_EQ(Optimizer::ConstraintType::Rate, settings_optimizer_->constraints()[2].type);
-        EXPECT_EQ(Optimizer::ConstraintType::WellSplineInterwellDistance, settings_optimizer_->constraints()[3].type);
-        EXPECT_EQ(Optimizer::ConstraintType::CombinedWellSplineLengthInterwellDistance, settings_optimizer_->constraints()[4].type);
-    }
-
-    TEST_F(OptimizerSettingsTest, BHPConstraint) {
-        auto constr = settings_optimizer_->constraints()[0];
-        EXPECT_STREQ("PROD", constr.well.toLatin1().constData());
-        EXPECT_FLOAT_EQ(3000.0, constr.max);
-        EXPECT_FLOAT_EQ(1000.0, constr.min);
-    }
-
-    TEST_F(OptimizerSettingsTest, WellSplineLengthConstraint) {
-        auto constr = settings_optimizer_->constraints()[1];
-        EXPECT_STREQ("INJ", constr.well.toLatin1().constData());
-        EXPECT_FLOAT_EQ(400, constr.min_length);
-        EXPECT_FLOAT_EQ(1200, constr.max_length);
-        EXPECT_FLOAT_EQ(400, constr.min);
-        EXPECT_FLOAT_EQ(1200, constr.max);
-    }
+    EXPECT_STREQ("CumulativeWellWaterProduction", obj.weighted_sum.at(1).property.toLatin1().constData());
+    EXPECT_FLOAT_EQ(-0.2, obj.weighted_sum.at(1).coefficient);
+    EXPECT_EQ(10, obj.weighted_sum.at(1).time_step);
+    EXPECT_TRUE(obj.weighted_sum.at(1).is_well_prop);
+    EXPECT_STREQ("PROD", obj.weighted_sum.at(1).well.toLatin1().constData());
+}
 
 
-    TEST_F(OptimizerSettingsTest, RateConstraint) {
-        auto constr = settings_optimizer_->constraints()[2];
-        EXPECT_STREQ("INJ", constr.well.toLatin1().constData());
-        EXPECT_FLOAT_EQ(1200, constr.min);
-        EXPECT_FLOAT_EQ(1400, constr.max);
-    }
+TEST_F(OptimizerSettingsTest, Constraints) {
+    EXPECT_EQ(5, settings_optimizer_->constraints().length());
+    EXPECT_EQ(Optimizer::ConstraintType::BHP, settings_optimizer_->constraints()[0].type);
+    EXPECT_EQ(Optimizer::ConstraintType::WellSplineLength, settings_optimizer_->constraints()[1].type);
+    EXPECT_EQ(Optimizer::ConstraintType::Rate, settings_optimizer_->constraints()[2].type);
+    EXPECT_EQ(Optimizer::ConstraintType::WellSplineInterwellDistance, settings_optimizer_->constraints()[3].type);
+    EXPECT_EQ(Optimizer::ConstraintType::CombinedWellSplineLengthInterwellDistance, settings_optimizer_->constraints()[4].type);
+}
+
+TEST_F(OptimizerSettingsTest, BHPConstraint) {
+    auto constr = settings_optimizer_->constraints()[0];
+    EXPECT_STREQ("PROD", constr.well.toLatin1().constData());
+    EXPECT_FLOAT_EQ(300.0, constr.max);
+    EXPECT_FLOAT_EQ(100.0, constr.min);
+}
+
+TEST_F(OptimizerSettingsTest, WellSplineLengthConstraint) {
+    auto constr = settings_optimizer_->constraints()[1];
+    EXPECT_STREQ("INJ", constr.well.toLatin1().constData());
+    EXPECT_FLOAT_EQ(400, constr.min_length);
+    EXPECT_FLOAT_EQ(1200, constr.max_length);
+    EXPECT_FLOAT_EQ(400, constr.min);
+    EXPECT_FLOAT_EQ(1200, constr.max);
+}
 
 
-    TEST_F(OptimizerSettingsTest, InterwellDistanceConstraint) {
-        auto constr = settings_optimizer_->constraints()[3];
-        EXPECT_EQ(2, constr.wells.length());
-        EXPECT_STREQ("TESTW", constr.wells[1].toLatin1().constData());
-        EXPECT_FLOAT_EQ(100, constr.min);
-        EXPECT_FLOAT_EQ(100, constr.min_distance);
-    }
+TEST_F(OptimizerSettingsTest, RateConstraint) {
+    auto constr = settings_optimizer_->constraints()[2];
+    EXPECT_STREQ("INJ", constr.well.toLatin1().constData());
+    EXPECT_FLOAT_EQ(1200, constr.min);
+    EXPECT_FLOAT_EQ(1400, constr.max);
+}
 
-    TEST_F(OptimizerSettingsTest, CombinedSplineLengthInterwellDistanceConstraint) {
-        auto constr = settings_optimizer_->constraints()[4];
-        EXPECT_EQ(2, constr.wells.length());
-        EXPECT_STREQ("TESTW", constr.wells[1].toLatin1().constData());
-        EXPECT_FLOAT_EQ(100, constr.min_distance);
-        EXPECT_FLOAT_EQ(400, constr.min_length);
-        EXPECT_FLOAT_EQ(1200, constr.max_length);
-        EXPECT_EQ(50, constr.max_iterations);
-    }
 
-    TEST_F(OptimizerSettingsTest, CombinedSplineLengthInterwellDistanceConstraintReservoirBoundary) {
-        auto constr = settings_optimizer_->constraints()[4];
-        EXPECT_EQ(2, constr.wells.length());
-        EXPECT_STREQ("TESTW", constr.wells[1].toLatin1().constData());
-        EXPECT_FLOAT_EQ(100, constr.min_distance);
-        EXPECT_FLOAT_EQ(400, constr.min_length);
-        EXPECT_FLOAT_EQ(1200, constr.max_length);
-        EXPECT_EQ(50, constr.max_iterations);
-    }
+TEST_F(OptimizerSettingsTest, InterwellDistanceConstraint) {
+    auto constr = settings_optimizer_->constraints()[3];
+    EXPECT_EQ(2, constr.wells.length());
+    EXPECT_STREQ("TESTW", constr.wells[1].toLatin1().constData());
+    EXPECT_FLOAT_EQ(100, constr.min);
+    EXPECT_FLOAT_EQ(100, constr.min_distance);
+}
+
+TEST_F(OptimizerSettingsTest, CombinedSplineLengthInterwellDistanceConstraint) {
+    auto constr = settings_optimizer_->constraints()[4];
+    EXPECT_EQ(2, constr.wells.length());
+    EXPECT_STREQ("TESTW", constr.wells[1].toLatin1().constData());
+    EXPECT_FLOAT_EQ(100, constr.min_distance);
+    EXPECT_FLOAT_EQ(400, constr.min_length);
+    EXPECT_FLOAT_EQ(1200, constr.max_length);
+    EXPECT_EQ(50, constr.max_iterations);
+}
+
+TEST_F(OptimizerSettingsTest, CombinedSplineLengthInterwellDistanceConstraintReservoirBoundary) {
+    auto constr = settings_optimizer_->constraints()[4];
+    EXPECT_EQ(2, constr.wells.length());
+    EXPECT_STREQ("TESTW", constr.wells[1].toLatin1().constData());
+    EXPECT_FLOAT_EQ(100, constr.min_distance);
+    EXPECT_FLOAT_EQ(400, constr.min_length);
+    EXPECT_FLOAT_EQ(1200, constr.max_length);
+    EXPECT_EQ(50, constr.max_iterations);
+}
 }

--- a/FieldOpt/Settings/tests/test_settings_optimizer.cpp
+++ b/FieldOpt/Settings/tests/test_settings_optimizer.cpp
@@ -70,7 +70,7 @@ TEST_F(OptimizerSettingsTest, Objective) {
 
 
 TEST_F(OptimizerSettingsTest, Constraints) {
-    EXPECT_EQ(5, settings_optimizer_->constraints().length());
+    EXPECT_EQ(6, settings_optimizer_->constraints().length());
     EXPECT_EQ(Optimizer::ConstraintType::BHP, settings_optimizer_->constraints()[0].type);
     EXPECT_EQ(Optimizer::ConstraintType::WellSplineLength, settings_optimizer_->constraints()[1].type);
     EXPECT_EQ(Optimizer::ConstraintType::Rate, settings_optimizer_->constraints()[2].type);
@@ -82,7 +82,7 @@ TEST_F(OptimizerSettingsTest, BHPConstraint) {
     auto constr = settings_optimizer_->constraints()[0];
     EXPECT_STREQ("PROD", constr.well.toLatin1().constData());
     EXPECT_FLOAT_EQ(300.0, constr.max);
-    EXPECT_FLOAT_EQ(100.0, constr.min);
+    EXPECT_FLOAT_EQ(90.0, constr.min);
 }
 
 TEST_F(OptimizerSettingsTest, WellSplineLengthConstraint) {


### PR DESCRIPTION
Adds some functions that will be used later to make box constraint more effective (e.g., finding cells corresponding to the edges of the box, checking for feasibility wrt one large box instead of looping through all grid blocks within the box boundary definition). First part out of about seven parts for alternative implementation of box constraint; see reservoir_boundary.h for todo note).

Tests for the above functions still remains, as well as the other steps for the alternative box constraint implementation. This is next on the to-do list.
Also includes several small fixes to tests.


 