### PR TITLE
Implement passing of static RNG seed.

### DIFF
--- a/FieldOpt/Optimization/optimizers/GeneticAlgorithm.cpp
+++ b/FieldOpt/Optimization/optimizers/GeneticAlgorithm.cpp
@@ -35,7 +35,7 @@ GeneticAlgorithm::GeneticAlgorithm(Settings::Optimizer *settings,
 )
     : Optimizer(settings, base_case, variables, grid, logger, case_handler, constraint_handler) {
     n_vars_ = variables->ContinousVariableSize();
-    gen_ = get_random_generator();
+    gen_ = get_random_generator(settings->parameters().rng_seed);
     max_generations_ = settings->parameters().max_generations;
     if (settings->parameters().population_size < 0)
         population_size_ = std::min(10*n_vars_, 100);

--- a/FieldOpt/Optimization/optimizers/bayesian_optimization/EGO.cpp
+++ b/FieldOpt/Optimization/optimizers/bayesian_optimization/EGO.cpp
@@ -48,14 +48,14 @@ EGO::EGO(Settings::Optimizer *settings,
     }
     n_initial_guesses_ = variables->ContinousVariableSize() * 2;
     af_ = AcquisitionFunction(settings->parameters());
-    af_opt_ = AFOptimizers::AFPSO(lb_, ub_);
+    af_opt_ = AFOptimizers::AFPSO(lb_, ub_, settings->parameters().rng_seed);
     gp_ = new libgp::GaussianProcess(variables->ContinousVariableSize(), "CovMatern5iso");
 
     cout << "Lower bounds: " << eigenvec_to_str(lb_) << endl;
     cout << "Upper bounds: " << eigenvec_to_str(ub_) << endl;
 
     // Guess some random initial positions
-    auto rng = get_random_generator();
+    auto rng = get_random_generator(settings->parameters().rng_seed);
     for (int i = 0; i < n_initial_guesses_; ++i) {
         VectorXd pos = VectorXd::Zero(lb_.size());
         for (int i = 0; i < lb_.size(); ++i) {

--- a/FieldOpt/Optimization/optimizers/bayesian_optimization/af_optimizers/AFCompassSearch.cpp
+++ b/FieldOpt/Optimization/optimizers/bayesian_optimization/af_optimizers/AFCompassSearch.cpp
@@ -25,8 +25,8 @@ namespace Optimizers {
 namespace BayesianOptimization {
 namespace AFOptimizers {
 Optimization::Optimizers::BayesianOptimization::AFOptimizers::AFCompassSearch::AFCompassSearch() {}
-AFCompassSearch::AFCompassSearch(const VectorXd &lb, const VectorXd &ub) : lb_(lb), ub_(ub) {
-    gen_ = get_random_generator();
+AFCompassSearch::AFCompassSearch(const VectorXd &lb, const VectorXd &ub, int rng_seed) : lb_(lb), ub_(ub) {
+    gen_ = get_random_generator(rng_seed*2);
     step_lengths_ = 0.25 * (ub - lb);
     min_step_lengths_ = step_lengths_ / 100.0;
     directions_ = ::Optimization::GSSPatterns::Compass(lb_.size());

--- a/FieldOpt/Optimization/optimizers/bayesian_optimization/af_optimizers/AFCompassSearch.h
+++ b/FieldOpt/Optimization/optimizers/bayesian_optimization/af_optimizers/AFCompassSearch.h
@@ -35,7 +35,7 @@ namespace AFOptimizers {
 class AFCompassSearch : public AFOptimizer {
  public:
   AFCompassSearch();
-  AFCompassSearch(const VectorXd &lb, const VectorXd &ub);
+  AFCompassSearch(const VectorXd &lb, const VectorXd &ub, int rng_seed=0);
   Eigen::VectorXd Optimize(libgp::GaussianProcess *gp, AcquisitionFunction &af, double target) override;
 
  private:

--- a/FieldOpt/Optimization/optimizers/bayesian_optimization/af_optimizers/AFPSO.cpp
+++ b/FieldOpt/Optimization/optimizers/bayesian_optimization/af_optimizers/AFPSO.cpp
@@ -32,11 +32,11 @@ AFPSO::AFPSO() {
     inertia_ = 1.2;
     n_particles_ = 200;
     n_neighbourhoods_ = 20;
-    gen_ = get_random_generator();
     n_iterations_ = 500;
     iteration_ = 0;
 }
-AFPSO::AFPSO(VectorXd lb, VectorXd ub) : AFPSO() {
+AFPSO::AFPSO(VectorXd lb, VectorXd ub, int rng_seed) : AFPSO() {
+    gen_ = get_random_generator(rng_seed*2);
     lb_ = lb;
     ub_ = ub;
     n_dims_ = lb.size();

--- a/FieldOpt/Optimization/optimizers/bayesian_optimization/af_optimizers/AFPSO.h
+++ b/FieldOpt/Optimization/optimizers/bayesian_optimization/af_optimizers/AFPSO.h
@@ -61,8 +61,9 @@ class AFPSO : public AFOptimizer {
    * @brief Initialize the optimizer, setting the bounds for the variables.
    * @param lb Lower bounds.
    * @param ub Upper bounds.
+   * @rng_seed Seed to use for the random number generator.
    */
-  AFPSO(VectorXd lb, VectorXd ub);
+  AFPSO(VectorXd lb, VectorXd ub, int rng_seed=0);
 
  private:
   struct Particle {

--- a/FieldOpt/Optimization/tests/optimizers/test_apps.cpp
+++ b/FieldOpt/Optimization/tests/optimizers/test_apps.cpp
@@ -80,7 +80,7 @@ TEST_F(APPSTest, GetNewCases) {
 }
 
 TEST_F(APPSTest, TestFunctionSpherical) {
-    auto gen = get_random_generator();
+    auto gen = get_random_generator(10);
     test_case_2r_->set_objective_function_value(Sphere(test_case_2r_->GetRealVarVector()));
     Optimization::Optimizer *minimizer = new APPS(settings_apps_min_unconstr_,
                                                   test_case_2r_,
@@ -110,7 +110,7 @@ TEST_F(APPSTest, TestFunctionSpherical) {
 }
 
 TEST_F(APPSTest, TestFunctionRosenbrock) {
-    auto gen = get_random_generator();
+    auto gen = get_random_generator(10);
 
     // First test the Rosenbrock function itself
     Eigen::VectorXd optimum(2); optimum << 1.0, 1.0;

--- a/FieldOpt/Optimization/tests/optimizers/test_ego.cpp
+++ b/FieldOpt/Optimization/tests/optimizers/test_ego.cpp
@@ -63,7 +63,7 @@ TEST_F(EGOTest, GaussianProcess) {
     params << 1, 1;
     gp.covf().set_loghyper(params);
 
-    auto gen = get_random_generator();
+    auto gen = get_random_generator(10);
 
     cout << "Log likelihood: " << gp.log_likelihood() << endl;
 
@@ -123,26 +123,26 @@ TEST_F(EGOTest, SingleIteration) {
     cout << next_case->objective_function_value() << endl;
 }
 
-//TEST_F(EGOTest, TestFunctionSpherical) {
-//    test_case_ga_spherical_6r_->set_objective_function_value(- abs(Sphere(test_case_ga_spherical_6r_->GetRealVarVector())));
-//    Optimization::Optimizer *ego = new BayesianOptimization::EGO(settings_ego_max_,
-//                                                                 test_case_ga_spherical_6r_,
-//                                                                 varcont_6r_,
-//                                                                 grid_5spot_,
-//                                                                 logger_
-//    );
-//
-//    while (ego->IsFinished() == Optimization::Optimizer::TerminationCondition::NOT_FINISHED) {
-//        auto next_case = ego->GetCaseForEvaluation();
-//        next_case->set_objective_function_value(- abs(Sphere(next_case->GetRealVarVector())));
-//        next_case->state.eval = Optimization::Case::CaseState::EvalStatus::E_DONE;
-//        ego->SubmitEvaluatedCase(next_case);
-//    }
-//    auto best_case = ego->GetTentativeBestCase();
-//    EXPECT_NEAR(0.0, best_case->objective_function_value(), 0.1);
-//    EXPECT_NEAR(0.0, best_case->GetRealVarVector()[0], 0.1);
-//    EXPECT_NEAR(0.0, best_case->GetRealVarVector()[1], 0.1);
-//}
+TEST_F(EGOTest, TestFunctionSpherical) {
+    test_case_ga_spherical_6r_->set_objective_function_value(- abs(Sphere(test_case_ga_spherical_6r_->GetRealVarVector())));
+    Optimization::Optimizer *ego = new BayesianOptimization::EGO(settings_ego_max_,
+                                                                 test_case_ga_spherical_6r_,
+                                                                 varcont_6r_,
+                                                                 grid_5spot_,
+                                                                 logger_
+    );
+
+    while (ego->IsFinished() == Optimization::Optimizer::TerminationCondition::NOT_FINISHED) {
+        auto next_case = ego->GetCaseForEvaluation();
+        next_case->set_objective_function_value(- abs(Sphere(next_case->GetRealVarVector())));
+        next_case->state.eval = Optimization::Case::CaseState::EvalStatus::E_DONE;
+        ego->SubmitEvaluatedCase(next_case);
+    }
+    auto best_case = ego->GetTentativeBestCase();
+    EXPECT_NEAR(0.0, best_case->objective_function_value(), 0.1);
+    EXPECT_NEAR(0.0, best_case->GetRealVarVector()[0], 0.2);
+    EXPECT_NEAR(0.0, best_case->GetRealVarVector()[1], 0.2);
+}
 
 
 }

--- a/FieldOpt/Optimization/tests/test_resource_cases.h
+++ b/FieldOpt/Optimization/tests/test_resource_cases.h
@@ -32,7 +32,7 @@ class TestResourceCases : public TestResources::TestResourceVariablePropertyCont
 
       test_case_2r_ = new Optimization::Case(QHash<QUuid, bool>(), QHash<QUuid, int>(), real_variables_2d_);
 
-      auto gen = get_random_generator();
+      auto gen = get_random_generator(10);
       std::vector<double> rand_reals_30 = random_doubles(gen, -5.12, 5.12, 30);
       for (double rand : rand_reals_30)
           real_variables_sph_rand_30d_.insert(QUuid::createUuid(), rand);

--- a/FieldOpt/Optimization/tests/test_resource_optimizer.h
+++ b/FieldOpt/Optimization/tests/test_resource_optimizer.h
@@ -124,7 +124,8 @@ class TestResourceOptimizer : public TestResourceModel, public TestResourceCases
           {"LowerBoundInt", 0.0},
           {"UpperBoundInt", 10.0},
           {"LowerBoundReal", 0.0},
-          {"UpperBoundReal", 100.0}
+          {"UpperBoundReal", 100.0},
+          {"RNGSeed", 5}
 
       }},
       {"Objective", obj_fun_}
@@ -141,7 +142,8 @@ class TestResourceOptimizer : public TestResourceModel, public TestResourceCases
           {"MutationStrength",      0.25},
           {"StagnationLimit",       1e-10},
           {"LowerBound",            -10.0},
-          {"UpperBound",            10.0}
+          {"UpperBound",            10.0},
+          {"RNGSeed", 5}
 
       }},
       {"Objective", obj_fun_}
@@ -151,9 +153,10 @@ class TestResourceOptimizer : public TestResourceModel, public TestResourceCases
       {"Type", "EGO"},
       {"Mode", "Maximize"},
       {"Parameters", QJsonObject{
-          {"LowerBound", -3},
-          {"UpperBound",  3},
-          {"MaxEvaluations", 50}
+          {"LowerBound", -1},
+          {"UpperBound",  1},
+          {"MaxEvaluations", 50},
+          {"RNGSeed", 25}
       }},
       {"Objective", obj_fun_},
 //      {"Constraints", QJsonArray{

--- a/FieldOpt/Runner/runners/abstract_runner.cpp
+++ b/FieldOpt/Runner/runners/abstract_runner.cpp
@@ -71,7 +71,7 @@ void AbstractRunner::InitializeSettings(QString output_subdirectory)
 
     if (settings_->simulator()->is_ensemble()) {
         is_ensemble_run_ = true;
-        ensemble_helper_ = EnsembleHelper(settings_->simulator()->get_ensemble());
+        ensemble_helper_ = EnsembleHelper(settings_->simulator()->get_ensemble(), settings_->optimizer()->parameters().rng_seed);
     }
     else {
         is_ensemble_run_ = false;

--- a/FieldOpt/Runner/runners/ensemble_helper.cpp
+++ b/FieldOpt/Runner/runners/ensemble_helper.cpp
@@ -32,13 +32,13 @@ EnsembleHelper::EnsembleHelper() {
     rzn_busy_ = std::vector<std::string>();
 }
 
-EnsembleHelper::EnsembleHelper(const Settings::Ensemble &ensemble) {
+EnsembleHelper::EnsembleHelper(const Settings::Ensemble &ensemble, int rng_seed) {
     ensemble_ = ensemble;
     current_case_ = 0;
     rzn_queue_ = std::vector<std::string>();
     rzn_busy_ = std::vector<std::string>();
     n_select_ = 4;
-    rng_ = get_random_generator();
+    rng_ = get_random_generator(rng_seed*3);
 
     assert(n_select_ < ensemble.GetAliases().size());
 }

--- a/FieldOpt/Runner/runners/ensemble_helper.h
+++ b/FieldOpt/Runner/runners/ensemble_helper.h
@@ -38,7 +38,7 @@ class EnsembleHelper {
 
  public:
   EnsembleHelper();
-  EnsembleHelper(const Settings::Ensemble &ensemble);
+  EnsembleHelper(const Settings::Ensemble &ensemble, int rng_seed=0);
 
   /*!
    * Set a new active case and populate the realization queue

--- a/FieldOpt/Settings/optimizer.cpp
+++ b/FieldOpt/Settings/optimizer.cpp
@@ -301,6 +301,14 @@ Optimizer::Parameters Optimizer::parseParameters(QJsonObject &json_parameters) {
         if (json_parameters.contains("UpperBound"))
             params.upper_bound = json_parameters["UpperBound"].toDouble();
         else params.upper_bound = 10;
+
+        // RNG seed
+        if (json_parameters.contains("RNGSeed")) {
+            params.rng_seed = json_parameters["RNGSeed"].toInt();
+        }
+        else {
+            params.rng_seed = std::time(0);
+        }
     }
     catch (std::exception const &ex) {
         throw UnableToParseOptimizerParametersSectionException("Unable to parse optimizer parameters: " + std::string(ex.what()));

--- a/FieldOpt/Settings/optimizer.h
+++ b/FieldOpt/Settings/optimizer.h
@@ -75,6 +75,8 @@ class Optimizer
     double stagnation_limit;  //!< Stagnation limit. Default: 1e-10.
     double lower_bound;       //!< Simple lower bound. This is applied to _all_ variables. Default: -10.0.
     double upper_bound;       //!< Simple upper bound. This is applied to _all_ variables. Default: +10.0.
+
+    int rng_seed;             //!< Seed to be used for random number renerators in relevant algorithms.
   };
 
   struct Objective {

--- a/FieldOpt/Utilities/math.hpp
+++ b/FieldOpt/Utilities/math.hpp
@@ -86,10 +86,16 @@ inline std::vector<T> range(T start, T end, T step) {
  * @brief Get a random generator (Mersenne Twister) for use with the random functions in this file.
  * @return A Mersenne Twister RNG.
  */
-inline boost::random::mt19937 get_random_generator() {
-    boost::random_device dev;
-    boost::random::mt19937 gen(dev);
-    return gen;
+inline boost::random::mt19937 get_random_generator(int seed = 0) {
+    if (seed == 0) {
+        boost::random_device dev;
+        boost::random::mt19937 gen(dev);
+        return gen;
+    }
+    else {
+        boost::random::mt19937 gen(seed);
+        return gen;
+    }
 }
 
 /*!

--- a/FieldOpt/Utilities/tests/test_math.cpp
+++ b/FieldOpt/Utilities/tests/test_math.cpp
@@ -121,4 +121,20 @@ TEST_F(MathTest, RandomFloats) {
     }
 }
 
+TEST_F(MathTest, SeededRandoms) {
+    auto gen11 = get_random_generator(1);
+    auto gen12 = get_random_generator(2);
+    auto gen21 = get_random_generator(1);
+    auto gen22 = get_random_generator(2);
+
+    double rand11 = random_double(gen11);
+    double rand12 = random_double(gen12);
+    double rand21 = random_double(gen21);
+    double rand22 = random_double(gen22);
+    EXPECT_EQ(rand11, rand21);
+    EXPECT_EQ(rand12, rand22);
+    EXPECT_NE(rand11, rand12);
+    EXPECT_NE(rand21, rand22);
+}
+
 }


### PR DESCRIPTION
An RNG (Random Number Generator) seed can now be set in the json driver file (under Optimization.Parameters). This will be passed to both optimization algorithms and the EnsembleHelper.

This allows for reproducible results with stochastic algorithms.

If no seed is passed, the current (UNIX) time will be set as the seed by default.