### PR TITLE
Implemented a `MaxMinutes` setting for simulations.

### DIFF
--- a/FieldOpt/Runner/runners/synchronous_mpi_runner.cpp
+++ b/FieldOpt/Runner/runners/synchronous_mpi_runner.cpp
@@ -124,9 +124,13 @@ void SynchronousMPIRunner::Execute() {
                 printMessage("Applying case to model.", 2);
                 model_->ApplyCase(worker_->GetCurrentCase());
                 auto start = QDateTime::currentDateTime();
-                if (simulation_times_.size() == 0 || runtime_settings_->simulation_timeout() == 0) {
+                if (runtime_settings_->simulation_timeout() == 0) {
                     printMessage("Starting model evaluation.", 2);
                     simulator_->Evaluate();
+                }
+                else if (simulation_times_.size() == 0 && settings_->simulator()->max_minutes() > 0) {
+                    simulation_success = simulator_->Evaluate(settings_->simulator()->max_minutes() * 60,
+                                                              runtime_settings_->threads_per_sim());
                 }
                 else {
                     printMessage("Starting model evaluation with timeout.", 2);

--- a/FieldOpt/Runner/runners/synchronous_mpi_runner.cpp
+++ b/FieldOpt/Runner/runners/synchronous_mpi_runner.cpp
@@ -124,7 +124,7 @@ void SynchronousMPIRunner::Execute() {
                 printMessage("Applying case to model.", 2);
                 model_->ApplyCase(worker_->GetCurrentCase());
                 auto start = QDateTime::currentDateTime();
-                if (runtime_settings_->simulation_timeout() == 0) {
+                if (runtime_settings_->simulation_timeout() == 0 && settings_->simulator()->max_minutes() < 0) {
                     printMessage("Starting model evaluation.", 2);
                     simulator_->Evaluate();
                 }

--- a/FieldOpt/Settings/README.md
+++ b/FieldOpt/Settings/README.md
@@ -211,6 +211,7 @@ In the simulator section we define settings and parameters needed to launch the 
 ```
 "Simulator": {
 	"Type": string,
+	"MaxMinutes": int
 	"Commands": string array,
 	"ExecutionScript": string,
 	"DriverPath": string,
@@ -221,6 +222,7 @@ In the simulator section we define settings and parameters needed to launch the 
 Note that the simulator driver path may be omitted from the driver file. If it is, the path must be passed as a command line parameter. If a path is specified both places, the one passed in the command line will be used.
 
 * `Type` denotes the simulator to be used. Currently, the only supported simulatorsare `ECLIPSE` and `ADGPRS`.
+* `MaxMinutes` is the maximum number of minutes a simulation is allowed to run if a "normal" timeout value cannot be calculated.
 * `Commands` is an array of (BASH) commands that should be executed in order to start the simulator.
 * `ExecutionScript` is the name of a script found in the `FieldOpt/execution_scripts` folder that should be used to execute simulations. The name should be given without the suffix (e.g. `"ExecutionScript": "csh_eclrun"`). If defined, this will override any commands given.
 * `DriverPath` is the path to a complete driver file for the model (e.g. the one run to generate the grid files). Fluid functions, rock properties etc. is taken from this file. This may be omitted.

--- a/FieldOpt/Settings/simulator.cpp
+++ b/FieldOpt/Settings/simulator.cpp
@@ -1,48 +1,75 @@
+/******************************************************************************
+   Copyright (C) 2015-2017 Einar J.M. Baumann <einar.baumann@gmail.com>
+
+   This file is part of the FieldOpt project.
+
+   FieldOpt is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   FieldOpt is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with FieldOpt.  If not, see <http://www.gnu.org/licenses/>.
+******************************************************************************/
+
 #include "simulator.h"
 #include "settings_exceptions.h"
 
 namespace Settings {
 
-    Simulator::Simulator(QJsonObject json_simulator)
-    {
-        // Driver path
-        if (json_simulator.contains("DriverPath"))
-            driver_file_path_ = json_simulator["DriverPath"].toString();
-        else driver_file_path_ = "";
+Simulator::Simulator(QJsonObject json_simulator)
+{
+    // Driver path
+    if (json_simulator.contains("DriverPath"))
+        driver_file_path_ = json_simulator["DriverPath"].toString();
+    else driver_file_path_ = "";
 
-        // Simulator type
-        QString type = json_simulator["Type"].toString();
-        if (QString::compare(type, "ECLIPSE") == 0)
-            type_ = SimulatorType::ECLIPSE;
-        else if (QString::compare(type, "ADGPRS") == 0)
-            type_ = SimulatorType::ADGPRS;
-        else if (QString::compare(type, "Flow", Qt::CaseInsensitive) == 0)
-            type_ = SimulatorType::Flow;
-        else throw SimulatorTypeNotRecognizedException("The simulator type " + type.toStdString() + " was not recognized");
+    // Simulator type
+    QString type = json_simulator["Type"].toString();
+    if (QString::compare(type, "ECLIPSE") == 0)
+        type_ = SimulatorType::ECLIPSE;
+    else if (QString::compare(type, "ADGPRS") == 0)
+        type_ = SimulatorType::ADGPRS;
+    else if (QString::compare(type, "Flow", Qt::CaseInsensitive) == 0)
+        type_ = SimulatorType::Flow;
+    else throw SimulatorTypeNotRecognizedException("The simulator type " + type.toStdString() + " was not recognized");
 
-        // Simulator commands
-        QJsonArray commands = json_simulator["Commands"].toArray();
-        script_name_ = "";
-        if (json_simulator.contains("ExecutionScript") && json_simulator["ExecutionScript"].toString().size() > 0) {
-            script_name_ = json_simulator["ExecutionScript"].toString();
-        }
-        if (json_simulator.contains("Commands") && commands.size() > 0) {
-            commands_ = new QStringList();
-            for (int i = 0; i < commands.size(); ++i) {
-                commands_->append(commands[i].toString());
-            }
-        }
-        if (script_name_.length() == 0 && commands.size() == 0)
-            throw NoSimulatorCommandsGivenException("At least one simulator command or a simulator script must be given.");
-
-        if (json_simulator.contains("FluidModel")) {
-            QString fluid_model = json_simulator["FluidModel"].toString();
-            if (QString::compare(fluid_model, "DeadOil") == 0)
-                fluid_model_ = SimulatorFluidModel::DeadOil;
-            else if (QString::compare(fluid_model, "BlackOil") == 0)
-                fluid_model_ = SimulatorFluidModel::BlackOil;
-        }
-        else fluid_model_ = SimulatorFluidModel::BlackOil;
+    // Maximum runtime
+    if (json_simulator.contains("MaxMinutes") && json_simulator["MaxMinutes"].toInt() > 0) {
+        max_minutes_ = json_simulator["MaxMinutes"].toInt();
     }
+    else {
+        max_minutes_ = -1;
+    }
+
+    // Simulator commands
+    QJsonArray commands = json_simulator["Commands"].toArray();
+    script_name_ = "";
+    if (json_simulator.contains("ExecutionScript") && json_simulator["ExecutionScript"].toString().size() > 0) {
+        script_name_ = json_simulator["ExecutionScript"].toString();
+    }
+    if (json_simulator.contains("Commands") && commands.size() > 0) {
+        commands_ = new QStringList();
+        for (int i = 0; i < commands.size(); ++i) {
+            commands_->append(commands[i].toString());
+        }
+    }
+    if (script_name_.length() == 0 && commands.size() == 0)
+        throw NoSimulatorCommandsGivenException("At least one simulator command or a simulator script must be given.");
+
+    if (json_simulator.contains("FluidModel")) {
+        QString fluid_model = json_simulator["FluidModel"].toString();
+        if (QString::compare(fluid_model, "DeadOil") == 0)
+            fluid_model_ = SimulatorFluidModel::DeadOil;
+        else if (QString::compare(fluid_model, "BlackOil") == 0)
+            fluid_model_ = SimulatorFluidModel::BlackOil;
+    }
+    else fluid_model_ = SimulatorFluidModel::BlackOil;
+}
 
 }

--- a/FieldOpt/Settings/simulator.h
+++ b/FieldOpt/Settings/simulator.h
@@ -1,3 +1,22 @@
+/******************************************************************************
+   Copyright (C) 2015-2017 Einar J.M. Baumann <einar.baumann@gmail.com>
+
+   This file is part of the FieldOpt project.
+
+   FieldOpt is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   FieldOpt is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with FieldOpt.  If not, see <http://www.gnu.org/licenses/>.
+******************************************************************************/
+
 #ifndef SETTINGS_SIMULATOR_H
 #define SETTINGS_SIMULATOR_H
 
@@ -12,34 +31,36 @@ namespace Settings {
  * may _only_ be created by the Settings class. They are created when reading a JSON-formatted
  * "driver file".
  */
-    class Simulator
-    {
-        friend class Settings;
+class Simulator
+{
+  friend class Settings;
 
-    public:
-        enum SimulatorType { ECLIPSE, ADGPRS, Flow };
-        enum SimulatorFluidModel { BlackOil, DeadOil };
+ public:
+  enum SimulatorType { ECLIPSE, ADGPRS, Flow };
+  enum SimulatorFluidModel { BlackOil, DeadOil };
 
-        SimulatorType type() const { return type_; } //!< Get the simulator type (e.g. ECLIPSE).
-        QStringList *commands() const { return commands_; } //!< Get the simulator commands (commands used to execute a simulation). Each list element is executed in sequence.
-        QString script_name() const { return script_name_; } //!< Get the name of the script to be used to execute simulations.
-        QString driver_file_path() const { return driver_file_path_; } //!< Get the path to the driver file.
-        void set_driver_file_path(const QString path) { driver_file_path_ = path; } //!< Set the driver file path. Used when the path is passed by command line argument.
-        void set_execution_script_path (const QString path) { custom_exec_script_path_ = path; } //!< Set a custom path for the simulator execution script.
-        QString custom_simulator_execution_script_path() const { return custom_exec_script_path_; } //!< Get the path to the simulator execution script.
-        QString output_directory() const { return output_directory_; } //!< Get the output directory path.
-        SimulatorFluidModel fluid_model() const { return fluid_model_; } //!< Get the fluid model
+  SimulatorType type() const { return type_; } //!< Get the simulator type (e.g. ECLIPSE).
+  QStringList *commands() const { return commands_; } //!< Get the simulator commands (commands used to execute a simulation). Each list element is executed in sequence.
+  QString script_name() const { return script_name_; } //!< Get the name of the script to be used to execute simulations.
+  QString driver_file_path() const { return driver_file_path_; } //!< Get the path to the driver file.
+  void set_driver_file_path(const QString path) { driver_file_path_ = path; } //!< Set the driver file path. Used when the path is passed by command line argument.
+  void set_execution_script_path (const QString path) { custom_exec_script_path_ = path; } //!< Set a custom path for the simulator execution script.
+  QString custom_simulator_execution_script_path() const { return custom_exec_script_path_; } //!< Get the path to the simulator execution script.
+  QString output_directory() const { return output_directory_; } //!< Get the output directory path.
+  SimulatorFluidModel fluid_model() const { return fluid_model_; } //!< Get the fluid model
+  int max_minutes() { return max_minutes_; } //!< Get the maximum number of minutes simulations are allowed to run if no timeout value can be calculated.
 
-    private:
-        Simulator(QJsonObject json_simulator);
-        SimulatorType type_;
-        SimulatorFluidModel fluid_model_;
-        QStringList *commands_;
-        QString script_name_;
-        QString driver_file_path_;
-        QString output_directory_;
-        QString custom_exec_script_path_;
-    };
+ private:
+  Simulator(QJsonObject json_simulator);
+  SimulatorType type_;
+  SimulatorFluidModel fluid_model_;
+  QStringList *commands_;
+  QString script_name_;
+  QString driver_file_path_;
+  QString output_directory_;
+  QString custom_exec_script_path_;
+  int max_minutes_;
+};
 
 }
 

--- a/FieldOpt/Settings/simulator.h
+++ b/FieldOpt/Settings/simulator.h
@@ -48,7 +48,7 @@ class Simulator
   QString custom_simulator_execution_script_path() const { return custom_exec_script_path_; } //!< Get the path to the simulator execution script.
   QString output_directory() const { return output_directory_; } //!< Get the output directory path.
   SimulatorFluidModel fluid_model() const { return fluid_model_; } //!< Get the fluid model
-  int max_minutes() { return max_minutes_; } //!< Get the maximum number of minutes simulations are allowed to run if no timeout value can be calculated.
+  int max_minutes() { return max_minutes_; } //!< Get the maximum number of minutes simulations are allowed to run if no timeout value can be calculated. Returns -1 if field is not set.
 
  private:
   Simulator(QJsonObject json_simulator);


### PR DESCRIPTION
This new field specifies a maximum number of minutes a simulator is allowed to run. This value will be used when a normal timeout value cannot be determined (e.g. in the first iteration). It is needed to avoid severe hangups in the first iteration for large reservoirs, particularly when used with a stochastic optimizer and a large number of workers.