### PR TITLE
Feature/alternatig hybrid optimization

### DIFF
--- a/FieldOpt/.gitignore
+++ b/FieldOpt/.gitignore
@@ -1,0 +1,2 @@
+*.nvimrc
+*.clang_complete

--- a/FieldOpt/ERTWrapper/eclsummaryreader.cpp
+++ b/FieldOpt/ERTWrapper/eclsummaryreader.cpp
@@ -133,7 +133,9 @@ void ECLSummaryReader::populateKeyLists() {
     for (auto well : wells_) {
         for (auto key : well_keys_) ss << well << ":" << key << ", ";
     }
-    Printer::ext_info("Found summary keys: " + ss.str(), "ERTWrapper, ECLSummaryReader");
+    if (VERB_SIM >= 2) {
+        Printer::ext_info("Found summary keys: " + ss.str(), "ERTWrapper, ECLSummaryReader");
+    }
 
 
     stringlist_free(keys);

--- a/FieldOpt/ERTWrapper/eclsummaryreader.cpp
+++ b/FieldOpt/ERTWrapper/eclsummaryreader.cpp
@@ -243,7 +243,7 @@ void ECLSummaryReader::initializeWellCumulatives() {
             double_vector_free(wopt);
         }
         else if (hasWellVar(wname, "WOPR")) {
-            Printer::ext_info("WOPT not found, computing from WOPR.", "ERTWrapper", "ECLSummaryReader");
+            if (VERB_SIM >= 2) Printer::ext_info("WOPT not found, computing from WOPR.", "ERTWrapper", "ECLSummaryReader");
             wopt_[wname] = computeCumulativeFromRate(wopr_[wname]);
         }
 
@@ -259,7 +259,7 @@ void ECLSummaryReader::initializeWellCumulatives() {
             double_vector_free(wwpt);
         }
         else if (hasWellVar(wname, "WWPR")) {
-            Printer::ext_info("WWPT not found, computing from WWPR.", "ERTWrapper", "ECLSummaryReader");
+            if (VERB_SIM >= 2) Printer::ext_info("WWPT not found, computing from WWPR.", "ERTWrapper", "ECLSummaryReader");
             wwpt_[wname] = computeCumulativeFromRate(wwpr_[wname]);
         }
 
@@ -275,7 +275,7 @@ void ECLSummaryReader::initializeWellCumulatives() {
             double_vector_free(wgpt);
         }
         else if (hasWellVar(wname, "WGPR")) {
-            Printer::ext_info("WGPT not found, computing from WGPR.", "ERTWrapper", "ECLSummaryReader");
+            if (VERB_SIM >= 2) Printer::ext_info("WGPT not found, computing from WGPR.", "ERTWrapper", "ECLSummaryReader");
             wgpt_[wname] = computeCumulativeFromRate(wgpr_[wname]);
         }
 
@@ -291,7 +291,7 @@ void ECLSummaryReader::initializeWellCumulatives() {
             double_vector_free(wwit);
         }
         else if (hasWellVar(wname, "WWIR")) {
-            Printer::ext_info("WWIT not found, computing from WWIR.", "ERTWrapper", "ECLSummaryReader");
+            if (VERB_SIM >= 2) Printer::ext_info("WWIT not found, computing from WWIR.", "ERTWrapper", "ECLSummaryReader");
             wwit_[wname] = computeCumulativeFromRate(wwir_[wname]);
         }
 
@@ -307,7 +307,7 @@ void ECLSummaryReader::initializeWellCumulatives() {
             double_vector_free(wgit);
         }
         else if (hasWellVar(wname, "WGIR")) {
-            Printer::ext_info("WGIT not found, computing from WGIR.", "ERTWrapper", "ECLSummaryReader");
+            if (VERB_SIM >= 2) Printer::ext_info("WGIT not found, computing from WGIR.", "ERTWrapper", "ECLSummaryReader");
             wgit_[wname] = computeCumulativeFromRate(wgir_[wname]);
         }
     }

--- a/FieldOpt/Model/model.cpp
+++ b/FieldOpt/Model/model.cpp
@@ -49,6 +49,11 @@ Model::Model(Settings::Settings settings, Logger *logger)
 }
 
 void Model::Finalize() {
+    if (current_case_->GetRealizationOFVMap().size() > 0) {
+        realization_ofv_map_ = current_case_->GetRealizationOFVMap();
+        ensemble_avg_ofv_ = current_case_->GetEnsembleExpectedOfv().first;
+        ensemble_ofv_st_dev_ = current_case_->GetEnsembleExpectedOfv().second;
+    }
     logger_->AddEntry(this); // Removing this causes the last case to not be in the JSON file
     logger_->AddEntry(new Summary(this));
 }
@@ -128,6 +133,9 @@ void Model::wellCost(Settings::Optimizer *settings) {
     well_economy_.wells_pointer = *wells_;
     for (auto well : *wells_) {
         auto spline_points = well->trajectory()->GetWellSpline()->GetSplinePoints();
+        well_economy_.well_xy[well->name().toStdString()] = 0;
+        well_economy_.well_z[well->name().toStdString()] = 0;
+        well_economy_.well_lengths[well->name().toStdString()] = 0;
         for(int j = 0; j < spline_points.size()-1; j++){
             double well_length = (spline_points[j+1]->ToEigenVector() - spline_points[j]->ToEigenVector()).norm();
             double well_spline_length_z = abs(spline_points[j+1]->ToEigenVector()[2]-spline_points[j]->ToEigenVector()[2]);

--- a/FieldOpt/Optimization/hybrid_optimizer.cpp
+++ b/FieldOpt/Optimization/hybrid_optimizer.cpp
@@ -130,7 +130,9 @@ void HybridOptimizer::iterate() {
             primary_best_case_ = tentative_best_case_;
             initializeComponent(1);
             active_component_ = 1;
-            secondary_->iterate();
+            if (case_handler_->QueuedCases().size() == 0) { // Iterate if the constructor does not generate cases
+                secondary_->iterate();
+            }
 
             if (iteration_ > 1 && isBetter(primary_best_case_, secondary_best_case_) == false) {
                 // If primary didn't find an improvement over previous secondary
@@ -149,7 +151,9 @@ void HybridOptimizer::iterate() {
             secondary_best_case_ = tentative_best_case_;
             initializeComponent(0);
             active_component_ = 0;
-            primary_->iterate();
+            if (case_handler_->QueuedCases().size() == 0) { // Iterate if the constructor does not generate cases
+                primary_->iterate();
+            }
 
             if (isBetter(secondary_best_case_, primary_best_case_) == false) {
                 // If secondary didn't find an improvement over previous primary

--- a/FieldOpt/Optimization/hybrid_optimizer.cpp
+++ b/FieldOpt/Optimization/hybrid_optimizer.cpp
@@ -37,6 +37,7 @@ HybridOptimizer::HybridOptimizer(Settings::Optimizer *settings,
 {
     variables_ = variables;
     grid_ = grid;
+    iteration_ = 0;
 
     assert(settings->HybridComponents().size() == 2);
     primary_settings_ = new Settings::Optimizer(settings->HybridComponents()[0]);
@@ -44,7 +45,6 @@ HybridOptimizer::HybridOptimizer(Settings::Optimizer *settings,
 
     initializeComponent(0);
     active_component_ = 0;
-    iteration_ = 0;
 
     component_improvement_found_ = true;
 
@@ -65,7 +65,7 @@ HybridOptimizer::HybridOptimizer(Settings::Optimizer *settings,
 
 Optimizer::TerminationCondition HybridOptimizer::IsFinished() {
     if (hybrid_termination_condition_ == HybridTerminationCondition::NO_IMPROVEMENT && component_improvement_found_ == false) {
-        Printer::ext_info("No improvement found in previous component run. Terminating.", "HybridOptimizer", "Optimization");
+        Printer::ext_info("No improvement found in previous component run. Terminating.", "Optimization", "HybridOptimizer");
         if (enable_logging_) {
             logger_->AddEntry(this);
         }
@@ -90,7 +90,11 @@ void HybridOptimizer::handleEvaluatedCase(Case *c) {
     if (active_component_ == 0) {
         if (isImprovement(c)) {
             if (VERB_OPT >= 1) {
-                Printer::ext_info("Found better case. Passing to primary.", "HybridOptimizer", "Optimization");
+                std::stringstream ss;
+                ss << "Found better case. Passing to primary." << "|";
+                ss << " ID: " << c->id().toString().toStdString() << "|";
+                ss << "OFV: " << c->objective_function_value();
+                Printer::ext_info(ss.str(), "Optimization", "HybridOptimizer");
                 updateTentativeBestCase(c);
             }
         }
@@ -99,13 +103,16 @@ void HybridOptimizer::handleEvaluatedCase(Case *c) {
     else {
         if (isImprovement(c)) {
             if (VERB_OPT >= 1) {
-                Printer::ext_info("Found better case. Passing to secondary.", "HybridOptimizer", "Optimization");
+                std::stringstream ss;
+                ss << "Found better case. Passing to secondary." << "|";
+                ss << " ID: " << c->id().toString().toStdString() << "|";
+                ss << "OFV: " << c->objective_function_value();
+                Printer::ext_info(ss.str(), "Optimization", "HybridOptimizer");
                 updateTentativeBestCase(c);
             }
         }
         secondary_->handleEvaluatedCase(c);
     }
-    // 6.016680E+10
 
 }
 void HybridOptimizer::iterate() {
@@ -114,16 +121,16 @@ void HybridOptimizer::iterate() {
     }
     if (active_component_ == 0) { // Primary is active.
         if (primary_->IsFinished() == TerminationCondition::NOT_FINISHED) { // Primary is not finished.
-            if (VERB_OPT >= 1) { Printer::ext_info("Iterating with primary.", "HybridOptimizer", "Optimization"); }
+            if (VERB_OPT >= 1) { Printer::ext_info("Iterating with primary.", "Optimization", "HybridOptimizer"); }
             primary_->iterate();
         }
         else { // Primary is finished. Switch to secondary.
-            if (VERB_OPT >= 1) { Printer::ext_info("Primary component converged. Switching to secondary.", "HybridOptimizer", "Optimization"); }
+            if (VERB_OPT >= 1) { Printer::ext_info("Primary component converged. Switching to secondary.", "Optimization", "HybridOptimizer"); }
+            iteration_++;
             primary_best_case_ = tentative_best_case_;
             initializeComponent(1);
             active_component_ = 1;
             secondary_->iterate();
-            iteration_++;
 
             if (iteration_ > 1 && isBetter(primary_best_case_, secondary_best_case_) == false) {
                 // If primary didn't find an improvement over previous secondary
@@ -133,11 +140,12 @@ void HybridOptimizer::iterate() {
     }
     else { // Secondary is active
         if (secondary_->IsFinished() == TerminationCondition::NOT_FINISHED) { // Secondary is not finished.
-            if (VERB_OPT >= 1) { Printer::ext_info("Iterating with secondary.", "HybridOptimizer", "Optimization"); }
+            if (VERB_OPT >= 1) { Printer::ext_info("Iterating with secondary.", "Optimization", "HybridOptimizer"); }
             secondary_->iterate();
         }
         else { // Secondary is finished. Switch back to primary.
-            if (VERB_OPT >= 1) { Printer::ext_info("Secondary component converged. Switching to primary.", "HybridOptimizer", "Optimization"); }
+            if (VERB_OPT >= 1) { Printer::ext_info("Secondary component converged. Switching to primary.", "Optimization", "HybridOptimizer"); }
+            iteration_++;
             secondary_best_case_ = tentative_best_case_;
             initializeComponent(0);
             active_component_ = 0;
@@ -163,33 +171,36 @@ void HybridOptimizer::initializeComponent(int component=0) {
         opt_settings = secondary_settings_;
         compstr = "secondary";
     }
+    opt_settings->SetRngSeed(opt_settings->parameters().rng_seed + iteration_ * 7);
+    opt_settings->set_mode(mode_);
 
     Optimizer *opt;
 
     switch (opt_settings->type()) {
         case Settings::Optimizer::OptimizerType::Compass:
-            std::cout << "Using Compass Search as " + compstr + " component in hybrid algorithm." << std::endl;
+            Printer::ext_info("Using Compass Search as " + compstr + " component in hybrid algorithm.", "Optimization", "HybridOptimizer");
             opt = new Optimizers::CompassSearch(
                 opt_settings, tentative_best_case_, variables_, grid_, logger_,
                 case_handler_, constraint_handler_
             );
             break;
         case Settings::Optimizer::OptimizerType::APPS:
-            std::cout << "Using APPS as " + compstr + " component in hybrid algorithm." << std::endl;
+            Printer::ext_info("Using APPS as " + compstr + " component in hybrid algorithm.", "Optimization", "HybridOptimizer");
             opt = new Optimizers::APPS(
                 opt_settings, tentative_best_case_, variables_, grid_, logger_,
                 case_handler_, constraint_handler_
             );
             break;
         case Settings::Optimizer::OptimizerType::GeneticAlgorithm:
-            std::cout << "Using Genetic Algorithm as " + compstr + " component in hybrid algorithm." << std::endl;
+            Printer::ext_info("Using Genetic Algorithm as " + compstr + " component in hybrid algorithm.|RNG Seed: "
+                               + Printer::num2str(opt_settings->parameters().rng_seed), "Optimization", "HybridOptimizer");
             opt = new Optimizers::RGARDD(
                 opt_settings, tentative_best_case_, variables_, grid_, logger_,
                 case_handler_, constraint_handler_
             );
             break;
         case Settings::Optimizer::OptimizerType::EGO:
-            std::cout << "Using EGO as " + compstr + " component in hybrid algorithm." << std::endl;
+            Printer::ext_info("Using EGO as " + compstr + " component in hybrid algorithm.", "Optimization", "HybridOptimizer");
             opt = new Optimizers::BayesianOptimization::EGO(
                 opt_settings, tentative_best_case_, variables_, grid_, logger_,
                 case_handler_, constraint_handler_

--- a/FieldOpt/Optimization/hybrid_optimizer.cpp
+++ b/FieldOpt/Optimization/hybrid_optimizer.cpp
@@ -64,15 +64,15 @@ HybridOptimizer::HybridOptimizer(Settings::Optimizer *settings,
 }
 
 Optimizer::TerminationCondition HybridOptimizer::IsFinished() {
-    if (hybrid_termination_condition_ == HybridTerminationCondition::NO_IMPROVEMENT && component_improvement_found_ == false) {
+    if (case_handler_->CasesBeingEvaluated().size() > 0) {
+        return TerminationCondition::NOT_FINISHED;
+    }
+    else if (hybrid_termination_condition_ == HybridTerminationCondition::NO_IMPROVEMENT && component_improvement_found_ == false) {
         Printer::ext_info("No improvement found in previous component run. Terminating.", "Optimization", "HybridOptimizer");
         if (enable_logging_) {
             logger_->AddEntry(this);
         }
         return TerminationCondition::MINIMUM_STEP_LENGTH_REACHED;
-    }
-    else if (case_handler_->CasesBeingEvaluated().size() > 0) {
-        return TerminationCondition::NOT_FINISHED;
     }
     else if (iteration_ < max_hybrid_iterations_) {
         return TerminationCondition::NOT_FINISHED;

--- a/FieldOpt/Optimization/hybrid_optimizer.h
+++ b/FieldOpt/Optimization/hybrid_optimizer.h
@@ -50,14 +50,26 @@ class HybridOptimizer : public Optimizer {
       Logger *logger);
 
   TerminationCondition IsFinished() override;
+
  protected:
   void handleEvaluatedCase(Case *c) override;
   void iterate() override;
 
  private:
+  enum HybridSwitchMode { ON_CONVERGENCE };
+  enum HybridTerminationCondition { NO_IMPROVEMENT };
+
+  int max_hybrid_iterations_; //!< Maximum number of times to run each of the components
+  HybridSwitchMode switch_mode_; //!< When to switch
+  HybridTerminationCondition hybrid_termination_condition_; //!< When to terminate (before max iterations)
+
   int active_component_; //!< Currently active component (0=primary; 1=secondary)
   Optimizer *primary_; //!< Primary optimizer (will be called first).
   Optimizer *secondary_; //!< Secondary optimizer (will be called after the termination of the first component is reached).
+
+  Case *primary_best_case_; //!< Best case found at the end of a primary run.
+  Case *secondary_best_case_; //!< Best case found at the end of a secondary run.
+  bool component_improvement_found_; //!< Whether a component run has found an improvement over the previous component.
 
   Settings::Optimizer *primary_settings_;
   Settings::Optimizer *secondary_settings_;

--- a/FieldOpt/Optimization/optimizer.cpp
+++ b/FieldOpt/Optimization/optimizer.cpp
@@ -44,12 +44,14 @@ Optimizer::Optimizer(Settings::Optimizer *settings, Case *base_case,
         case_handler_ = new CaseHandler(tentative_best_case_);
     }
     else {
+        Printer::ext_info("Using shared CaseHandler.", "Optimizer", "Optimization");
         case_handler_ = case_handler;
     }
     if (constraint_handler == 0) {
         constraint_handler_ = new Constraints::ConstraintHandler(settings->constraints(), variables, grid);
     }
     else {
+        Printer::ext_info("Using shared ConstraintHandler.", "Optimizer", "Optimization");
         constraint_handler_ = constraint_handler;
     }
     iteration_ = 0;

--- a/FieldOpt/Optimization/optimizer.h
+++ b/FieldOpt/Optimization/optimizer.h
@@ -28,6 +28,8 @@
 #include "Runner/loggable.hpp"
 #include "Runner/logger.h"
 #include "normalizer.h"
+#include "Utilities/verbosity.h"
+#include "Utilities/printer.hpp"
 
 class Logger;
 

--- a/FieldOpt/Optimization/optimizers/APPS.cpp
+++ b/FieldOpt/Optimization/optimizers/APPS.cpp
@@ -56,7 +56,6 @@ void APPS::iterate() {
         set_active(inactive());
     }
     iteration_++;
-    if (VERB_OPT >= 2) print_state("iteration start");
 }
 
 void APPS::handleEvaluatedCase(Case *c) {
@@ -70,7 +69,7 @@ void APPS::successful_iteration(Case *c) {
     expand();
     reset_active();
     prune_queue();
-    if (VERB_OPT  >= 2) print_state("successful iteration");
+    if (VERB_OPT >= 2) print_state("Successful iteration");
     iterate();
 }
 
@@ -81,7 +80,6 @@ void APPS::unsuccessful_iteration(Case *c) {
         set_inactive(unsuccessful_direction);
         contract(unsuccessful_direction);
     }
-    if (VERB_OPT >= 2) print_state("unsuccessful iteration");
     if (!is_converged()) iterate();
 }
 
@@ -125,13 +123,10 @@ void APPS::prune_queue() {
 void APPS::print_state(string header) {
     std::stringstream ss;
     ss << header << "|";
-    ss << "step_lengths_  : " << vec_to_str(vector<double>(step_lengths_.data(), step_lengths_.data() + step_lengths_.size())) << "|";
-    ss << "active_        : " << vec_to_str(vector<int>(active_.begin(), active_.end())) << "|";
-    ss << "inactive()     : " << vec_to_str(inactive()) << "|";
-    ss << "queue size     : " << case_handler_->QueuedCases().size() << "|";
-    ss << "best case origin:" << "|";
-    ss << " direction idx : " << GetTentativeBestCase()->origin_direction_index() << "|";
-    ss << " step length   : " << GetTentativeBestCase()->origin_step_length() << "|";
+    ss << "Step lengths  : " << vec_to_str(vector<double>(step_lengths_.data(), step_lengths_.data() + step_lengths_.size())) << "|";
+    ss << "Iteration: " << iteration_ << "|";
+    ss << "Current best case: " << tentative_best_case_->id().toString().toStdString() << "|";
+    ss << "              OFV: " << tentative_best_case_->objective_function_value();
     Printer::ext_info(ss.str(), "Optimization", "APPS");
 }
 }

--- a/FieldOpt/Optimization/optimizers/GSS.cpp
+++ b/FieldOpt/Optimization/optimizers/GSS.cpp
@@ -70,8 +70,8 @@ namespace Optimization {
                 }
                 step_lengths_ = base * settings->parameters().auto_step_init_scale;
                 step_tol_ = base * settings->parameters().auto_step_conv_scale;
-                Printer::ext_info("Step lengths: " + eigenvec_to_str(step_lengths_));
-                Printer::ext_info("Step tols: " + eigenvec_to_str(step_tol_));
+                Printer::ext_info("Step lengths: " + eigenvec_to_str(step_lengths_), "Optimization", "GSS");
+                Printer::ext_info("Step tols: " + eigenvec_to_str(step_tol_), "Optimization", "GSS");
                 assert(step_lengths_.size() == directions_.size());
                 assert(step_lengths_.size() == step_tol_.size());
             }

--- a/FieldOpt/Optimization/optimizers/RGARDD.cpp
+++ b/FieldOpt/Optimization/optimizers/RGARDD.cpp
@@ -51,9 +51,10 @@ void RGARDD::iterate() {
     population_ = sortPopulation(population_);
 
     if (is_stagnant()) {
-        if (verbosity_level_ > 1) {
-            cout << "The population has stagnated in generation "
-                 << iteration_ << ". Repopulating." << endl;
+        if (VERB_OPT >= 1) {
+            Printer::ext_info("The population has stagnated in generation" +
+                              Printer::num2str(iteration_) + ". Repopulating",
+                              "RGARDD", "Optimization");
         }
         repopulate();
         iteration_++;
@@ -94,9 +95,9 @@ void RGARDD::handleEvaluatedCase(Case *c) {
         population_[index] = mating_pool_[index];
         if (isImprovement(c)) {
             updateTentativeBestCase(c);
-            if (verbosity_level_ > 1) {
-                cout << "New best in generation " << iteration_ << ": "
-                     << GetTentativeBestCase()->objective_function_value() << endl;
+            if (VERB_OPT >= 1) {
+                Printer::ext_info("New best in generation " + Printer::num2str(iteration_) + ": "
+                + Printer::num2str(GetTentativeBestCase()->objective_function_value()), "RGARDD", "Optimization");
             }
         }
     }

--- a/FieldOpt/Optimization/optimizers/RGARDD.cpp
+++ b/FieldOpt/Optimization/optimizers/RGARDD.cpp
@@ -42,6 +42,7 @@ RGARDD::RGARDD(Settings::Optimizer *settings,
     }
 }
 void RGARDD::iterate() {
+    if (VERB_OPT >= 2) print_state("Iterating with RGARDD");
     if (enable_logging_) {
         logger_->AddEntry(this);
     }
@@ -208,6 +209,15 @@ QUuid RGARDD::ConfigurationSummary::GetId() {
 map<string, vector<double>> RGARDD::ConfigurationSummary::GetValues() {
     map<string, vector<double>> valmap;
     return valmap;
+}
+
+void RGARDD::print_state(string header) {
+    std::stringstream ss;
+    ss << header << "|";
+    ss << "Iteration: " << iteration_ << "|";
+    ss << "Current best case: " << tentative_best_case_->id().toString().toStdString() << "|";
+    ss << "              OFV: " << tentative_best_case_->objective_function_value() << "|";
+    Printer::ext_info(ss.str(), "Optimization", "RGARDD");
 }
 }
 }

--- a/FieldOpt/Optimization/optimizers/RGARDD.cpp
+++ b/FieldOpt/Optimization/optimizers/RGARDD.cpp
@@ -42,6 +42,10 @@ RGARDD::RGARDD(Settings::Optimizer *settings,
     }
 }
 void RGARDD::iterate() {
+    if (case_handler_->QueuedCases().size() > 0 || case_handler_->CasesBeingEvaluated().size() > 0) {
+        Printer::ext_warn("Iteration requested while evaluation queue is not empty. Skipping call.", "Optimization", "RGARDD");
+        return;
+    }
     if (VERB_OPT >= 2) print_state("Iterating with RGARDD");
     if (enable_logging_) {
         logger_->AddEntry(this);
@@ -91,6 +95,15 @@ void RGARDD::handleEvaluatedCase(Case *c) {
             index = i;
             break;
         }
+    }
+    if (index == -1) {
+        if (isImprovement(c)) {
+            Printer::ext_warn("Unable to handle case which would have been an improvement.", "Optimization", "RGARDD");
+        }
+        else {
+            Printer::ext_warn("Unable to handle case (would not have been an improvement).", "Optimization", "RGARDD");
+        }
+        return;
     }
     if (isBetter(c, population_[index].case_pointer)) {
         population_[index] = mating_pool_[index];

--- a/FieldOpt/Optimization/optimizers/RGARDD.h
+++ b/FieldOpt/Optimization/optimizers/RGARDD.h
@@ -130,6 +130,12 @@ class RGARDD : public GeneticAlgorithm {
    */
   void snap_to_bounds(Chromosome &chrom);
 
+  /*!
+   * @brief Print the current state of the optimizer.
+   * @param header Header for print
+   */
+  void print_state(std::string header);
+
   class ConfigurationSummary : public Loggable {
    public:
     ConfigurationSummary(RGARDD *opt) { opt_ = opt; }

--- a/FieldOpt/Runner/runners/mpi_runner.cpp
+++ b/FieldOpt/Runner/runners/mpi_runner.cpp
@@ -32,7 +32,7 @@ namespace Runner {
             }
             world_.send(message.destination, message.tag, s);
             printMessage("Sent a message to " + boost::lexical_cast<std::string>(message.destination)
-                         + " with tag " + boost::lexical_cast<std::string>(message.tag) + " (" + tag_to_string[message.tag] + ")");
+                         + " with tag " + boost::lexical_cast<std::string>(message.tag) + " (" + tag_to_string[message.tag] + ")", 2);
         }
 
         void MPIRunner::RecvMessage(Message &message) {
@@ -54,7 +54,7 @@ namespace Runner {
 
             if (message.tag == TERMINATE) {
                 message.c = nullptr;
-                printMessage("Received termination signal.");
+                printMessage("Received termination signal.", 2);
                 return;
             }
             else if (message.tag == MODEL_SYNC) {

--- a/FieldOpt/Settings/optimizer.cpp
+++ b/FieldOpt/Settings/optimizer.cpp
@@ -346,29 +346,25 @@ Optimizer::Parameters Optimizer::parseParameters(QJsonObject &json_parameters) {
             if (json_parameters["HybridSwitchMode"].toString() == "OnConvergence") {
                 params.hybrid_switch_mode = "OnConvergence";
             }
-            else throw std::runtime_error("HybridSwitchMode setting not recognized.");
-        }
-        else {
-            Printer::ext_warn("HybridSwitchMode not set. Defaulting to OnConvergence", "Optimizer", "Settings");
-            params.hybrid_switch_mode = "OnConvergence";
+            else {
+                throw std::runtime_error("HybridSwitchMode setting not recognized.");
+            }
         }
         if (json_parameters.contains("HybridTerminationCondition")) {
             if (json_parameters["HybridTerminationCondition"].toString() == "NoImprovement") {
                 params.hybrid_termination_condition = "NoImprovement";
-            } else throw std::runtime_error("HybridTerminationCondition setting not recognized.");
-        }
-        else {
-            Printer::ext_warn("HybridTerminationCondition not set. Defaulting to NoImprovement", "Optimizer", "Settings");
-            params.hybrid_termination_condition = "NoImprovement";
+            }
+            else {
+                throw std::runtime_error("HybridTerminationCondition setting not recognized.");
+            }
         }
         if (json_parameters.contains("HybridMaxIterations")) {
             if (json_parameters["HybridMaxIterations"].toInt() >= 1) {
                 params.hybrid_max_iterations = json_parameters["HybridMaxIterations"].toInt();
-            } else throw std::runtime_error("Invalid value for setting HybridMaxIterations");
-        }
-        else {
-            Printer::ext_warn("HybridMaxIterations not set. Defaulting to 2", "Optimizer", "Settings");
-            params.hybrid_max_iterations = 2;
+            }
+            else {
+                throw std::runtime_error("Invalid value for setting HybridMaxIterations");
+            }
         }
 
 

--- a/FieldOpt/Settings/optimizer.cpp
+++ b/FieldOpt/Settings/optimizer.cpp
@@ -38,9 +38,7 @@ Optimizer::Optimizer(QJsonObject json_optimizer)
         if (type_ == Hybrid) {
             hybrid_components_ = parseHybridComponents(json_optimizer);
         }
-        else {
-            parameters_ = parseParameters(json_parameters);
-        }
+        parameters_ = parseParameters(json_parameters);
     }
     objective_ = parseObjective(json_objective);
 

--- a/FieldOpt/Settings/optimizer.cpp
+++ b/FieldOpt/Settings/optimizer.cpp
@@ -93,7 +93,7 @@ Optimizer::Constraint Optimizer::parseSingleConstraint(QJsonObject json_constrai
         if (json_constraint.contains("Min"))
             optimizer_constraint.min = json_constraint["Min"].toDouble();
     }
-    // Packer- and ICV Constraints
+        // Packer- and ICV Constraints
     else if (QString::compare(constraint_type, "ICVConstraint") == 0) {
         optimizer_constraint.type = ConstraintType::ICVConstraint;
         optimizer_constraint.max = json_constraint["Max"].toDouble();
@@ -191,7 +191,7 @@ Optimizer::Constraint Optimizer::parseSingleConstraint(QJsonObject json_constrai
         }
         if (optimizer_constraint.wells.length() != 2)
             throw UnableToParseOptimizerConstraintsSectionException("WellSplineInterwellDistance constraint"
-                                                                        " needs a Wells array with exactly two well names specified.");
+                                                                    " needs a Wells array with exactly two well names specified.");
     }
 
     else if (QString::compare(constraint_type, "ReservoirBoundary") == 0) {
@@ -211,7 +211,7 @@ Optimizer::Constraint Optimizer::parseSingleConstraint(QJsonObject json_constrai
         optimizer_constraint.max_iterations = json_constraint["MaxIterations"].toInt();
         if (optimizer_constraint.wells.length() != 2)
             throw UnableToParseOptimizerConstraintsSectionException("WellSplineInterwellDistance constraint"
-                                                                        " needs a Wells array with exactly two well names specified.");
+                                                                    " needs a Wells array with exactly two well names specified.");
     }
     else if (QString::compare(constraint_type, "CombinedWellSplineLengthInterwellDistanceReservoirBoundary") == 0) {
         optimizer_constraint.type = ConstraintType::CombinedWellSplineLengthInterwellDistanceReservoirBoundary;
@@ -320,8 +320,8 @@ Optimizer::Parameters Optimizer::parseParameters(QJsonObject &json_parameters) {
         }
         if (json_parameters.contains("EGO-Kernel")) {
             QStringList available_kernels = { "CovLinearard", "CovLinearone", "CovMatern3iso",
-                                            "CovMatern5iso", "CovNoise", "CovRQiso", "CovSEard",
-                                            "CovSEiso", "CovPeriodicMatern3iso", "CovPeriodic"};
+                                              "CovMatern5iso", "CovNoise", "CovRQiso", "CovSEard",
+                                              "CovSEiso", "CovPeriodicMatern3iso", "CovPeriodic"};
             if (available_kernels.contains(json_parameters["EGO-Kernel"].toString())) {
                 params.ego_kernel = json_parameters["EGO-Kernel"].toString().toStdString();
             }
@@ -342,6 +342,37 @@ Optimizer::Parameters Optimizer::parseParameters(QJsonObject &json_parameters) {
                 throw std::runtime_error("Failed reading EGO settings.");
             }
         }
+
+        // Hybrid parameters
+        if (json_parameters.contains("HybridSwitchMode")) {
+            if (json_parameters["HybridSwitchMode"].toString() == "OnConvergence") {
+                params.hybrid_switch_mode = "OnConvergence";
+            }
+            else throw std::runtime_error("HybridSwitchMode setting not recognized.");
+        }
+        else {
+            Printer::ext_warn("HybridSwitchMode not set. Defaulting to OnConvergence", "Optimizer", "Settings");
+            params.hybrid_switch_mode = "OnConvergence";
+        }
+        if (json_parameters.contains("HybridTerminationCondition")) {
+            if (json_parameters["HybridTerminationCondition"].toString() == "NoImprovement") {
+                params.hybrid_termination_condition = "NoImprovement";
+            } else throw std::runtime_error("HybridTerminationCondition setting not recognized.");
+        }
+        else {
+            Printer::ext_warn("HybridTerminationCondition not set. Defaulting to NoImprovement", "Optimizer", "Settings");
+            params.hybrid_termination_condition = "NoImprovement";
+        }
+        if (json_parameters.contains("HybridMaxIterations")) {
+            if (json_parameters["HybridMaxIterations"].toInt() >= 1) {
+                params.hybrid_max_iterations = json_parameters["HybridMaxIterations"].toInt();
+            } else throw std::runtime_error("Invalid value for setting HybridMaxIterations");
+        }
+        else {
+            Printer::ext_warn("HybridMaxIterations not set. Defaulting to 2", "Optimizer", "Settings");
+            params.hybrid_max_iterations = 2;
+        }
+
 
         // RNG seed
         if (json_parameters.contains("RNGSeed")) {
@@ -436,31 +467,31 @@ Optimizer::Objective Optimizer::parseObjective(QJsonObject &json_objective) {
         } else {
             obj.separatehorizontalandvertical= false;
         }
-      if (json_objective.contains("UseWellCost")) {
-        obj.use_well_cost = json_objective["UseWellCost"].toBool();
-        if (obj.separatehorizontalandvertical) {
-          if (json_objective.contains("WellCostXY")) {
-            obj.wellCostXY = json_objective["WellCostXY"].toDouble();
-            if (json_objective.contains("WellCostZ")) {
-              obj.wellCostZ = json_objective["WellCostZ"].toDouble();
+        if (json_objective.contains("UseWellCost")) {
+            obj.use_well_cost = json_objective["UseWellCost"].toBool();
+            if (obj.separatehorizontalandvertical) {
+                if (json_objective.contains("WellCostXY")) {
+                    obj.wellCostXY = json_objective["WellCostXY"].toDouble();
+                    if (json_objective.contains("WellCostZ")) {
+                        obj.wellCostZ = json_objective["WellCostZ"].toDouble();
+                    } else {
+                        throw UnableToParseOptimizerObjectiveSectionException(
+                            "Unable to parse optimizer objective a WellCostZ was not defined, while SeparateHorizontalAndVertical was invoked");
+                    }
+                } else {
+                    throw UnableToParseOptimizerObjectiveSectionException(
+                        "Unable to parse optimizer objective a WellCostXY was not defined, while SeparateHorizontalAndVertical was invoked");
+                }
             } else {
-              throw UnableToParseOptimizerObjectiveSectionException(
-                  "Unable to parse optimizer objective a WellCostZ was not defined, while SeparateHorizontalAndVertical was invoked");
+                if (json_objective.contains("WellCost")) {
+                    obj.wellCost = json_objective["WellCost"].toDouble();
+                    obj.wellCostXY = 0;
+                    obj.wellCostZ = 0;
+                } else {
+                    throw UnableToParseOptimizerObjectiveSectionException(
+                        "Unable to parse optimizer objective a WellCost was not defined, while UseWellCost was invoked");
+                }
             }
-          } else {
-            throw UnableToParseOptimizerObjectiveSectionException(
-                "Unable to parse optimizer objective a WellCostXY was not defined, while SeparateHorizontalAndVertical was invoked");
-          }
-        } else {
-          if (json_objective.contains("WellCost")) {
-            obj.wellCost = json_objective["WellCost"].toDouble();
-            obj.wellCostXY = 0;
-            obj.wellCostZ = 0;
-          } else {
-            throw UnableToParseOptimizerObjectiveSectionException(
-                "Unable to parse optimizer objective a WellCost was not defined, while UseWellCost was invoked");
-          }
-        }
 
         } else {
             obj.use_well_cost = false;

--- a/FieldOpt/Settings/optimizer.h
+++ b/FieldOpt/Settings/optimizer.h
@@ -177,7 +177,7 @@ class Optimizer
   OptimizerType type_;
   Parameters parameters_;
   Objective objective_;
-  OptimizerMode mode_;
+  OptimizerMode mode_ = OptimizerMode::Maximize; //!< Optimization mode (maximize or minimize). Default: Maximize
   QList<HybridComponent> hybrid_components_;
 
   OptimizerType parseType(QString &type);

--- a/FieldOpt/Settings/optimizer.h
+++ b/FieldOpt/Settings/optimizer.h
@@ -164,10 +164,12 @@ class Optimizer
 
   OptimizerType type() const { return type_; } //!< Get the Optimizer type (e.g. Compass).
   OptimizerMode mode() const { return mode_; } //!< Get the optimizer mode (maximize/minimize).
+  void set_mode(const OptimizerMode mode) { mode_ = mode; } //!< Set the optimizer mode (used by HybridOptimizer)
   Parameters parameters() const { return parameters_; } //!< Get the optimizer parameters.
   Objective objective() const { return objective_; } //!< Get the optimizer objective function.
   QList<Constraint> constraints() const { return constraints_; } //!< Get the optimizer constraints.
   QList<HybridComponent> HybridComponents() { return hybrid_components_; } // Get the list of hybrid-optimizer components when using the HYBRID type.
+  void SetRngSeed(const int seed) { parameters_.rng_seed = seed; } //!< Change the RNG seed (used by HybridOptimizer).
 
 
  private:

--- a/FieldOpt/Settings/optimizer.h
+++ b/FieldOpt/Settings/optimizer.h
@@ -84,6 +84,39 @@ class Optimizer
     std::string ego_init_sampling_method = "Random"; //!< Sampling method to be used for initial guesses (Random or Uniform)
     std::string ego_kernel = "CovMatern5iso";        //!< Which kernel function to use for the gaussian process model.
     std::string ego_af = "ExpectedImprovement";      //!< Which acquisiton function to use.
+
+    // Hybrid parameters
+    /*!
+     * @brief How switching between component optimizers is handled.
+     *
+     * Default: OnFinished -- switch between components when IsFinished() == true
+     *
+     * Example: "Optimizer": { "Type": "Hybrid", "Parameters": { "HybridSwitchMode": "OnConvergence" } }
+     */
+    std::string hybrid_switch_mode = "OnConvergence";
+
+    /*!
+     * @brief Termination condition for hybrid optimizer.
+     *
+     * Default: NoImprovement -- terminate when a component has not managed to
+     *                           improve upon the result of the previous component.
+     *
+     * Example: "Optimizer": { "Type": "Hybrid", "Parameters": { "HybridTerminationCondition": "NoImprovement" } }
+     */
+    std::string hybrid_termination_condition = "NoImprovement";
+
+    /*!
+     * @brief Max iterations for the hybrid optimizer.
+     *
+     * One iteration implies running each component to completion once.
+     * If
+     *
+     * Default: 2 -- Each component will be executed twice (unleass the HybridTerminationCondition
+     *               is met first).
+     *
+     * Example: "Optimizer": { "Type": "Hybrid", "Parameters": { "HybridMaxIterations": 2 } }
+     */
+    int hybrid_max_iterations = 2;
   };
 
   struct Objective {

--- a/FieldOpt/Settings/paths.cpp
+++ b/FieldOpt/Settings/paths.cpp
@@ -18,13 +18,16 @@
 ******************************************************************************/
 
 #include "paths.h"
+#include "Utilities/printer.hpp"
 
 Paths::Paths() { }
 
 void Paths::SetPath(Paths::Path path, std::string path_string) {
     if (path >= 0 && !FileExists(path_string)) {
-        std::cerr << "ERROR: Cannot set " << GetPathDescription(path)
-                  << " path to non-existing file (" <<  path_string  << ")" << std::endl;
+        std::stringstream ss;
+        ss << "ERROR: Cannot set " << GetPathDescription(path)
+           << " path to non-existing file (" <<  path_string  << ")";
+        Printer::error(ss.str());
         throw std::runtime_error(Paths::GetPathDescription(path) + " not found at " + path_string);
     }
     else if (path < 0 && !DirectoryExists(path_string)) {
@@ -41,7 +44,7 @@ bool Paths::IsSet(Paths::Path path) {
 }
 std::string Paths::GetPath(Paths::Path path) {
     if (!IsSet(path)) {
-        std::cerr << "WARNING: Getting unset variable (" <<  GetPathDescription(path) << ")" << std::endl;
+        Printer::ext_warn("Getting unset variable (" + GetPathDescription(path) + ")", "Settings", "Paths");
         return "UNSET";
     }
     else {

--- a/FieldOpt/Simulation/results/eclresults.cpp
+++ b/FieldOpt/Simulation/results/eclresults.cpp
@@ -16,7 +16,7 @@ ECLResults::ECLResults()
 
 void ECLResults::ReadResults(QString file_path)
 {
-    if (VERB_SIM >= 1) {
+    if (VERB_SIM >= 2) {
         Printer::ext_info("Attempting to read results from" + file_path.toStdString(), "Simulation", "ECLResults");
     }
     file_path_ = file_path;

--- a/FieldOpt/Simulation/simulator_interfaces/driver_file_writers/ecldriverfilewriter.cpp
+++ b/FieldOpt/Simulation/simulator_interfaces/driver_file_writers/ecldriverfilewriter.cpp
@@ -43,7 +43,7 @@ EclDriverFileWriter::EclDriverFileWriter(Settings::Settings *settings, Model::Mo
 
 void EclDriverFileWriter::WriteDriverFile(QString schedule_file_path)
 {
-    if (VERB_SIM >= 1) {
+    if (VERB_SIM >= 2) {
         auto fp = schedule_file_path.toStdString();
         Printer::ext_info("Writing driver file to " + fp + ".", "Simulation", "EclDriverFileWriter");
     }

--- a/FieldOpt/Simulation/simulator_interfaces/eclsimulator.cpp
+++ b/FieldOpt/Simulation/simulator_interfaces/eclsimulator.cpp
@@ -46,21 +46,21 @@ ECLSimulator::ECLSimulator(Settings::Settings *settings, Model::Model *model)
 
 void ECLSimulator::Evaluate()
 {
-    if (VERB_SIM >= 1) { Printer::ext_info("Starting unmonitored evaluation.", "Simulation", "ECLSimulator"); }
-    if (VERB_SIM >= 1) { Printer::info("Copying driver files."); }
+    if (VERB_SIM >= 2) { Printer::ext_info("Starting unmonitored evaluation.", "Simulation", "ECLSimulator"); }
+    if (VERB_SIM >= 2) { Printer::info("Copying driver files."); }
     copyDriverFiles();
-    if (VERB_SIM >= 1) { Printer::info("Updating file paths."); }
+    if (VERB_SIM >= 2) { Printer::info("Updating file paths."); }
     UpdateFilePaths();
     script_args_ = (QStringList() << QString::fromStdString(paths_.GetPath(Paths::SIM_WORK_DIR)) << deck_name_);
     auto driver_file_writer = EclDriverFileWriter(settings_, model_);
-    if (VERB_SIM >= 1) { Printer::info("Writing schedule."); }
+    if (VERB_SIM >= 2) { Printer::info("Writing schedule."); }
     driver_file_writer.WriteDriverFile(QString::fromStdString(paths_.GetPath(Paths::SIM_OUT_SCH_FILE)));
-    if (VERB_SIM >= 1) { Printer::info("Starting unmonitored simulation."); }
+    if (VERB_SIM >= 2) { Printer::info("Starting unmonitored simulation."); }
     Utilities::Unix::ExecShellScript(
         QString::fromStdString(paths_.GetPath(Paths::SIM_EXEC_SCRIPT_FILE)),
         script_args_
     );
-    if (VERB_SIM >= 1) { Printer::info("Unmonitored simulation done. Reading results."); }
+    if (VERB_SIM >= 2) { Printer::info("Unmonitored simulation done. Reading results."); }
     results_->ReadResults(QString::fromStdString(paths_.GetPath(Paths::SIM_OUT_DRIVER_FILE)));
     updateResultsInModel();
 }
@@ -76,17 +76,17 @@ bool ECLSimulator::Evaluate(int timeout, int threads) {
         t = 10; // Always let simulations run for at least 10 seconds
     }
 
-    if (VERB_SIM >= 1) {
+    if (VERB_SIM >= 2) {
         Printer::info("Starting monitored simulation with timeout.");
     }
     bool success = ::Utilities::Unix::ExecShellScriptTimeout(
         QString::fromStdString(paths_.GetPath(Paths::SIM_EXEC_SCRIPT_FILE)),
         script_args_, t);
-    if (VERB_SIM >= 1) {
+    if (VERB_SIM >= 2) {
         Printer::info("Monitored simulation done.");
     }
     if (success) {
-        if (VERB_SIM >= 1) {
+        if (VERB_SIM >= 2) {
             Printer::info("Simulation successful. Reading results.");
         }
         results_->DumpResults();

--- a/FieldOpt/Simulation/simulator_interfaces/eclsimulator.cpp
+++ b/FieldOpt/Simulation/simulator_interfaces/eclsimulator.cpp
@@ -158,7 +158,7 @@ void ECLSimulator::copyDriverFiles() {
         }
     }
     paths_.SetPath(Paths::SIM_WORK_DIR, workdir);
-    if (VERB_SIM >= 1) {
+    if (VERB_SIM >= 2) {
         Printer::ext_info("Done copying directories. Set working directory to: " + workdir,
                           "Simulation",
                           "ECLSimulator");

--- a/FieldOpt/Simulation/simulator_interfaces/ix_simulator.cpp
+++ b/FieldOpt/Simulation/simulator_interfaces/ix_simulator.cpp
@@ -124,7 +124,7 @@ void IXSimulator::copyDriverFiles() {
         }
     }
     paths_.SetPath(Paths::SIM_WORK_DIR, workdir);
-    if (VERB_SIM >= 1) {
+    if (VERB_SIM >= 2) {
         Printer::ext_info("Done copying directories. Set working directory to: " + workdir,
             "Simulation", "IXSimulator");
     }

--- a/FieldOpt/ThirdParty/libecl/lib/util/hash.c
+++ b/FieldOpt/ThirdParty/libecl/lib/util/hash.c
@@ -22,7 +22,6 @@
 #include <string.h>
 #include <stdint.h>
 #include <errno.h>
-
 #include <ert/util/hash.h>
 #include <ert/util/hash_sll.h>
 #include <ert/util/hash_node.h>
@@ -309,26 +308,30 @@ static char ** hash_alloc_keylist__(hash_type *hash , bool lock) {
   char **keylist;
   if (lock) __hash_rdlock( hash );
   {
-    if (hash->elements > 0) {
-      int i = 0;
-      hash_node_type *node = NULL;
-      keylist = (char**)calloc(hash->elements , sizeof *keylist);
-      {
-        uint32_t i = 0;
-        while (i < hash->size && hash_sll_empty(hash->table[i]))
-          i++;
+      if(hash !=NULL){
+        if (hash->elements > 0) {
+          int i = 0;
+          hash_node_type *node = NULL;
+          keylist = (char**)calloc(hash->elements , sizeof *keylist);
+          {
+            uint32_t i = 0;
+            while (i < hash->size && hash_sll_empty(hash->table[i]))
+              i++;
 
-        if (i < hash->size)
-          node = hash_sll_get_head(hash->table[i]);
-      }
+            if (i < hash->size)
+              node = hash_sll_get_head(hash->table[i]);
+          }
 
-      while (node != NULL) {
-        const char *key = hash_node_get_key(node);
-        keylist[i] = util_alloc_string_copy(key);
-        node = hash_internal_iter_next(hash , node);
-        i++;
-      }
-    } else keylist = NULL;
+          while (node != NULL) {
+            const char *key = hash_node_get_key(node);
+            keylist[i] = util_alloc_string_copy(key);
+            node = hash_internal_iter_next(hash , node);
+            i++;
+          }
+        } else keylist = NULL;
+    } else {
+      keylist = NULL;
+    }
   }
   if (lock) __hash_unlock( hash );
   return keylist;
@@ -641,7 +644,11 @@ bool hash_has_key(const hash_type *hash , const char *key) {
 
 
 int hash_get_size(const hash_type *hash) {
-  return hash->elements;
+  if (hash != NULL){
+    return hash->elements;
+  } else {
+    return 0;
+  }
 }
 
 

--- a/FieldOpt/Utilities/printer.hpp
+++ b/FieldOpt/Utilities/printer.hpp
@@ -74,7 +74,6 @@ inline std::vector<std::string> split_line(const std::string text, const int &wi
             strv.push_back(line);
             remainder = remainder.substr(end_idx+1, remainder.size());
             if (end_idx >= width) {
-                truncate_text(remainder);
                 break;
             }
         }

--- a/FieldOpt/Utilities/stringhelpers.hpp
+++ b/FieldOpt/Utilities/stringhelpers.hpp
@@ -6,20 +6,23 @@
 #include <vector>
 #include <boost/lexical_cast.hpp>
 #include <Eigen/Core>
+#include <iomanip>
 
 using namespace std;
 
 template <typename T>
 inline string vec_to_str(vector<T> vec) {
-    string str = "";
-    if (vec.size() == 0) return str;
-    str = boost::lexical_cast<string>(vec[0]);
+    stringstream str;
+    str << std::fixed << scientific << std::setprecision(3);
+    if (vec.size() == 0)
+        return "";
+    str << vec[0];
     if (vec.size() > 1) {
         for (int i = 1; i < vec.size(); ++i) {
-            str = str + ", " + boost::lexical_cast<string>(vec[i]);
+            str << ", " << vec[i];
         }
     }
-    return str;
+    return str.str();
 }
 
 inline string eigenvec_to_str(Eigen::VectorXd vec) {

--- a/FieldOpt/Utilities/verbosity.h
+++ b/FieldOpt/Utilities/verbosity.h
@@ -32,12 +32,12 @@
  */
 
 //                    Module
-#define VERB_MOD 2 // Model
+#define VERB_MOD 1 // Model
 #define VERB_OPT 2 // Optimization
-#define VERB_WIC 2 // WellIndexCalculation
-#define VERB_SIM 2 // Simulation
-#define VERB_RUN 2 // Runner
-#define VERB_RES 2 // Reservoir
-#define VERB_SET 2 // Settings
+#define VERB_WIC 1 // WellIndexCalculation
+#define VERB_SIM 1 // Simulation
+#define VERB_RUN 1 // Runner
+#define VERB_RES 1 // Reservoir
+#define VERB_SET 1 // Settings
 
 #endif //FIELDOPT_VERBOSITY_H

--- a/FieldOpt/Utilities/verbosity.h
+++ b/FieldOpt/Utilities/verbosity.h
@@ -32,12 +32,12 @@
  */
 
 //                    Module
-#define VERB_MOD 1 // Model
-#define VERB_OPT 1 // Optimization
-#define VERB_WIC 1 // WellIndexCalculation
-#define VERB_SIM 1 // Simulation
-#define VERB_RUN 1 // Runner
-#define VERB_RES 1 // Reservoir
-#define VERB_SET 1 // Settings
+#define VERB_MOD 2 // Model
+#define VERB_OPT 2 // Optimization
+#define VERB_WIC 2 // WellIndexCalculation
+#define VERB_SIM 2 // Simulation
+#define VERB_RUN 2 // Runner
+#define VERB_RES 2 // Reservoir
+#define VERB_SET 2 // Settings
 
 #endif //FIELDOPT_VERBOSITY_H

--- a/examples/ECLIPSE/5spot/fo_driver_2_horz_icds_controls_hybrid-alternating.json
+++ b/examples/ECLIPSE/5spot/fo_driver_2_horz_icds_controls_hybrid-alternating.json
@@ -1,18 +1,23 @@
 {
     "Global": {
-        "Name": "5spot-icd-ego",
-        "BookkeeperTolerance": 0.0
+        "Name": "5spot-icd-hybrid-alternating",
+        "BookkeeperTolerance": 5.0
     },
     "Optimizer": {
         "Type": "Hybrid",
         "Mode": "Maximize",
+        "Parameters": {
+            "HybridSwitchMode": "OnConvergence",
+            "HybridTerminationCondition": "NoImprovement",
+            "HybridMaxIterations": 4
+        },
         "HybridComponents": [
             {
                 "Type": "GeneticAlgorithm",
                 "Parameters": {
                     "MaxEvaluations": 2000,
-                    "PopulationSize": 40,
-                    "MaxGenerations": 1,
+                    "PopulationSize": 20,
+                    "MaxGenerations": 4,
                     "CrossoverProbability": 0.1,
                     "DecayRate": 4.0,
                     "MutationStrength": 0.25
@@ -21,10 +26,10 @@
             {
                 "Type": "APPS",
                 "Parameters": {
-                    "MaxEvaluations": 500,
+                    "MaxEvaluations": 120,
                     "AutoStepLengths": true,
-                    "AutoStepInitScale": 0.1,
-                    "AutoStepConvScale": 0.01
+                    "AutoStepInitScale": 0.25,
+                    "AutoStepConvScale": 0.05
                 }
             }
         ],
@@ -43,22 +48,10 @@
         },
         "Constraints": [
             {
-                "Type": "ICVConstraint",
-                "Wells": ["PRODUCER"],
-                "Min": 1e-9,
-                "Max": 1e-2
-            },
-            {
                 "Type": "Rate",
                 "Wells": ["INJECTOR"],
                 "Min": 1000,
                 "Max": 6000
-            },
-            {
-                "Type": "BHP",
-                "Wells": ["PRODUCER"],
-                "Min": 50.0,
-                "Max": 150.0
             }
         ]
     },
@@ -95,45 +88,27 @@
                         "IsVariable": false
                     }
                 },
-                "Segmentation": {
-                    "Tubing": {
-                        "Diameter": 0.1,
-                        "Roughness": 1.52E-5
-                    },
-                    "Annulus": {
-                        "Diameter": 0.04,
-                        "CrossSeactionArea": 0.00817,
-                        "Roughness": 1.52E-5
-                    },
-                    "Compartments": {
-                        "Count": 3,
-                        "VariablePackers": false,
-                        "VariableICDs": true,
-                        "ICDType": "Valve",
-                        "ICDValveSize": 7.85E-5
-                    }
-                },
                 "Controls": [
                     {
                         "TimeStep": 0,
                         "State": "Open",
                         "Mode": "BHP",
                         "BHP": 100.0,
-                        "IsVariable": true
+                        "IsVariable": false
                     },
                     {
                         "TimeStep": 100,
                         "State": "Open",
                         "Mode": "BHP",
                         "BHP": 100.0,
-                        "IsVariable": true
+                        "IsVariable": false
                     },
                     {
                         "TimeStep": 200,
                         "State": "Open",
                         "Mode": "BHP",
                         "BHP": 100.0,
-                        "IsVariable": true
+                        "IsVariable": false
                     }
                 ]
             },

--- a/examples/ECLIPSE/5spot/fo_driver_2_horz_icds_controls_hybrid-alternating.json
+++ b/examples/ECLIPSE/5spot/fo_driver_2_horz_icds_controls_hybrid-alternating.json
@@ -1,0 +1,190 @@
+{
+    "Global": {
+        "Name": "5spot-icd-ego",
+        "BookkeeperTolerance": 0.0
+    },
+    "Optimizer": {
+        "Type": "Hybrid",
+        "Mode": "Maximize",
+        "HybridComponents": [
+            {
+                "Type": "GeneticAlgorithm",
+                "Parameters": {
+                    "MaxEvaluations": 2000,
+                    "PopulationSize": 40,
+                    "MaxGenerations": 1,
+                    "CrossoverProbability": 0.1,
+                    "DecayRate": 4.0,
+                    "MutationStrength": 0.25
+                }
+            },
+            {
+                "Type": "APPS",
+                "Parameters": {
+                    "MaxEvaluations": 500,
+                    "AutoStepLengths": true,
+                    "AutoStepInitScale": 0.1,
+                    "AutoStepConvScale": 0.01
+                }
+            }
+        ],
+        "Objective": {
+            "Type": "WeightedSum",
+            "WeightedSumComponents": [
+                {
+                    "Coefficient": 1.0, "Property": "CumulativeOilProduction", "TimeStep": -1,
+                    "IsWellProp": false
+                },
+                {
+                    "Coefficient": -0.2, "Property": "CumulativeWaterProduction", "TimeStep": -1,
+                    "IsWellProp": false
+                }
+            ]
+        },
+        "Constraints": [
+            {
+                "Type": "ICVConstraint",
+                "Wells": ["PRODUCER"],
+                "Min": 1e-9,
+                "Max": 1e-2
+            },
+            {
+                "Type": "Rate",
+                "Wells": ["INJECTOR"],
+                "Min": 1000,
+                "Max": 6000
+            },
+            {
+                "Type": "BHP",
+                "Wells": ["PRODUCER"],
+                "Min": 50.0,
+                "Max": 150.0
+            }
+        ]
+    },
+    "Simulator": {
+        "Type": "ECLIPSE",
+        "FluidModel": "DeadOil",        
+        "ExecutionScript": "bash_ecl",
+        "ScheduleFile": "include/ECL_5SPOT_SCH.INC" 
+    },
+    "Model": {
+        "ControlTimes": [0, 50, 100, 200, 300],
+        "Reservoir": {
+            "Type": "ECLIPSE"
+        },
+        "Wells": [
+            {
+                "Name": "PRODUCER",
+                "Group": "G1",
+                "Type": "Producer",
+                "DefinitionType": "WellSpline",
+                "PreferredPhase": "Oil",
+                "WellboreRadius": 0.1905,
+                "SplinePoints": {
+                    "Heel": {
+                        "x": 300.0,
+                        "y": 900.0,
+                        "z": 1712.0,
+                        "IsVariable": false
+                    },
+                    "Toe": {
+                        "x": 900.0,
+                        "y": 900.0,
+                        "z": 1712.0,
+                        "IsVariable": false
+                    }
+                },
+                "Segmentation": {
+                    "Tubing": {
+                        "Diameter": 0.1,
+                        "Roughness": 1.52E-5
+                    },
+                    "Annulus": {
+                        "Diameter": 0.04,
+                        "CrossSeactionArea": 0.00817,
+                        "Roughness": 1.52E-5
+                    },
+                    "Compartments": {
+                        "Count": 3,
+                        "VariablePackers": false,
+                        "VariableICDs": true,
+                        "ICDType": "Valve",
+                        "ICDValveSize": 7.85E-5
+                    }
+                },
+                "Controls": [
+                    {
+                        "TimeStep": 0,
+                        "State": "Open",
+                        "Mode": "BHP",
+                        "BHP": 100.0,
+                        "IsVariable": true
+                    },
+                    {
+                        "TimeStep": 100,
+                        "State": "Open",
+                        "Mode": "BHP",
+                        "BHP": 100.0,
+                        "IsVariable": true
+                    },
+                    {
+                        "TimeStep": 200,
+                        "State": "Open",
+                        "Mode": "BHP",
+                        "BHP": 100.0,
+                        "IsVariable": true
+                    }
+                ]
+            },
+            {
+                "Name": "INJECTOR",
+                "Group": "G1",
+                "Type": "Injector",
+                "DefinitionType": "WellSpline",
+                "PreferredPhase": "Water",
+                "WellboreRadius": 0.1905,
+                "SplinePoints": {
+                    "Heel": {
+                        "x": 300.0,
+                        "y": 500.0,
+                        "z": 1712.0,
+                        "IsVariable": false
+                    },
+                    "Toe": {
+                        "x": 772.0,
+                        "y": 500.0,
+                        "z": 1712.0,
+                        "IsVariable": false
+                    }
+                },
+                "Controls": [
+                    {
+                        "TimeStep": 0,
+                        "Type": "Water",
+                        "State": "Open",
+                        "Mode": "Rate",
+                        "Rate": 5000.0,
+                        "IsVariable": true
+                    },
+                    {
+                        "TimeStep": 100,
+                        "Type": "Water",
+                        "State": "Open",
+                        "Mode": "Rate",
+                        "Rate": 5000.0,
+                        "IsVariable": true
+                    },
+                    {
+                        "TimeStep": 200,
+                        "Type": "Water",
+                        "State": "Open",
+                        "Mode": "Rate",
+                        "Rate": 5000.0,
+                        "IsVariable": true
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/examples/ECLIPSE/5spot/run_example.sh
+++ b/examples/ECLIPSE/5spot/run_example.sh
@@ -17,6 +17,7 @@
 #   8 - fo_driver_2_horz_icds_controls_ego
 #   9 - fo_driver_2_horz_icds_controls_hybrid
 #  10 - fo_driver_2_horz_icds_packers_apps
+#  11 - fo_driver_2_horz_icds_controls_hybrid-alternating
 #
 # Assumes that the following shell variables are set:
 #   FIELDOPT_BUILD - Path to the FieldOpt build (bin) directory.
@@ -34,11 +35,11 @@ declare -a CASES=(
     "fo_driver_2_horz_icds_controls_ego"
     "fo_driver_2_horz_icds_controls_hybrid"
     "fo_driver_2_horz_icds_packers_apps"
+    "fo_driver_2_horz_icds_controls_hybrid-alternating"
 )
 
 # Set case and path variables
 CASE_IDX=$(expr $1 - 1)
-echo $CASE_IDX
 CASE=${CASES[$CASE_IDX]}
 CURRENT_DIR=$(pwd)
 DRIVER_PATH=${CURRENT_DIR}/${CASE}.json
@@ -48,7 +49,6 @@ GRID_PATH=${CURRENT_DIR}/ECL_5SPOT.EGRID
 SCR_PATH=${FIELDOPT_BUILD}/execution_scripts/bash_ecl.sh
 
 # Delete and re-create ouput subdirectory
-rm -r ${OUTPUT_DIR}
 mkdir -p ${OUTPUT_DIR}
 
 echo "Output: " ${OUTPUT_DIR}
@@ -56,6 +56,6 @@ echo "Driver: " ${DRIVER_PATH}
 echo "Deck: " ${DECK_PATH}
 echo "Grid: " ${GRID_PATH}
 
-${FIELDOPT_BIN} ${DRIVER_PATH} ${OUTPUT_DIR} -r serial -v3 --force -g ${GRID_PATH} -s ${DECK_PATH} -e ${SCR_PATH}
+${FIELDOPT_BIN} ${DRIVER_PATH} ${OUTPUT_DIR} -r serial -v3 -g ${GRID_PATH} -s ${DECK_PATH} -e ${SCR_PATH}
 #mpirun -n 5 ${FIELDOPT_BIN} ${DRIVER_PATH} ${OUTPUT_DIR} -r mpisync -v3 -m4 --force -g ${GRID_PATH} -s ${DECK_PATH} -e ${SCR_PATH}
 


### PR DESCRIPTION
Extend the hybrid optimizer by allowing for alternating components.
One can now specify how many "super-iterations" should be performed.

Previously, the hybrid optimizer would first run the primary optimizer until the termination condition is reached, then the secondary. Now, after convergence in the secondary, it will switch back to the primary, and repeat a set number of times, or until a component run does not find an improvement at all.

Example driver file snippet:
```
    "Optimizer": {
        "Type": "Hybrid",
        "Mode": "Maximize",
        "Parameters": {
            "RNGSeed": 3,
            "HybridSwitchMode": "OnConvergence",
            "HybridTerminationCondition": "NoImprovement",
            "HybridMaxIterations": 4
        },
        "HybridComponents": [
            {
                "Type": "GeneticAlgorithm",
                "Parameters": {
                    "RNGSeed": 1,
                    "MaxEvaluations": 2000,
                    "PopulationSize": 10,
                    "MaxGenerations": 1,
                    "CrossoverProbability": 0.1,
                    "DecayRate": 4.0,
                    "MutationStrength": 0.10
                }
            },
            {
                "Type": "APPS",
                "Parameters": {
                    "MaxEvaluations": 120,
                    "AutoStepLengths": true,
                    "AutoStepInitScale": 0.10,
                    "AutoStepConvScale": 0.025
                }
            }
        ],
```

Other changes:
* General improvements to hybrid optimization; bug fixes.
* Use the new Printer in more places.
* Adjust the verbosity cutoff for many prints, especially in the simulation module.