### PR TITLE
Feature/fix wic 4 dual grid

### DIFF
--- a/FieldOpt/ERTWrapper/eclgridreader.cpp
+++ b/FieldOpt/ERTWrapper/eclgridreader.cpp
@@ -207,8 +207,8 @@ ECLGridReader::Cell ECLGridReader::GetGridCell(int global_index)
 	}
     
 	// Fracture grid
-	active_index = ecl_grid_get_active_fracture_index1(ecl_grid_, global_index);
-	if (active_index >= 0)
+	active_index = NumActiveMatrixCells() + ecl_grid_get_active_fracture_index1(ecl_grid_, global_index);
+	if (active_index >= NumActiveMatrixCells())
 	{
 		cell.porosity.push_back(ecl_kw_iget_as_double(poro_kw_, active_index));
 		cell.permx.push_back(ecl_kw_iget_as_double(permx_kw_, active_index));

--- a/FieldOpt/Reservoir/grid/cell.cpp
+++ b/FieldOpt/Reservoir/grid/cell.cpp
@@ -33,10 +33,11 @@ Cell::Cell(int global_index, IJKCoordinate ijk_index,
            Eigen::Vector3d center,
            vector<Eigen::Vector3d> corners,
            int faces_permutation_index,
-           bool active_matrix, bool active_fracture)
+           bool active_matrix, bool active_fracture, int k_fracture_index)
 {
     global_index_ = global_index;
     ijk_index_ = ijk_index;
+    k_fracture_index_ = k_fracture_index;
     volume_ = volume;
     porosity_ = poro_in;
     permx_ = permx_in;

--- a/FieldOpt/Reservoir/grid/cell.h
+++ b/FieldOpt/Reservoir/grid/cell.h
@@ -49,7 +49,8 @@ class Cell
        Eigen::Vector3d center,
        vector<Eigen::Vector3d> corners,
        int faces_permutation_index,
-       bool active_matrix, bool active_fracture
+       bool active_matrix, bool active_fracture,
+       int k_fracture_index
   );
 
   /*!
@@ -69,6 +70,10 @@ class Cell
 
   /*!
    * \brief ijk_index Gets the cells (i, j, k) index in its parent grid.
+   * The k index is the index in the matrix grid in fact 
+   * in the case of a dual grid. 
+   * For the k index in the fracure grid use k_fracture_index.
+   * This is most likely NZ + k but it is saved apart anyway. 
    */
   IJKCoordinate ijk_index() const { return ijk_index_; }
 
@@ -121,6 +126,13 @@ class Cell
    * @return
    */
   bool is_active_fracture() const { return is_active_fracture_; }
+  
+  /*!
+   * @brief The k index of the corresponding cell for this cell in the fracture grid 
+   * if this cell is active in the fracture grid as well. 
+   * @return
+   */  
+  int k_fracture_index() const { return k_fracture_index_; }
   
   /*!
    * \brief center Gets the (x, y, z) position of the cells center.
@@ -268,6 +280,7 @@ class Cell
   IJKCoordinate ijk_index_;
   bool is_active_matrix_; //!< Indicates whether or not the cell is active in the matrix grid.
   bool is_active_fracture_; //!< Indicates whether or not the cell is active in the fracture grid.
+  int k_fracture_index_;
   double volume_;
   Eigen::Vector3d center_;
   vector<Eigen::Vector3d> corners_;

--- a/FieldOpt/Reservoir/grid/eclgrid.cpp
+++ b/FieldOpt/Reservoir/grid/eclgrid.cpp
@@ -143,7 +143,8 @@ Cell ECLGrid::GetCell(int global_index) {
                     ertCell.volume, ertCell.porosity,
                     ertCell.permx, ertCell.permy, ertCell.permz,
                     center, corners, faces_permutation_index_,
-                    ertCell.matrix_active, ertCell.fracture_active
+                    ertCell.matrix_active, ertCell.fracture_active,
+                    Dimensions().nz + ijk_index.k()
         );
     } else {
         throw runtime_error("ECLGrid::GetCell(int global_index): Grid "


### PR DESCRIPTION
Added the k_fracture_index - in the case of a dual grid the fracture blocks though they have the same coordinates as the matrix grid blocks they have a k index that it usually Nz+k.
Corrected the reading of the block properties for the fracture grid blocks. 
