### PR TITLE
Feature/norne reservoir fix

### DIFF
--- a/FieldOpt/ERTWrapper/eclgridreader.cpp
+++ b/FieldOpt/ERTWrapper/eclgridreader.cpp
@@ -27,151 +27,161 @@
 #include "ertwrapper_exceptions.h"
 
 namespace ERTWrapper {
-    namespace ECLGrid {
-        Eigen::Vector3d ECLGridReader::GetCellCenter(int global_index)
-        {
-            double cx, cy, cz;
-            ecl_grid_get_xyz1(ecl_grid_, global_index, &cx, &cy, &cz);
-            return Eigen::Vector3d(cx, cy, cz);
-        }
+namespace ECLGrid {
+Eigen::Vector3d ECLGridReader::GetCellCenter(int global_index)
+{
+    double cx, cy, cz;
+    ecl_grid_get_xyz1(ecl_grid_, global_index, &cx, &cy, &cz);
+    return Eigen::Vector3d(cx, cy, cz);
+}
 
-        std::vector<Eigen::Vector3d> ECLGridReader::GetCellCorners(int global_index)
-        {
-            std::vector<Eigen::Vector3d> corners;
-            for (int i = 0; i < 8; ++i) {
-                double x, y, z;
-                ecl_grid_get_cell_corner_xyz1(ecl_grid_, global_index, i, &x, &y, &z);
-                corners.push_back(Eigen::Vector3d(x, y, z));
-            }
-            return corners;
-        }
-
-        double ECLGridReader::GetCellVolume(int global_index)
-        {
-            return ecl_grid_get_cell_volume1(ecl_grid_, global_index);
-        }
-
-        ECLGridReader::ECLGridReader()
-        {
-            ecl_grid_ = 0;
-            ecl_file_init_ = 0;
-            poro_kw_ = 0;
-            permx_kw_ = 0;
-            permy_kw_ = 0;
-            permz_kw_ = 0;
-        }
-
-        ECLGridReader::~ECLGridReader()
-        {
-            if (ecl_grid_ != 0)
-                ecl_grid_free(ecl_grid_);
-            if (ecl_file_init_ != 0)
-                ecl_file_close(ecl_file_init_);
-        }
-
-        void ECLGridReader::ReadEclGrid(std::string file_name)
-        {
-            file_name_ = file_name;
-            init_file_name_ = file_name;
-            if (boost::algorithm::ends_with(file_name, ".EGRID"))
-                boost::replace_all(init_file_name_, ".EGRID", ".INIT");
-
-            else if (boost::algorithm::ends_with(file_name, ".GRID"))
-                boost::replace_all(init_file_name_, ".GRID", ".INIT");
-
-            if (ecl_grid_ == 0) {
-                ecl_grid_ = ecl_grid_alloc(file_name_.c_str());
-            } else {
-                ecl_grid_free(ecl_grid_);
-                ecl_grid_ = ecl_grid_alloc(file_name_.c_str());
-            }
-            if (ecl_file_init_ == 0) {
-                ecl_file_init_ = ecl_file_open(init_file_name_.c_str(), 0);
-                poro_kw_ = ecl_file_iget_named_kw(ecl_file_init_, "PORO", 0);
-                permx_kw_ = ecl_file_iget_named_kw(ecl_file_init_, "PERMX", 0);
-                permy_kw_ = ecl_file_iget_named_kw(ecl_file_init_, "PERMY", 0);
-                permz_kw_ = ecl_file_iget_named_kw(ecl_file_init_, "PERMZ", 0);
-            } else {
-                ecl_file_close(ecl_file_init_);
-                ecl_file_init_ = ecl_file_open(init_file_name_.c_str(), 0);
-                poro_kw_ = ecl_file_iget_named_kw(ecl_file_init_, "PORO", 0);
-                permx_kw_ = ecl_file_iget_named_kw(ecl_file_init_, "PERMX", 0);
-                permy_kw_ = ecl_file_iget_named_kw(ecl_file_init_, "PERMY", 0);
-                permz_kw_ = ecl_file_iget_named_kw(ecl_file_init_, "PERMZ", 0);
-            }
-        }
-
-        int ECLGridReader::ConvertIJKToGlobalIndex(ECLGridReader::IJKIndex ijk)
-        {
-            if (ecl_grid_ == 0) throw GridNotReadException("Grid must be read before converting indices.");
-            return ecl_grid_get_global_index3(ecl_grid_, ijk.i, ijk.j, ijk.k);
-        }
-
-        int ECLGridReader::ConvertIJKToGlobalIndex(int i, int j, int k)
-        {
-            if (ecl_grid_ == 0) throw GridNotReadException("Grid must be read before converting indices.");
-            return ecl_grid_get_global_index3(ecl_grid_, i, j, k);
-        }
-
-        ECLGridReader::IJKIndex ECLGridReader::ConvertGlobalIndexToIJK(int global_index)
-        {
-            if (ecl_grid_ == 0) throw GridNotReadException("Grid must be read before converting indices.");
-            int i, j, k;
-            ecl_grid_get_ijk1(ecl_grid_, global_index, &i, &j, &k);
-            ECLGridReader::IJKIndex ijk;
-            ijk.i = i; ijk.j = j; ijk.k = k;
-            return ijk;
-        }
-
-        ECLGridReader::Dims ECLGridReader::Dimensions()
-        {
-            ECLGridReader::Dims dims;
-            if (ecl_grid_ == 0) throw GridNotReadException("Grid must be read before getting dimensions.");
-            int x, y, z;
-            ecl_grid_get_dims(ecl_grid_, &x, &y, &z, NULL);
-            dims.nx = x; dims.ny = y; dims.nz = z;
-            return dims;
-        }
-
-        int ECLGridReader::ActiveCells()
-        {
-            if (ecl_grid_ == 0) throw GridNotReadException("Grid must be read before gettign active cells.");
-            else return ecl_grid_get_nactive(ecl_grid_);
-        }
-
-        ECLGridReader::Cell ECLGridReader::GetGridCell(int global_index)
-        {
-            if (!GlobalIndexIsInsideGrid(global_index))
-                throw InvalidIndexException("The global index " + boost::lexical_cast<std::string>(global_index) + " is outside the grid.");
-            if (ecl_grid_ == 0) throw GridNotReadException("Grid must be read before getting grid cells.");
-            ECLGridReader::Cell cell;
-            cell.global_index = global_index;
-            cell.volume = GetCellVolume(global_index);
-            cell.corners = GetCellCorners(global_index);
-            cell.center = GetCellCenter(global_index);
-
-            // Get properties from the INIT file
-            cell.porosity = ecl_kw_iget_as_double(poro_kw_, global_index);
-            cell.permx = ecl_kw_iget_as_double(permx_kw_, global_index);
-            cell.permy = ecl_kw_iget_as_double(permy_kw_, global_index);
-            cell.permz = ecl_kw_iget_as_double(permz_kw_, global_index);
-
-            return cell;
-        }
-
-        int ECLGridReader::GlobalIndexOfCellEnvelopingPoint(double x, double y, double z, int initial_guess)
-        {
-            if (ecl_grid_ == 0) throw GridNotReadException("Grid must be read before searching for cells.");
-            return ecl_grid_get_global_index_from_xyz(ecl_grid_, x, y, z, initial_guess);
-        }
-
-        bool ECLGridReader::GlobalIndexIsInsideGrid(int global_index)
-        {
-            Dims dims = Dimensions();
-            return global_index < dims.nx * dims.ny * dims.nz;
-        }
-
-
-
+std::vector<Eigen::Vector3d> ECLGridReader::GetCellCorners(int global_index)
+{
+    std::vector<Eigen::Vector3d> corners;
+    for (int i = 0; i < 8; ++i) {
+        double x, y, z;
+        ecl_grid_get_cell_corner_xyz1(ecl_grid_, global_index, i, &x, &y, &z);
+        corners.push_back(Eigen::Vector3d(x, y, z));
     }
+    return corners;
+}
+
+double ECLGridReader::getCellVolume(int global_index)
+{
+    return ecl_grid_get_cell_volume1(ecl_grid_, global_index);
+}
+
+ECLGridReader::ECLGridReader()
+{
+    ecl_grid_ = 0;
+    ecl_file_init_ = 0;
+    poro_kw_ = 0;
+    permx_kw_ = 0;
+    permy_kw_ = 0;
+    permz_kw_ = 0;
+}
+
+ECLGridReader::~ECLGridReader()
+{
+    if (ecl_grid_ != 0)
+        ecl_grid_free(ecl_grid_);
+    if (ecl_file_init_ != 0)
+        ecl_file_close(ecl_file_init_);
+}
+
+void ECLGridReader::ReadEclGrid(std::string file_name)
+{
+    file_name_ = file_name;
+    init_file_name_ = file_name;
+    if (boost::algorithm::ends_with(file_name, ".EGRID"))
+        boost::replace_all(init_file_name_, ".EGRID", ".INIT");
+
+    else if (boost::algorithm::ends_with(file_name, ".GRID"))
+        boost::replace_all(init_file_name_, ".GRID", ".INIT");
+
+    if (ecl_grid_ == 0) {
+        ecl_grid_ = ecl_grid_alloc(file_name_.c_str());
+    } else {
+        ecl_grid_free(ecl_grid_);
+        ecl_grid_ = ecl_grid_alloc(file_name_.c_str());
+    }
+    if (ecl_file_init_ == 0) {
+        ecl_file_init_ = ecl_file_open(init_file_name_.c_str(), 0);
+        poro_kw_ = ecl_file_iget_named_kw(ecl_file_init_, "PORO", 0);
+        permx_kw_ = ecl_file_iget_named_kw(ecl_file_init_, "PERMX", 0);
+        permy_kw_ = ecl_file_iget_named_kw(ecl_file_init_, "PERMY", 0);
+        permz_kw_ = ecl_file_iget_named_kw(ecl_file_init_, "PERMZ", 0);
+    } else {
+        ecl_file_close(ecl_file_init_);
+        ecl_file_init_ = ecl_file_open(init_file_name_.c_str(), 0);
+        poro_kw_ = ecl_file_iget_named_kw(ecl_file_init_, "PORO", 0);
+        permx_kw_ = ecl_file_iget_named_kw(ecl_file_init_, "PERMX", 0);
+        permy_kw_ = ecl_file_iget_named_kw(ecl_file_init_, "PERMY", 0);
+        permz_kw_ = ecl_file_iget_named_kw(ecl_file_init_, "PERMZ", 0);
+    }
+}
+
+int ECLGridReader::ConvertIJKToGlobalIndex(ECLGridReader::IJKIndex ijk)
+{
+    if (ecl_grid_ == 0) throw GridNotReadException("Grid must be read before converting indices.");
+    return ecl_grid_get_global_index3(ecl_grid_, ijk.i, ijk.j, ijk.k);
+}
+
+int ECLGridReader::ConvertIJKToGlobalIndex(int i, int j, int k)
+{
+    if (ecl_grid_ == 0) throw GridNotReadException("Grid must be read before converting indices.");
+    return ecl_grid_get_global_index3(ecl_grid_, i, j, k);
+}
+
+ECLGridReader::IJKIndex ECLGridReader::ConvertGlobalIndexToIJK(int global_index)
+{
+    if (ecl_grid_ == 0) throw GridNotReadException("Grid must be read before converting indices.");
+    int i, j, k;
+    ecl_grid_get_ijk1(ecl_grid_, global_index, &i, &j, &k);
+    ECLGridReader::IJKIndex ijk;
+    ijk.i = i; ijk.j = j; ijk.k = k;
+    return ijk;
+}
+
+ECLGridReader::Dims ECLGridReader::Dimensions()
+{
+    ECLGridReader::Dims dims;
+    if (ecl_grid_ == 0) throw GridNotReadException("Grid must be read before getting dimensions.");
+    int x, y, z;
+    ecl_grid_get_dims(ecl_grid_, &x, &y, &z, NULL);
+    dims.nx = x; dims.ny = y; dims.nz = z;
+    return dims;
+}
+
+int ECLGridReader::ActiveCells()
+{
+    if (ecl_grid_ == 0) throw GridNotReadException("Grid must be read before gettign active cells.");
+    else return ecl_grid_get_nactive(ecl_grid_);
+}
+
+ECLGridReader::Cell ECLGridReader::GetGridCell(int global_index)
+{
+    if (!GlobalIndexIsInsideGrid(global_index))
+        throw InvalidIndexException("The global index " + boost::lexical_cast<std::string>(global_index) + " is outside the grid.");
+    if (ecl_grid_ == 0) throw GridNotReadException("Grid must be read before getting grid cells.");
+    ECLGridReader::Cell cell;
+    cell.global_index = global_index;
+    cell.volume = getCellVolume(global_index);
+    cell.corners = GetCellCorners(global_index);
+    cell.center = GetCellCenter(global_index);
+    return cell;
+}
+
+ECLGridReader::CellProperties ECLGridReader::GetCellProperties(int global_index) {
+    CellProperties props;
+    if (isActive(global_index)) {
+        props.is_active = true;
+        props.porosity = ecl_kw_iget_as_double(poro_kw_, global_index);
+        props.permx = ecl_kw_iget_as_double(permx_kw_, global_index);
+        props.permy = ecl_kw_iget_as_double(permy_kw_, global_index);
+        props.permz = ecl_kw_iget_as_double(permz_kw_, global_index);
+    }
+    else {
+        props.is_active = false;
+        props.porosity = 0;
+        props.permx, props.permy, props.permz = 0;
+    }
+    return props;
+}
+
+int ECLGridReader::GlobalIndexOfCellEnvelopingPoint(double x, double y, double z, int initial_guess)
+{
+    if (ecl_grid_ == 0) throw GridNotReadException("Grid must be read before searching for cells.");
+    return ecl_grid_get_global_index_from_xyz(ecl_grid_, x, y, z, initial_guess);
+}
+bool ECLGridReader::GlobalIndexIsInsideGrid(int global_index)
+{
+    Dims dims = Dimensions();
+    return global_index < dims.nx * dims.ny * dims.nz;
+}
+bool ECLGridReader::isActive(int global_index) {
+    return ecl_grid_get_active_index1(ecl_grid_, global_index) != -1;
+}
+
+}
 }

--- a/FieldOpt/ERTWrapper/eclgridreader.cpp
+++ b/FieldOpt/ERTWrapper/eclgridreader.cpp
@@ -154,12 +154,13 @@ ECLGridReader::Cell ECLGridReader::GetGridCell(int global_index)
 
 ECLGridReader::CellProperties ECLGridReader::GetCellProperties(int global_index) {
     CellProperties props;
-    if (isActive(global_index)) {
+    int active_index = getActiveIndex(ConvertGlobalIndexToIJK(global_index));
+    if (active_index != -1) {
         props.is_active = true;
-        props.porosity = ecl_kw_iget_as_double(poro_kw_, global_index);
-        props.permx = ecl_kw_iget_as_double(permx_kw_, global_index);
-        props.permy = ecl_kw_iget_as_double(permy_kw_, global_index);
-        props.permz = ecl_kw_iget_as_double(permz_kw_, global_index);
+        props.porosity = ecl_kw_iget_as_double(poro_kw_, active_index);
+        props.permx = ecl_kw_iget_as_double(permx_kw_, active_index);
+        props.permy = ecl_kw_iget_as_double(permy_kw_, active_index);
+        props.permz = ecl_kw_iget_as_double(permz_kw_, active_index);
     }
     else {
         props.is_active = false;
@@ -179,8 +180,11 @@ bool ECLGridReader::GlobalIndexIsInsideGrid(int global_index)
     Dims dims = Dimensions();
     return global_index < dims.nx * dims.ny * dims.nz;
 }
-bool ECLGridReader::isActive(int global_index) {
+int ECLGridReader::getActiveIndex(int global_index) {
     return ecl_grid_get_active_index1(ecl_grid_, global_index) != -1;
+}
+int ECLGridReader::getActiveIndex(ECLGridReader::IJKIndex global_ijk) {
+    return ecl_grid_get_active_index3(ecl_grid_, global_ijk.i, global_ijk.j, global_ijk.k);
 }
 
 }

--- a/FieldOpt/ERTWrapper/eclgridreader.h
+++ b/FieldOpt/ERTWrapper/eclgridreader.h
@@ -27,130 +27,156 @@
 
 namespace ERTWrapper {
 
-    namespace ECLGrid {
+namespace ECLGrid {
 
-        /*!
-         * \brief The ECLGridReader class reads ECLIPSE grid files (.GRID and .EGRID).
-         *
-         * \note ERT uses 0-index IJK indeces. These are not directly valid in ECL or
-         * ADGPRS simulator -- they need to be incremented by 1.
-         */
-        class ECLGridReader
-        {
-        public:
-            /*!
-                 * \brief The Dims struct holds the x,y and z dimensions of a grid.
-                 */
-            struct Dims {
-                int nx, ny, nz;
-            };
+/*!
+ * \brief The ECLGridReader class reads ECLIPSE grid files (.GRID and .EGRID).
+ *
+ * \note ERT uses 0-index IJK indeces. These are not directly valid in ECL or
+ * ADGPRS simulator -- they need to be incremented by 1.
+ */
+class ECLGridReader
+{
+ public:
+  /*!
+       * \brief The Dims struct holds the x,y and z dimensions of a grid.
+       */
+  struct Dims {
+    int nx, ny, nz;
+  };
 
-            /*!
-                 * \brief The Cell struct represents a cell in the grid.
-                 *
-                 * The corners list contains all the corner points specifying the grid.
-                 * The first four elements represent the corners in the lower layer,
-                 * the four last represent the corners in the top layer:
-                 *
-                 * Bottom:  Top:
-                 * 2---3    6---7
-                 * |   |    |   |
-                 * 0---1    4---5
-                 *
-                 * Bottom and Top here refers to z-values.
-            */
-            struct Cell {
-                int global_index;
-                double volume;
-                double porosity;
-                double permx;
-                double permy;
-                double permz;
-                std::vector<Eigen::Vector3d> corners;
-                Eigen::Vector3d center;
-            };
+  /*!
+       * \brief The Cell struct represents a cell in the grid.
+       *
+       * The corners list contains all the corner points specifying the grid.
+       * The first four elements represent the corners in the lower layer,
+       * the four last represent the corners in the top layer:
+       *
+       * Bottom:  Top:
+       * 2---3    6---7
+       * |   |    |   |
+       * 0---1    4---5
+       *
+       * Bottom and Top here refers to z-values.
+  */
+  struct Cell {
+    int global_index;
+    float volume;
+    std::vector<Eigen::Vector3d> corners;
+    Eigen::Vector3d center;
+  };
 
-            struct IJKIndex {
-                int i;
-                int j;
-                int k;
-            };
+  /*!
+   * @brief The CellProperties struct contains all non-geometric properties
+   * for a cell, i.e. permeabilities, porosities, and whether or not the cell
+   * is active.
+   */
+  struct CellProperties {
+    bool is_active;
+    float porosity;
+    float permx;
+    float permy;
+    float permz;
+  };
 
-        private:
-            std::string file_name_;
-            std::string init_file_name_;
-            ecl_grid_type* ecl_grid_;
-            ecl_file_type* ecl_file_init_;
-            Eigen::Vector3d GetCellCenter(int global_index);
-            std::vector<Eigen::Vector3d> GetCellCorners(int global_index);
-            double GetCellVolume(int global_index);
+  struct IJKIndex {
+    int i;
+    int j;
+    int k;
+  };
 
-            ecl_kw_type *poro_kw_;
-            ecl_kw_type *permx_kw_;
-            ecl_kw_type *permy_kw_;
-            ecl_kw_type *permz_kw_;
-        public:
-            ECLGridReader();
-            ECLGridReader(const ECLGridReader& other) = delete;
-            virtual ~ECLGridReader(); //!< Frees the grid object if it has been set.
+ private:
+  std::string file_name_;
+  std::string init_file_name_;
+  ecl_grid_type* ecl_grid_;
+  ecl_file_type* ecl_file_init_;
+  Eigen::Vector3d GetCellCenter(int global_index);
+  std::vector<Eigen::Vector3d> GetCellCorners(int global_index);
+  double getCellVolume(int global_index);
+  bool isActive(int global_index); //!< Check whether or not a cell is active.
 
-            /*!
-                 * \brief ReadEclGrid reads an ECLIPSE .GRID or .EGRID file.
-                 * \param file_name The path to the grid to be read, including suffix.
-                 */
-            void ReadEclGrid(std::string file_name);
+  ecl_kw_type *poro_kw_;
+  ecl_kw_type *permx_kw_;
+  ecl_kw_type *permy_kw_;
+  ecl_kw_type *permz_kw_;
+ public:
+  ECLGridReader();
+  ECLGridReader(const ECLGridReader& other) = delete;
+  virtual ~ECLGridReader(); //!< Frees the grid object if it has been set.
 
-            /*!
-                 * \brief ConvertIJKToGlobalIndex Converts a set of zero-offset (i,j,k) coordinates to the global index to that cell.
-                 * \param ijk Zero-offset coordinates for a cell.
-                 * \return global index
-                 */
-            int ConvertIJKToGlobalIndex(IJKIndex ijk);
-            int ConvertIJKToGlobalIndex(int i, int j, int k);
+  /*!
+   * \brief ReadEclGrid reads an ECLIPSE .GRID or .EGRID file.
+   * \param file_name The path to the grid to be read, including suffix.
+   */
+  void ReadEclGrid(std::string file_name);
 
-            /*!
-                 * \brief ConvertGlobalIndexToIJK Converts a global index for a cell to the corresponding zero-offset (i,j,k) coordinates.
-                 * \param global_index Global index for a cell.
-                 * \return (i,j,k) Zero-offset coordinates
-                 */
-            IJKIndex ConvertGlobalIndexToIJK(int global_index);
+  /*!
+   * \brief ConvertIJKToGlobalIndex Converts a set of zero-offset (i,j,k) coordinates to the global index to that cell.
+   * \param ijk Zero-offset coordinates for a cell.
+   * \return global index
+   */
+  int ConvertIJKToGlobalIndex(IJKIndex ijk);
+  int ConvertIJKToGlobalIndex(int i, int j, int k);
 
-            /*!
-                 * \brief Dimensions returns the total dimensions of the grid that has been read.
-                 * \return Dims struct containing the number of blocks in x, y and z direction.
-                 */
-            Dims Dimensions();
+  /*!
+   * \brief ConvertGlobalIndexToIJK Converts a global index for a cell to the corresponding zero-offset (i,j,k) coordinates.
+   * \param global_index Global index for a cell.
+   * \return (i,j,k) Zero-offset coordinates
+   */
+  IJKIndex ConvertGlobalIndexToIJK(int global_index);
 
-            /*!
-                 * \brief ActiveCells Number of active cells in the grid that has been read.
-                 */
-            int ActiveCells();
+  /*!
+   * \brief Dimensions returns the total dimensions of the grid that has been read.
+   * \return Dims struct containing the number of blocks in x, y and z direction.
+   */
+  Dims Dimensions();
 
-            /*!
-                 * \brief GetGridCell get a Cell struct describing the cell with the specified global index.
-                 * \param global_index The global index of the cell to get.
-                 * \return Cell struct.
-                 */
-            Cell GetGridCell(int global_index);
+  /*!
+   * \brief ActiveCells Number of active cells in the grid that has been read.
+   */
+  int ActiveCells();
 
-            /*!
-                 * \brief GetGlobalIndexOfCellContainingPoint Gets the global index of any cell that envelops/contains the point (x,y,z).
-                 *
-                 * Searches the grid to check whether any cell envelops the point (x,y,z).
-                 * If one is found, the global index is returned; if not, -1 is returned.
-                 * An initial guess may be provided: the search will start from/around this global index. If no guess is
-                 * provided the search will start at the global index 0.
-                 * \param x coordinate in x-direction.
-                 * \param y coordinate in y-direction.
-                 * \param z coordinate in z-direction.
-                 * \param initial_guess (optional) Global index to start search at/around
-                 * \return Global index or -1.
-                 */
-            int GlobalIndexOfCellEnvelopingPoint(double x, double y, double z, int initial_guess=0);
+  /*!
+   * \brief GetGridCell get a Cell struct describing the cell with the
+   * specified global index. This method will retrieve the cell geometry
+   * from the .EGRID/.GRID file.
+   *
+   * \note This method will only retrieve the cell geometry. Use the
+   * FillCellProperties method to get permabilities etc. This is done
+   * in order to avoid crashes when one attempts to get inactive cells.
+   *
+   * \param global_index The global index of the cell to get.
+   * \return Cell struct.
+   */
+  Cell GetGridCell(int global_index);
 
-            bool GlobalIndexIsInsideGrid(int global_index);
-        };
-    }
+  /*!
+   * @brief Get the non-geometric properties of a cell. This will retrieve the
+   * prososity and permeability data from the .INIT file.
+   * @param global_index The global index of the cell to get the additional properties for.
+   */
+  CellProperties GetCellProperties(int global_index);
+
+  /*!
+   * \brief GetGlobalIndexOfCellContainingPoint Gets the global index of any cell
+   * that envelops/contains the point (x,y,z).
+   *
+   * Searches the grid to check whether any cell envelops the point (x,y,z).
+   * If one is found, the global index is returned; if not, -1 is returned.
+   * An initial guess may be provided: the search will start from/around this
+   * global index. If no guess is provided the search will start at the global
+   * index 0.
+   * \param x coordinate in x-direction.
+   * \param y coordinate in y-direction.
+   * \param z coordinate in z-direction.
+   * \param initial_guess (optional) Global index to start search at/around
+   * \return Global index or -1.
+   */
+  int GlobalIndexOfCellEnvelopingPoint(double x, double y, double z, int initial_guess=0);
+
+  bool GlobalIndexIsInsideGrid(int global_index);
+};
+}
 }
 
 #endif // ECLGRIDREADER_H

--- a/FieldOpt/ERTWrapper/eclgridreader.h
+++ b/FieldOpt/ERTWrapper/eclgridreader.h
@@ -93,7 +93,8 @@ class ECLGridReader
   Eigen::Vector3d GetCellCenter(int global_index);
   std::vector<Eigen::Vector3d> GetCellCorners(int global_index);
   double getCellVolume(int global_index);
-  bool isActive(int global_index); //!< Check whether or not a cell is active.
+  int getActiveIndex(int global_index); //!< Get the active index for a cell. Returns -1 if the cell is inactive.
+  int getActiveIndex(IJKIndex global_ijk); //!< Get the active index for a cell. Returns -1 if the cell is inactive.
 
   ecl_kw_type *poro_kw_;
   ecl_kw_type *permx_kw_;

--- a/FieldOpt/ERTWrapper/tests/test_eclgridreader.cpp
+++ b/FieldOpt/ERTWrapper/tests/test_eclgridreader.cpp
@@ -99,8 +99,8 @@ TEST_F(ECLGridReaderTest, GetCell) {
 }
 
 TEST_F(ECLGridReaderTest, CellProperties) {
-    ECLGridReader::Cell cell_1 = ecl_grid_reader_->GetGridCell(1);
-    ECLGridReader::Cell cell_1000 = ecl_grid_reader_->GetGridCell(1000);
+    auto cell_1 = ecl_grid_reader_->GetCellProperties(1);
+    auto cell_1000 = ecl_grid_reader_->GetCellProperties(1000);
     EXPECT_FLOAT_EQ(0.25, cell_1.porosity);
     EXPECT_FLOAT_EQ(100, cell_1.permx);
     EXPECT_FLOAT_EQ(100, cell_1.permy);

--- a/FieldOpt/Reservoir/grid/cell.cpp
+++ b/FieldOpt/Reservoir/grid/cell.cpp
@@ -24,20 +24,20 @@ namespace Grid {
 
 Cell::Cell(int global_index,
            IJKCoordinate ijk_index,
-           double volume, double poro,
-           double permx, double permy, double permz,
+           float volume,
            Eigen::Vector3d center,
            std::vector<Eigen::Vector3d> corners)
 {
     global_index_ = global_index;
     ijk_index_ = ijk_index;
     volume_ = volume;
-    porosity_ = poro;
-    permx_ = permx;
-    permy_ = permy;
-    permz_ = permz;
     center_ = center;
     corners_ = corners;
+    is_active_ = true;
+    porosity_ = 0;
+    permx_ = 0;
+    permy_ = 0;
+    permz_ = 0;
     initializeFaces();
 }
 
@@ -79,10 +79,17 @@ void Cell::initializeFaces() {
 
         face.normal_vector =
             (face.corners[2] - face.corners[0]).cross(
-            face.corners[1] - face.corners[0]).normalized();
+                face.corners[1] - face.corners[0]).normalized();
 
         faces_.push_back(face);
     }
+}
+void Cell::SetProperties(bool is_active, float porosity, float permx, float permy, float permz) {
+    is_active_ = is_active;
+    porosity_ = porosity;
+    permx_ = permx;
+    permy_ = permy;
+    permz_ = permz;
 }
 
 }

--- a/FieldOpt/Reservoir/grid/cell.h
+++ b/FieldOpt/Reservoir/grid/cell.h
@@ -25,228 +25,236 @@
 #include <vector>
 
 namespace Reservoir {
-    namespace Grid {
+namespace Grid {
 
-        /*!
-         * \brief The Cell class describes a cell in a grid, including it's
-         * geometry and static properties like porosity and permeability.
-         */
-        class Cell
-        {
-        public:
-            Cell(){};
-            Cell(int global_index,
-                 IJKCoordinate ijk_index,
-                 double volume,
-                 double poro,
-                 double permx,
-                 double permy,
-                 double permz,
-                 Eigen::Vector3d center,
-                 std::vector<Eigen::Vector3d> corners);
+/*!
+ * \brief The Cell class describes a cell in a grid, including it's
+ * geometry and static properties like porosity and permeability.
+ */
+class Cell
+{
+ public:
+  Cell(){};
+  Cell(int global_index,
+       IJKCoordinate ijk_index,
+       float volume,
+       Eigen::Vector3d center,
+       std::vector<Eigen::Vector3d> corners);
 
-            /*!
-             * \brief global_index Gets the cells global index in its parent grid.
-             */
-            int global_index() const { return global_index_; }
+  void SetProperties(bool is_active,
+                float porosity,
+                float permx, float permy, float permz);
 
-            /*!
-             * \brief ijk_index Gets the cells (i, j, k) index in its parent grid.
-             */
-            IJKCoordinate ijk_index() const { return ijk_index_; }
+  /*!
+   * \brief global_index Gets the cells global index in its parent grid.
+   */
+  int global_index() const { return global_index_; }
 
-            /*!
-             * \brief volume Gets the cells volume.
-             */
-            double volume() const { return volume_; }
+  /*!
+   * \brief ijk_index Gets the cells (i, j, k) index in its parent grid.
+   */
+  IJKCoordinate ijk_index() const { return ijk_index_; }
 
-            /*!
-             * \brief porosity Gets the cell's porosity.
-             */
-            double porosity() const { return porosity_; }
+  /*!
+   * \brief volume Gets the cells volume.
+   */
+  float volume() const { return volume_; }
 
-            /*!
-             * \brief porosity Gets the cell's x-permeability.
-             */
-            double permx() const { return permx_; }
+  /*!
+   * \brief porosity Gets the cell's porosity.
+   */
+  float porosity() const { return porosity_; }
 
-            /*!
-             * \brief porosity Gets the cell's y-permeability.
-             */
-            double permy() const { return permy_; }
+  /*!
+   * \brief porosity Gets the cell's x-permeability.
+   */
+  float permx() const { return permx_; }
 
-            /*!
-             * \brief porosity Gets the cell's z-permeability.
-             */
-            double permz() const { return permz_; }
+  /*!
+   * \brief porosity Gets the cell's y-permeability.
+   */
+  float permy() const { return permy_; }
 
+  /*!
+   * \brief porosity Gets the cell's z-permeability.
+   */
+  float permz() const { return permz_; }
 
-            /*!
-             * \brief center Gets the (x, y, z) position of the cells center.
-             * \todo Find how these are computed by ERT
-             */
-            Eigen::Vector3d center() const { return center_; }
-
-            /*!
-             * \brief corners Gets the (x, y, z) coordinates of each of the
-             * cell's 8 corners.
-             *
-             * The first four elements represent the corners in the top layer,
-             * the four last represent the corners in the bottom layer:
-             *
-             * Top:    Bottom:
-             * 2---3    6---7
-             * |   |    |   |
-             * 0---1    4---5
-             *
-             */
-            std::vector<Eigen::Vector3d> corners() const { return corners_; }
-
-            /*!
-             * \brief Equals Check if the global indices of the two cells being
-             * compared are equal.
-             */
-            bool Equals(const Cell *other) const;
-            bool Equals(const Cell &other) const;
-
-            /*!
-             * \brief Check whether a given point is inside or on the boundary
-             * of a cell. This function has similar logic as the function
-             * Face.point_on_same_side() defined below.
-             *
-             * A vector vA is defined by the line between a point and (the first)
-             * corner of a face, while vector vB is the normal vector of the face.
-             *
-             * If vA.dot(vB) = 0, then the two vectors are orthogonal and the point
-             * resides on the face plane. However, if vA.dot(vB) < 0 then the angle
-             * between vA and vB is larger than 90deg, and the point is outside the
-             * cell.
-             *
-             *
-             *      +--------+
-             *     /        /|
-             *    /        / |
-             *   +--------+  |
-             *   |        |  |
-             *   |        |  +
-             *   |        | /
-             *   |        |/
-             *   +--------+
-             *
-             *                 o
-             *                /|\
-             *               / | \
-             *              /  |  \
-             *             /   |   \
-             *            /    |    \
-             *           /     |     \
-             *          +      |      \
-             *          |      |       \
-             *          |      |        \___
-             *  +_______|________________\_|_____________>
-             *          |      |
-             *          |      |
-             *          |      |
-             *          |      +
-             *          |     /
-             *          |    /
-             *          |   /
-             *          |  /
-             *          | /
-             *          |/
-             *          +
-             *
-             *
-             * Conversely, if vA.dot(vB) > 0 then the vector defined by the point
-             * (vB) makes an acute angle with the normal vector (vA) and the point
-             * is thus inside the cell.
-             */
-            bool EnvelopsPoint(Eigen::Vector3d point);
-
-            /*!
-             * \brief Face Struc that contains coordinate information about
-             * a single face, i.e., its corners, and normal vector. Also, it
-             * includes two functions that 1) determine the position a point
-             * relative to the face, and 2) finds the point of intersection
-             * of a line traversing the plane.
-             */
-            struct Face {
-                std::vector<Eigen::Vector3d> corners;
-                Eigen::Vector3d normal_vector;
-
-                /*!
-                 * \brief point_on_same_side returns true if point is on the same
-                 * side of this plane, true if it is in the plane, and false if
-                 * it's on the other side.
-                 *
-                 * In the function, a dot product helps us determine if the angle
-                 * between the two vectors is below (positive answer), at (zero
-                 * answer) or above (negative answer) 90 degrees. Essentially
-                 * telling us which side of a plane the point is. See explanation
-                 * of EnvelopsPoint above.
-                 *
-                 * \param point The point to be checked.
-                 * \param slack A slack factor.
-                 * \return True if the point is on the same side as the normal
-                 * vector or in the plane; otherwise false.
-                 *
-                 * \todo Discuss what the magnitude of the slack should be
-                 */
-                bool point_on_same_side(const Eigen::Vector3d &point,
-                                        const double slack) {
-                    return (point - corners[0]).dot(normal_vector) >= 0.0 - slack;
-                }
-
-                /*!
-                 * \brief Find the point of intersection between a line and this plane.
-                 *
-                 * \param p0 Point defining one end of the line.
-                 * \param p1 Point defining other end of the line.
-                 * \return The point of intersection.
-                 */
-                Eigen::Vector3d intersection_with_line(const Eigen::Vector3d &p0,
-                                                       const Eigen::Vector3d &p1) {
-                    Eigen::Vector3d line_vector = (p1 - p0).normalized();
-                      auto w = p0 - corners[0];
-                    double s = normal_vector.dot(-w) / normal_vector.dot(line_vector);
-                    return p0 + s*line_vector;
-                }
-            };
-
-            /*!
-             * \brief Vector containing the six faces of the cell
-             *
-             */
-            std::vector<Face> faces() const { return faces_; }
+  /*!
+   * @brief Check whether or not a cell is active. Note that before
+   * SetProperties is called, all cells are assumed to be active.
+   * @return
+   */
+  bool is_active() const { return is_active_; }
 
 
-        private:
-            int global_index_;
-            IJKCoordinate ijk_index_;
-            double volume_;
-            Eigen::Vector3d center_;
-            std::vector<Eigen::Vector3d> corners_;
-            double porosity_;
-            double permx_;
-            double permy_;
-            double permz_;
-            std::vector<Face> faces_;
+  /*!
+   * \brief center Gets the (x, y, z) position of the cells center.
+   * \todo Find how these are computed by ERT
+   */
+  Eigen::Vector3d center() const { return center_; }
 
-            /*!
-             * \brief Populates the faces_ field.
-             *
-             * Generates a double array with the numbers of 3 corners
-             * from each of the 6 faces of this cell that will be used
-             * to create a normal vector for each face.
+  /*!
+   * \brief corners Gets the (x, y, z) coordinates of each of the
+   * cell's 8 corners.
+   *
+   * The first four elements represent the corners in the top layer,
+   * the four last represent the corners in the bottom layer:
+   *
+   * Top:    Bottom:
+   * 2---3    6---7
+   * |   |    |   |
+   * 0---1    4---5
+   *
+   */
+  std::vector<Eigen::Vector3d> corners() const { return corners_; }
 
-             * \todo Clarify this comment.
+  /*!
+   * \brief Equals Check if the global indices of the two cells being
+   * compared are equal.
+   */
+  bool Equals(const Cell *other) const;
+  bool Equals(const Cell &other) const;
 
-             * \return double list of corner numbers for each face
-             */
-            void initializeFaces();
-        };
+  /*!
+   * \brief Check whether a given point is inside or on the boundary
+   * of a cell. This function has similar logic as the function
+   * Face.point_on_same_side() defined below.
+   *
+   * A vector vA is defined by the line between a point and (the first)
+   * corner of a face, while vector vB is the normal vector of the face.
+   *
+   * If vA.dot(vB) = 0, then the two vectors are orthogonal and the point
+   * resides on the face plane. However, if vA.dot(vB) < 0 then the angle
+   * between vA and vB is larger than 90deg, and the point is outside the
+   * cell.
+   *
+   *
+   *      +--------+
+   *     /        /|
+   *    /        / |
+   *   +--------+  |
+   *   |        |  |
+   *   |        |  +
+   *   |        | /
+   *   |        |/
+   *   +--------+
+   *
+   *                 o
+   *                /|\
+   *               / | \
+   *              /  |  \
+   *             /   |   \
+   *            /    |    \
+   *           /     |     \
+   *          +      |      \
+   *          |      |       \
+   *          |      |        \___
+   *  +_______|________________\_|_____________>
+   *          |      |
+   *          |      |
+   *          |      |
+   *          |      +
+   *          |     /
+   *          |    /
+   *          |   /
+   *          |  /
+   *          | /
+   *          |/
+   *          +
+   *
+   *
+   * Conversely, if vA.dot(vB) > 0 then the vector defined by the point
+   * (vB) makes an acute angle with the normal vector (vA) and the point
+   * is thus inside the cell.
+   */
+  bool EnvelopsPoint(Eigen::Vector3d point);
 
+  /*!
+   * \brief Face Struc that contains coordinate information about
+   * a single face, i.e., its corners, and normal vector. Also, it
+   * includes two functions that 1) determine the position a point
+   * relative to the face, and 2) finds the point of intersection
+   * of a line traversing the plane.
+   */
+  struct Face {
+    std::vector<Eigen::Vector3d> corners;
+    Eigen::Vector3d normal_vector;
+
+    /*!
+     * \brief point_on_same_side returns true if point is on the same
+     * side of this plane, true if it is in the plane, and false if
+     * it's on the other side.
+     *
+     * In the function, a dot product helps us determine if the angle
+     * between the two vectors is below (positive answer), at (zero
+     * answer) or above (negative answer) 90 degrees. Essentially
+     * telling us which side of a plane the point is. See explanation
+     * of EnvelopsPoint above.
+     *
+     * \param point The point to be checked.
+     * \param slack A slack factor.
+     * \return True if the point is on the same side as the normal
+     * vector or in the plane; otherwise false.
+     *
+     * \todo Discuss what the magnitude of the slack should be
+     */
+    bool point_on_same_side(const Eigen::Vector3d &point,
+                            const double slack) {
+        return (point - corners[0]).dot(normal_vector) >= 0.0 - slack;
     }
+
+    /*!
+     * \brief Find the point of intersection between a line and this plane.
+     *
+     * \param p0 Point defining one end of the line.
+     * \param p1 Point defining other end of the line.
+     * \return The point of intersection.
+     */
+    Eigen::Vector3d intersection_with_line(const Eigen::Vector3d &p0,
+                                           const Eigen::Vector3d &p1) {
+        Eigen::Vector3d line_vector = (p1 - p0).normalized();
+        auto w = p0 - corners[0];
+        double s = normal_vector.dot(-w) / normal_vector.dot(line_vector);
+        return p0 + s*line_vector;
+    }
+  };
+
+  /*!
+   * \brief Vector containing the six faces of the cell
+   *
+   */
+  std::vector<Face> faces() const { return faces_; }
+
+
+ private:
+  int global_index_;
+  IJKCoordinate ijk_index_;
+  bool is_active_; //!< Indicates whether or not the cell is active.
+  float volume_;
+  Eigen::Vector3d center_;
+  std::vector<Eigen::Vector3d> corners_;
+  float porosity_;
+  float permx_;
+  float permy_;
+  float permz_;
+  std::vector<Face> faces_;
+
+  /*!
+   * \brief Populates the faces_ field.
+   *
+   * Generates a double array with the numbers of 3 corners
+   * from each of the 6 faces of this cell that will be used
+   * to create a normal vector for each face.
+
+   * \todo Clarify this comment.
+
+   * \return double list of corner numbers for each face
+   */
+  void initializeFaces();
+};
+
+}
 }
 
 #endif // CELL_H

--- a/FieldOpt/Reservoir/grid/eclgrid.cpp
+++ b/FieldOpt/Reservoir/grid/eclgrid.cpp
@@ -118,14 +118,21 @@ Cell ECLGrid::GetCell(int global_index)
     // Return cell info
     return Cell(global_index,
                 ijk_index,
-                ertCell.volume, ertCell.porosity,
-                ertCell.permx, ertCell.permy, ertCell.permz,
+                ertCell.volume,
                 center, corners);
   }
   else{
     throw runtime_error("ECLGrid::GetCell(int global_index): Grid "
                             "source must be defined before getting a cell.");
   }
+}
+
+void ECLGrid::FillCellProperties(Cell &cell) {
+    auto props = ecl_grid_reader_->GetCellProperties(cell.global_index());
+    cell.SetProperties(props.is_active,
+                       props.porosity,
+                       props.permx, props.permy, props.permz
+    );
 }
 
 Cell ECLGrid::GetCell(int i, int j, int k)

--- a/FieldOpt/Reservoir/grid/eclgrid.h
+++ b/FieldOpt/Reservoir/grid/eclgrid.h
@@ -34,23 +34,24 @@ namespace Grid {
  */
 class ECLGrid : public Grid
 {
-public:
-    ECLGrid(std::string file_path);
-    virtual ~ECLGrid();
+ public:
+  ECLGrid(std::string file_path);
+  virtual ~ECLGrid();
 
-    Dims Dimensions();
-    Cell GetCell(int global_index);
-    Cell GetCell(int i, int j, int k);
-    Cell GetCell(IJKCoordinate* ijk);
-    Cell GetCellEnvelopingPoint(double x, double y, double z);
-    Cell GetCellEnvelopingPoint(Eigen::Vector3d xyz);
+  Dims Dimensions() override;
+  Cell GetCell(int global_index) override;
+  Cell GetCell(int i, int j, int k) override;
+  Cell GetCell(IJKCoordinate* ijk) override;
+  void FillCellProperties(Cell &cell) override;
+  Cell GetCellEnvelopingPoint(double x, double y, double z) override;
+  Cell GetCellEnvelopingPoint(Eigen::Vector3d xyz) override;
 
 
-private:
-    ERTWrapper::ECLGrid::ECLGridReader* ecl_grid_reader_ = 0;
-    bool IndexIsInsideGrid(int global_index); //!< Check that global_index is less than nx*ny*nz
-    bool IndexIsInsideGrid(int i, int j, int k); //!< Check that (i,j,k) are >= 0 and less than n*.
-    bool IndexIsInsideGrid(IJKCoordinate *ijk); //!< Check that (i,j,k) are >= 0 and less than n*.
+ private:
+  ERTWrapper::ECLGrid::ECLGridReader* ecl_grid_reader_ = 0;
+  bool IndexIsInsideGrid(int global_index); //!< Check that global_index is less than nx*ny*nz
+  bool IndexIsInsideGrid(int i, int j, int k); //!< Check that (i,j,k) are >= 0 and less than n*.
+  bool IndexIsInsideGrid(IJKCoordinate *ijk); //!< Check that (i,j,k) are >= 0 and less than n*.
 
 };
 

--- a/FieldOpt/Reservoir/grid/grid.h
+++ b/FieldOpt/Reservoir/grid/grid.h
@@ -26,68 +26,77 @@
 #include "ERTWrapper/eclgridreader.h"
 
 namespace Reservoir {
-    namespace Grid {
+namespace Grid {
 
-        /*!
-         * \brief The abstract Grid class represents a reservoir grid. It indcludes basic operations for lookup,
-         * checks and calculations on grids.
-         */
-        class Grid
-        {
-        public:
-            /*!
-             * \brief The GridSourceType enum Enumerates the supported grid types.
-             */
-            enum GridSourceType {ECLIPSE};
-            Grid(const Grid& other) = delete;
+/*!
+ * \brief The abstract Grid class represents a reservoir grid. It indcludes basic operations for lookup,
+ * checks and calculations on grids.
+ */
+class Grid
+{
+ public:
+  /*!
+   * \brief The GridSourceType enum Enumerates the supported grid types.
+   */
+  enum GridSourceType {ECLIPSE};
+  Grid(const Grid& other) = delete;
 
-            /*!
-             * \brief The Dims struct Contains the grid dimensions.
-             */
-            struct Dims {
-                int nx; int ny; int nz;
-            };
+  /*!
+   * \brief The Dims struct Contains the grid dimensions.
+   */
+  struct Dims {
+    int nx; int ny; int nz;
+  };
 
-            virtual ~Grid();
+  virtual ~Grid();
 
-            /*!
-             * \brief Dimensions Returns the grid dimensions (number of blocks in x, y and z directions).
-             * \return
-             */
-            virtual Dims Dimensions() = 0;
+  /*!
+   * \brief Dimensions Returns the grid dimensions (number of blocks in x, y and z directions).
+   * \return
+   */
+  virtual Dims Dimensions() = 0;
 
-            /*!
-             * \brief GetCell Get a cell from its global index.
-             */
-            virtual Cell GetCell(int global_index) = 0;
+  /*!
+   * \brief GetCell Get a cell from its global index.
+   * \note This only gets the cell geometry.
+   */
+  virtual Cell GetCell(int global_index) = 0;
 
-            /*!
-             * \brief GetCell Get a cell from its (i,j,k) index.
-             */
-            virtual Cell GetCell(int i, int j, int k) = 0;
+  /*!
+   * \brief GetCell Get a cell from its (i,j,k) index.
+   * \note This only gets the cell geometry.
+   */
+  virtual Cell GetCell(int i, int j, int k) = 0;
 
-            /*!
-             * \brief GetCell Get a cell from its (i,j,k) index.
-             */
-            virtual Cell GetCell(IJKCoordinate* ijk) = 0;
+  /*!
+   * \brief GetCell Get a cell from its (i,j,k) index.
+   * \note This only gets the cell geometry.
+   */
+  virtual Cell GetCell(IJKCoordinate* ijk) = 0;
 
-            /*!
-             * \brief GetCellEnvelopingPoint Get the cell enveloping the point (x,y,z). Throws an exception if no cell is found.
-             */
-            virtual Cell GetCellEnvelopingPoint(double x, double y, double z) = 0;
+  /*!
+   * @brief Fill in the non-geometry properties of a cell/
+   * @param cell The cell to get the properties for.
+   */
+  virtual void FillCellProperties(Cell &cell) = 0;
 
-            /*!
-             * \brief GetCellEnvelopingPoint Get the cell enveloping the point (x,y,z). Throws an exception if no cell is found.
-             */
-            virtual Cell GetCellEnvelopingPoint(Eigen::Vector3d xyz) = 0;
+  /*!
+   * \brief GetCellEnvelopingPoint Get the cell enveloping the point (x,y,z). Throws an exception if no cell is found.
+   */
+  virtual Cell GetCellEnvelopingPoint(double x, double y, double z) = 0;
 
-        protected:
-            GridSourceType type_;
-            std::string file_path_;
-            Grid(GridSourceType type, std::string file_path);
-        };
+  /*!
+   * \brief GetCellEnvelopingPoint Get the cell enveloping the point (x,y,z). Throws an exception if no cell is found.
+   */
+  virtual Cell GetCellEnvelopingPoint(Eigen::Vector3d xyz) = 0;
 
-    }
+ protected:
+  GridSourceType type_;
+  std::string file_path_;
+  Grid(GridSourceType type, std::string file_path);
+};
+
+}
 }
 
 

--- a/FieldOpt/Reservoir/tests/grid/test_cell.cpp
+++ b/FieldOpt/Reservoir/tests/grid/test_cell.cpp
@@ -26,85 +26,86 @@ using namespace Reservoir::Grid;
 
 namespace {
 
-    class CellTest : public ::testing::Test, TestResources::TestResourceGrids {
-    protected:
-        CellTest() {
-            grid_ = grid_horzwel_;
-        }
+class CellTest : public ::testing::Test, TestResources::TestResourceGrids {
+ protected:
+  CellTest() {
+      grid_ = grid_horzwel_;
+  }
 
-        virtual ~CellTest() { }
-        virtual void SetUp() { }
-        virtual void TearDown() { }
+  virtual ~CellTest() { }
+  virtual void SetUp() { }
+  virtual void TearDown() { }
 
-        Grid *grid_;
-    };
+  Grid *grid_;
+};
 
-    TEST_F(CellTest, Equality) {
-        Cell cell_1 = grid_->GetCell(1); // Equal to cell_2_
-        Cell cell_2 = grid_->GetCell(1, 0, 0); // Equal to cell_1_
-        Cell cell_3 = grid_->GetCell(0);
-        EXPECT_TRUE(cell_1.Equals(cell_2));
-        EXPECT_FALSE(cell_1.Equals(cell_3));
-    }
+TEST_F(CellTest, Equality) {
+    Cell cell_1 = grid_->GetCell(1); // Equal to cell_2_
+    Cell cell_2 = grid_->GetCell(1, 0, 0); // Equal to cell_1_
+    Cell cell_3 = grid_->GetCell(0);
+    EXPECT_TRUE(cell_1.Equals(cell_2));
+    EXPECT_FALSE(cell_1.Equals(cell_3));
+}
 
-    TEST_F(CellTest, GlobalIndex) {
-        Cell cell = grid_->GetCell(5, 0, 0);
-        EXPECT_EQ(cell.global_index(), 5);
-    }
+TEST_F(CellTest, GlobalIndex) {
+    Cell cell = grid_->GetCell(5, 0, 0);
+    EXPECT_EQ(cell.global_index(), 5);
+}
 
-    TEST_F(CellTest, IJKIndex) {
-        Cell cell = grid_->GetCell(10);
-        EXPECT_TRUE(cell.ijk_index().Equals(new IJKCoordinate(10, 0, 0)));
-    }
+TEST_F(CellTest, IJKIndex) {
+    Cell cell = grid_->GetCell(10);
+    EXPECT_TRUE(cell.ijk_index().Equals(new IJKCoordinate(10, 0, 0)));
+}
 
-    TEST_F(CellTest, Volume) {
-        Cell cell = grid_->GetCell(0);
-        EXPECT_EQ(cell.volume(), 1.5e+06);
-    }
+TEST_F(CellTest, Volume) {
+    Cell cell = grid_->GetCell(0);
+    EXPECT_EQ(cell.volume(), 1.5e+06);
+}
 
-    TEST_F(CellTest, Center) {
-        Cell cell = grid_->GetCell(0);
-        Eigen::Vector3d center = Eigen::Vector3d(50.0, 150.0, 7025.0);
-        EXPECT_TRUE(cell.center() == center);
-    }
+TEST_F(CellTest, Center) {
+    Cell cell = grid_->GetCell(0);
+    Eigen::Vector3d center = Eigen::Vector3d(50.0, 150.0, 7025.0);
+    EXPECT_TRUE(cell.center() == center);
+}
 
-    TEST_F(CellTest, Corners) {
-        auto corners = grid_->GetCell(0).corners();
+TEST_F(CellTest, Corners) {
+    auto corners = grid_->GetCell(0).corners();
 
-        // Top layer
-        Eigen::Vector3d top_sw = Eigen::Vector3d(0.0, 0.0, 7000.0);
-        EXPECT_TRUE(corners[0] == top_sw);
+    // Top layer
+    Eigen::Vector3d top_sw = Eigen::Vector3d(0.0, 0.0, 7000.0);
+    EXPECT_TRUE(corners[0] == top_sw);
 
-        Eigen::Vector3d top_se = Eigen::Vector3d(100.0, 0.0, 7000.0);
-        EXPECT_TRUE(corners[1] == top_se);
+    Eigen::Vector3d top_se = Eigen::Vector3d(100.0, 0.0, 7000.0);
+    EXPECT_TRUE(corners[1] == top_se);
 
-        Eigen::Vector3d top_nw = Eigen::Vector3d(0.0, 300.0, 7000.0);
-        EXPECT_TRUE(corners[2] == top_nw);
+    Eigen::Vector3d top_nw = Eigen::Vector3d(0.0, 300.0, 7000.0);
+    EXPECT_TRUE(corners[2] == top_nw);
 
-        Eigen::Vector3d top_ne = Eigen::Vector3d(100.0, 300.0, 7000.0);
-        EXPECT_TRUE(corners[3] == top_ne);
+    Eigen::Vector3d top_ne = Eigen::Vector3d(100.0, 300.0, 7000.0);
+    EXPECT_TRUE(corners[3] == top_ne);
 
-        // Bottom layer
-        Eigen::Vector3d bottom_sw = Eigen::Vector3d(0.0, 0.0, 7050.0);
-        EXPECT_TRUE(corners[4] == bottom_sw);
+    // Bottom layer
+    Eigen::Vector3d bottom_sw = Eigen::Vector3d(0.0, 0.0, 7050.0);
+    EXPECT_TRUE(corners[4] == bottom_sw);
 
-        Eigen::Vector3d bottom_se = Eigen::Vector3d(100.0, 0.0, 7050.0);
-        EXPECT_TRUE(corners[5] == bottom_se);
+    Eigen::Vector3d bottom_se = Eigen::Vector3d(100.0, 0.0, 7050.0);
+    EXPECT_TRUE(corners[5] == bottom_se);
 
-        Eigen::Vector3d bottom_nw = Eigen::Vector3d(0.0, 300.0, 7050.0);
-        EXPECT_TRUE(corners[6] == bottom_nw);
+    Eigen::Vector3d bottom_nw = Eigen::Vector3d(0.0, 300.0, 7050.0);
+    EXPECT_TRUE(corners[6] == bottom_nw);
 
-        Eigen::Vector3d bottom_ne = Eigen::Vector3d(100.0, 300.0, 7050.0);
-        EXPECT_TRUE(corners[7] == bottom_ne);
-    }
+    Eigen::Vector3d bottom_ne = Eigen::Vector3d(100.0, 300.0, 7050.0);
+    EXPECT_TRUE(corners[7] == bottom_ne);
+}
 
-    TEST_F(CellTest, Properties) {
-        auto cell = grid_->GetCell(1);
-        EXPECT_FLOAT_EQ(0.25, cell.porosity());
-        EXPECT_FLOAT_EQ(100, cell.permx());
-        EXPECT_FLOAT_EQ(100, cell.permy());
-        EXPECT_FLOAT_EQ(5, cell.permz());
-    }
+TEST_F(CellTest, Properties) {
+    auto cell = grid_->GetCell(1);
+    grid_->FillCellProperties(cell);
+    EXPECT_FLOAT_EQ(0.25, cell.porosity());
+    EXPECT_FLOAT_EQ(100, cell.permx());
+    EXPECT_FLOAT_EQ(100, cell.permy());
+    EXPECT_FLOAT_EQ(5, cell.permz());
+}
 
 }
 


### PR DESCRIPTION
The changes in this pull request were done because a bug was discovered when attempting to run with the Norne reservoir model: when we attempt to retrieve properties from the `INIT` file for inactive cells, ERT crashes.

**ERTWrapper library**
The `ERTWrapper::ECLGrid::GetGridCell` function was changed to only retrieve cell geometry data, which is available for all cells, whether they are active or not. The other properties, porosity and permeabilities, are now gotten by calling the new `GetCellProperties` function. A new `CellProperties` struct was created to hold these data.

**Reservoir library**
Changes were made in the Reservoir library to acommodate the changes in the ERTWrapper library. Most importantly, `GetCell` now returns a cell with geometry data, but porosity and permeabilities set to zero. A new `Grid::FillCellProperties(&Cell)` function was created to allow for "on-demand" retrieval of this information when needed.

**WellIndexCalculator**
See the corresponding PR in the WIC repo: PetroleumCyberneticsGroup/FieldOpt-WellIndexCalculator#8

**A note on performance gains**
A side effect of these changes is a performance gain: the properties read from the `INIT` file are really only needed for the cells intersected by a well spline. Howevever, most of the cells retrieved, be it from constraints or when searching for intersected well blocks, only need the cell geometry. This we found it better to only retrieve these properties (and also only check if a cell is active) on demand when they are actually needed.