### PR TITLE
Make the distiction between matrix and fracture grids. 

### DIFF
--- a/FieldOpt/ERTWrapper/eclgridreader.cpp
+++ b/FieldOpt/ERTWrapper/eclgridreader.cpp
@@ -162,7 +162,12 @@ bool ECLGridReader::IsCellActive(int global_index)
 bool ECLGridReader::IsCellMatrixActive(int global_index)
 {
     if (ecl_grid_ == 0) throw GridNotReadException("Grid must be read before getting the active status of cells.");
-    else return ecl_grid_cell_active1(ecl_grid_, global_index);
+    else 
+    {
+    	int active_matrix_index = ecl_grid_get_active_index1(ecl_grid_, global_index);
+    	if (active_matrix_index < 0) return false;
+    	else return true;
+    }
 }
 
 bool ECLGridReader::IsCellFractureActive(int global_index)
@@ -171,7 +176,7 @@ bool ECLGridReader::IsCellFractureActive(int global_index)
     else
     {
     	int active_fracture_index = ecl_grid_get_active_fracture_index1(ecl_grid_, global_index);
-    	if (active_fracture_index == -1) return false;
+    	if (active_fracture_index < 0) return false;
     	else return true;
     }
  }
@@ -194,7 +199,7 @@ ECLGridReader::Cell ECLGridReader::GetGridCell(int global_index)
     // Get properties from the INIT file - only possible if the cell is active
     // Matrix grid
 	int active_index = ecl_grid_get_active_index1(ecl_grid_, global_index);
-	if (active_index > 0)
+	if (active_index >= 0)
 	{
 		cell.porosity.push_back(ecl_kw_iget_as_double(poro_kw_, active_index));
 		cell.permx.push_back(ecl_kw_iget_as_double(permx_kw_, active_index));
@@ -204,7 +209,7 @@ ECLGridReader::Cell ECLGridReader::GetGridCell(int global_index)
     
 	// Fracture grid
 	active_index = ecl_grid_get_active_fracture_index1(ecl_grid_, global_index);
-	if (active_index > 0)
+	if (active_index >= 0)
 	{
 		cell.porosity.push_back(ecl_kw_iget_as_double(poro_kw_, active_index));
 		cell.permx.push_back(ecl_kw_iget_as_double(permx_kw_, active_index));

--- a/FieldOpt/ERTWrapper/eclgridreader.h
+++ b/FieldOpt/ERTWrapper/eclgridreader.h
@@ -130,6 +130,14 @@ class ECLGridReader
   int ConvertIJKToGlobalIndex(int i, int j, int k);
 
   /*!
+   * \brief ConvertMatrixActiveIndexToGlobalIndex Converts a zero-offset index in the set of cells active in the matrix grid 
+   * to the global index.
+   * \param index Zero-offset index for a cell active in the matrix grid
+   * \return global index
+   */
+  int ConvertMatrixActiveIndexToGlobalIndex(int index);
+  
+  /*!
    * \brief ConvertGlobalIndexToIJK Converts a global index for a cell
    * to the corresponding zero-offset (i,j,k) coordinates.
    * \param global_index Global index for a cell.
@@ -144,7 +152,7 @@ class ECLGridReader
   Dims Dimensions();
 
   /*!
-   * \brief NumActiveMatrixCells Number of active cells in the matrix in the grid that has been read.
+   * \brief NumActiveCells Number of active cells in the matrix in the grid that has been read.
    */
   int NumActiveMatrixCells();
 
@@ -152,7 +160,13 @@ class ECLGridReader
    * \brief NumActiveFractureCells Number of active cells in the fracture grid that has been read.
    * This only makes sense for dual grids
    */
-  int NumActiveMatrixCells();
+  int NumActiveFractureCells();
+
+  /*!
+   * \brief IsCellActive returns false if the cell identified by its global index 
+   * is not active in the matrix grid nor in the fracture
+   */
+  bool IsCellActive(int global_index);
   
   /*!
    * \brief IsCellMatrixActive returns false if the cell identified by its global index 

--- a/FieldOpt/ERTWrapper/eclgridreader.h
+++ b/FieldOpt/ERTWrapper/eclgridreader.h
@@ -51,7 +51,20 @@ class ECLGridReader
    *
    * The cell struct also contains all non-geometric properties
    * for a cell, i.e. permeabilities, porosities, and whether or
-   * not the cell is active
+   * not the cell is active.
+   * 
+   * In case of a dual grid the active status of matrix and fracture
+   * will be recorded and the properties for all grids is stored. 
+   * 
+   * The ecl_grid specifies the active status is encoded as: 
+   *                  0 - inactive, 
+   *                  1 - active in matrix, 
+   *                  2 - active in fracture 
+   *                  3 - active in both.
+   * Here we use two booleans to store the active status.
+   * The properties are stored in a vector with one or two items depending
+   * on the active status. If the cell is active both in the matrix grid as 
+   * well as in the fracture grid the matrix values will be stored first.
    *
    * The corners list contains all the corner points specifying the grid.
    * The first four elements represent the corners in the lower layer,
@@ -66,12 +79,13 @@ class ECLGridReader
    */
   struct Cell {
     int global_index;
-    bool active;
+    bool matrix_active;
+    bool fracture_active;
     double volume;
-    double porosity;
-    double permx;
-    double permy;
-    double permz;
+    std::vector<double> porosity;
+    std::vector<double> permx;
+    std::vector<double> permy;
+    std::vector<double> permz;
     std::vector<Eigen::Vector3d> corners;
     Eigen::Vector3d center;
   };
@@ -130,15 +144,28 @@ class ECLGridReader
   Dims Dimensions();
 
   /*!
-   * \brief ActiveCells Number of active cells in the grid that has been read.
+   * \brief NumActiveMatrixCells Number of active cells in the matrix in the grid that has been read.
    */
-  int ActiveCells();
+  int NumActiveMatrixCells();
 
   /*!
-   * \brief IsCellActive returns false if the cell identified by its global index is not active
+   * \brief NumActiveFractureCells Number of active cells in the fracture grid that has been read.
+   * This only makes sense for dual grids
    */
-  bool IsCellActive(int global_index);
+  int NumActiveMatrixCells();
+  
+  /*!
+   * \brief IsCellMatrixActive returns false if the cell identified by its global index 
+   * is not active in the matrix grid
+   */
+  bool IsCellMatrixActive(int global_index);
 
+  /*!
+   * \brief IsCellFractureActive returns false if the cell identified by its global index 
+   * is not active in the facture grid in the case of dual grid
+   */
+  bool IsCellFractureActive(int global_index);
+  
   /*!
    * \brief GetGridCell get a Cell struct describing the cell with the specified global index.
    * \param global_index The global index of the cell to get.

--- a/FieldOpt/ERTWrapper/tests/test_eclgridreader.cpp
+++ b/FieldOpt/ERTWrapper/tests/test_eclgridreader.cpp
@@ -56,7 +56,7 @@ class ECLGridReaderTest : public ::testing::Test {
 };
 
 TEST_F(ECLGridReaderTest, ReadGrid) {
-    EXPECT_EQ(1620, ecl_grid_reader_->ActiveCells());
+    EXPECT_EQ(1620, ecl_grid_reader_->NumActiveMatrixCells());
 }
 
 TEST_F(ECLGridReaderTest, ConvertIJKToGlobalIndex) {
@@ -101,14 +101,14 @@ TEST_F(ECLGridReaderTest, GetCell) {
 TEST_F(ECLGridReaderTest, CellProperties) {
     auto cell_1 = ecl_grid_reader_->GetGridCell(1);
     auto cell_1000 = ecl_grid_reader_->GetGridCell(1000);
-    EXPECT_FLOAT_EQ(0.25, cell_1.porosity);
-    EXPECT_FLOAT_EQ(100, cell_1.permx);
-    EXPECT_FLOAT_EQ(100, cell_1.permy);
-    EXPECT_FLOAT_EQ(5, cell_1.permz);
-    EXPECT_FLOAT_EQ(0.25, cell_1000.porosity);
-    EXPECT_FLOAT_EQ(100, cell_1000.permx);
-    EXPECT_FLOAT_EQ(100, cell_1000.permy);
-    EXPECT_FLOAT_EQ(5, cell_1000.permz);
+    EXPECT_FLOAT_EQ(0.25, cell_1.porosity[0]);
+    EXPECT_FLOAT_EQ(100, cell_1.permx[0]);
+    EXPECT_FLOAT_EQ(100, cell_1.permy[0]);
+    EXPECT_FLOAT_EQ(5, cell_1.permz[0]);
+    EXPECT_FLOAT_EQ(0.25, cell_1000.porosity[0]);
+    EXPECT_FLOAT_EQ(100, cell_1000.permx[0]);
+    EXPECT_FLOAT_EQ(100, cell_1000.permy[0]);
+    EXPECT_FLOAT_EQ(5, cell_1000.permz[0]);
 }
 
 TEST_F(ECLGridReaderTest, GlobalIndexOfCellEncompasingPoint) {

--- a/FieldOpt/Reservoir/grid/cell.cpp
+++ b/FieldOpt/Reservoir/grid/cell.cpp
@@ -28,12 +28,12 @@ namespace Grid {
 using namespace std;
 
 Cell::Cell(int global_index, IJKCoordinate ijk_index,
-           double volume, double poro,
-           double permx, double permy, double permz,
+           double volume, vector<double> poro,
+           vector<double> permx, vector<double> permy, vector<double> permz,
            Eigen::Vector3d center,
            vector<Eigen::Vector3d> corners,
            int faces_permutation_index,
-           bool active)
+           bool active_matrix, bool active_fracture)
 {
     global_index_ = global_index;
     ijk_index_ = ijk_index;
@@ -44,7 +44,8 @@ Cell::Cell(int global_index, IJKCoordinate ijk_index,
     permz_ = permz;
     center_ = center;
     corners_ = corners;
-    is_active_ = active;
+    is_active_matrix_ = active_matrix;
+    is_active_fracture_ = active_fracture;
 
     initializeFaces(faces_permutation_index);
 }

--- a/FieldOpt/Reservoir/grid/cell.cpp
+++ b/FieldOpt/Reservoir/grid/cell.cpp
@@ -28,8 +28,8 @@ namespace Grid {
 using namespace std;
 
 Cell::Cell(int global_index, IJKCoordinate ijk_index,
-           double volume, vector<double> poro,
-           vector<double> permx, vector<double> permy, vector<double> permz,
+           double volume, vector<double> poro_in,
+           vector<double> permx_in, vector<double> permy_in, vector<double> permz_in,
            Eigen::Vector3d center,
            vector<Eigen::Vector3d> corners,
            int faces_permutation_index,
@@ -38,10 +38,10 @@ Cell::Cell(int global_index, IJKCoordinate ijk_index,
     global_index_ = global_index;
     ijk_index_ = ijk_index;
     volume_ = volume;
-    porosity_ = poro;
-    permx_ = permx;
-    permy_ = permy;
-    permz_ = permz;
+    porosity_ = poro_in;
+    permx_ = permx_in;
+    permy_ = permy_in;
+    permz_ = permz_in;
     center_ = center;
     corners_ = corners;
     is_active_matrix_ = active_matrix;

--- a/FieldOpt/Reservoir/grid/cell.h
+++ b/FieldOpt/Reservoir/grid/cell.h
@@ -41,20 +41,26 @@ class Cell
   Cell(){};
   Cell(int global_index,
        IJKCoordinate ijk_index,
-       double volume, double poro,
-       double permx, double permy, double permz,
+       double volume, 
+       vector<double> poro,
+       vector<double> permx, 
+       vector<double> permy, 
+       vector<double> permz,
        Eigen::Vector3d center,
        vector<Eigen::Vector3d> corners,
        int faces_permutation_index,
-       bool active
+       bool active_matrix, bool active_fracture
   );
 
   /*!
-   * \brief
+   * \brief Set cell properties at a later stage
    */
-  void SetProperties(bool is_active,
-                     float porosity,
-                     float permx, float permy, float permz);
+  void SetProperties(bool is_active_matrix,
+		  bool is_active_fracture,
+          vector<double> porosity,
+          vector<double> permx,
+          vector<double> permy,
+          vector<double> permz);
 
   /*!
    * \brief global_index Gets the cells global index in its parent grid.
@@ -69,36 +75,53 @@ class Cell
   /*!
    * \brief volume Gets the cells volume.
    */
-  float volume() const { return volume_; }
+  double volume() const { return volume_; }
 
   /*!
-   * \brief porosity Gets the cell's porosity.
+   * \brief porosity Gets the cell's porosity vector 
+   * One value for all grid in which it is active.
    */
-  float porosity() const { return porosity_; }
+  vector<double> porosity() const { return porosity_; }
 
   /*!
-   * \brief porosity Gets the cell's x-permeability.
+   * \brief porosity Gets the cell's x-permeability vector.
+   * One value for all grid in which it is active.
    */
-  float permx() const { return permx_; }
+  vector<double> permx() const { return permx_; }
 
   /*!
-   * \brief porosity Gets the cell's y-permeability.
+   * \brief porosity Gets the cell's y-permeability vector.
+   * One value for all grid in which it is active.
    */
-  float permy() const { return permy_; }
+  vector<double> permy() const { return permy_; }
 
   /*!
-   * \brief porosity Gets the cell's z-permeability.
+   * \brief porosity Gets the cell's z-permeability vector.
+   * One value for all grid in which it is active.
    */
-  float permz() const { return permz_; }
+  vector<double> permz() const { return permz_; }
 
   /*!
    * @brief Check whether or not a cell is active. Note that before
    * SetProperties is called, all cells are assumed to be active.
    * @return
+   */  
+  bool is_active() const { return is_active_matrix_ || is_active_fracture_; }
+  
+  /*!
+   * @brief Check whether or not a cell is active. Note that before
+   * SetProperties is called, all cells are assumed to be active.
+   * @return
    */
-  bool is_active() const { return is_active_; }
+  bool is_active_matrix() const { return is_active_matrix_; }
 
-
+  /*!
+   * @brief Check whether or not a cell is active in the fracture grid. 
+   * Note that before SetProperties is called, all cells are assumed to be active.
+   * @return
+   */
+  bool is_active_fracture() const { return is_active_fracture_; }
+  
   /*!
    * \brief center Gets the (x, y, z) position of the cells center.
    * \todo Find how these are computed by ERT
@@ -243,14 +266,15 @@ class Cell
  private:
   int global_index_;
   IJKCoordinate ijk_index_;
-  bool is_active_; //!< Indicates whether or not the cell is active.
-  float volume_;
+  bool is_active_matrix_; //!< Indicates whether or not the cell is active in the matrix grid.
+  bool is_active_fracture_; //!< Indicates whether or not the cell is active in the fracture grid.
+  double volume_;
   Eigen::Vector3d center_;
   vector<Eigen::Vector3d> corners_;
-  float porosity_;
-  float permx_;
-  float permy_;
-  float permz_;
+  vector<double> porosity_;
+  vector<double> permx_;
+  vector<double> permy_;
+  vector<double> permz_;
   vector<Face> faces_;
 
   /*!

--- a/FieldOpt/Reservoir/grid/cell.h
+++ b/FieldOpt/Reservoir/grid/cell.h
@@ -55,13 +55,13 @@ class Cell
   /*!
    * \brief Set cell properties at a later stage
    */
-  void SetProperties(bool is_active_matrix,
+  /*void SetProperties(bool is_active_matrix,
 		  bool is_active_fracture,
           vector<double> porosity,
           vector<double> permx,
           vector<double> permy,
           vector<double> permz);
-
+*/
   /*!
    * \brief global_index Gets the cells global index in its parent grid.
    */
@@ -79,25 +79,25 @@ class Cell
 
   /*!
    * \brief porosity Gets the cell's porosity vector 
-   * One value for all grid in which it is active.
+   * One value for each grid in which it is active.
    */
   vector<double> porosity() const { return porosity_; }
 
   /*!
    * \brief porosity Gets the cell's x-permeability vector.
-   * One value for all grid in which it is active.
+   * One value for each grid in which it is active.
    */
   vector<double> permx() const { return permx_; }
 
   /*!
    * \brief porosity Gets the cell's y-permeability vector.
-   * One value for all grid in which it is active.
+   * One value for each grid in which it is active.
    */
   vector<double> permy() const { return permy_; }
 
   /*!
    * \brief porosity Gets the cell's z-permeability vector.
-   * One value for all grid in which it is active.
+   * One value for each grid in which it is active.
    */
   vector<double> permz() const { return permz_; }
 

--- a/FieldOpt/Reservoir/grid/eclgrid.cpp
+++ b/FieldOpt/Reservoir/grid/eclgrid.cpp
@@ -137,7 +137,7 @@ Cell ECLGrid::GetCell(int global_index) {
         for (auto corner : ertCell.corners) {
             corners.push_back(corner);
         }
-
+        
         // Return cell info
         return Cell(global_index, ijk_index,
                     ertCell.volume, ertCell.porosity,
@@ -210,11 +210,10 @@ vector<int> ECLGrid::GetBoundingBoxCellIndices(
 
     vector<int> indices_list;
     for (int ii = 0; ii < total_cells; ii++) {
-        Cell cell;
         // Try is here because we only want to get the list of active
         // cells - that means defined cells
         try {
-            cell = GetCell(ii);
+            Cell cell = GetCell(ii);
             // Calculate cell size
             double dx = (cell.corners()[5] - cell.corners()[4]).norm();
             double dy = (cell.corners()[6] - cell.corners()[4]).norm();

--- a/FieldOpt/Reservoir/grid/eclgrid.cpp
+++ b/FieldOpt/Reservoir/grid/eclgrid.cpp
@@ -53,17 +53,9 @@ ECLGrid::ECLGrid(string file_path)
     // so we are going to check all known permutations with the hoe tha one of them is suitable for
     // the current grid - we do that based on the cell 0 in the grid
 
-    // Find the first (active) cell index.
-    int idx = 0;
-    while (idx < ecl_grid_reader_->ActiveCells()) {
-        if (ecl_grid_reader_->IsCellActive(idx)) {
-            break;
-        }
-        else {
-            idx++;
-        }
-    }
-
+    // Find the first (active) cell index in the matrix.
+    int idx = ecl_grid_reader_->ConvertMatrixActiveIndexToGlobalIndex(0);
+    
     // Set faces permutation to first permutation type
     faces_permutation_index_ = 0;
     // Get the first cell
@@ -151,7 +143,7 @@ Cell ECLGrid::GetCell(int global_index) {
                     ertCell.volume, ertCell.porosity,
                     ertCell.permx, ertCell.permy, ertCell.permz,
                     center, corners, faces_permutation_index_,
-                    ertCell.active
+                    ertCell.matrix_active, ertCell.fracture_active
         );
     } else {
         throw runtime_error("ECLGrid::GetCell(int global_index): Grid "

--- a/FieldOpt/Reservoir/tests/grid/test_cell.cpp
+++ b/FieldOpt/Reservoir/tests/grid/test_cell.cpp
@@ -100,10 +100,10 @@ TEST_F(CellTest, Corners) {
 
 TEST_F(CellTest, Properties) {
     auto cell = grid_->GetCell(1);
-    EXPECT_FLOAT_EQ(0.25, cell.porosity());
-    EXPECT_FLOAT_EQ(100, cell.permx());
-    EXPECT_FLOAT_EQ(100, cell.permy());
-    EXPECT_FLOAT_EQ(5, cell.permz());
+    EXPECT_FLOAT_EQ(0.25, cell.porosity()[0]);
+    EXPECT_FLOAT_EQ(100, cell.permx()[0]);
+    EXPECT_FLOAT_EQ(100, cell.permy()[0]);
+    EXPECT_FLOAT_EQ(5, cell.permz()[0]);
 }
 
 }


### PR DESCRIPTION
An ECLGridReader::Cell now records cells as active in matrix and/or fracture and reads perm and poro for the grids in which it is active...

This is currently work in progress.