### PR TITLE
Cleaned up Docker- and Singularity configurations.

### DIFF
--- a/Docker/Base/Dockerfile
+++ b/Docker/Base/Dockerfile
@@ -1,6 +1,16 @@
 FROM ubuntu:16.04
-MAINTAINER einar90 version: 0.1
+MAINTAINER einar90 version: base
 
+# Build using:
+#   sudo docker build --no-cache -t einar90/fieldopt:base ~/path/to/FieldOpt/Docker/Base
+#   sudo docker push einar90/fieldopt:base
+#
+# This container contains the base for FieldOpt, i.e. all
+# depndencies, pre-compiled.
+# The FieldOpt source-code is in this container, but not built.
+# A different image should be created based on this to create
+# functional FieldOpt images.
+#
 # This is still a work in progress. In order to work fully,
 # the container still needs a simulator.
 # Flow will be added as a default (other simulators may
@@ -28,29 +38,10 @@ RUN git submodule update --init --recursive
 
 # Build the third party dependencies
 WORKDIR /app/FieldOpt/FieldOpt/ThirdParty
-RUN cmake . && make && make install
+RUN cmake -DCMAKE_BUILD_TYPE=Release . && make && make install
 
 # Build the opm-common dependency
 WORKDIR /app/FieldOpt/FieldOpt/ThirdParty/opm-common
 RUN git checkout release/2018.04
-RUN cmake . && make && make install
-
-# Build FieldOpt
-RUN mkdir /app/FieldOpt/FieldOpt/cmake-build-debug
-WORKDIR /app/FieldOpt/FieldOpt/cmake-build-debug
-RUN cmake ..  && make
-WORKDIR /app/FieldOpt/FieldOpt/cmake-build-debug/bin
-
-# Create output directory
-RUN mkdir /app/fieldopt-output
-
-# Define environment variables needed by example runscripts
-ENV NAME FieldOpt
-ENV FIELDOPT_BIN="/app/FieldOpt/FieldOpt/cmake-build-debug/bin/FieldOpt"
-ENV FIELDOPT_BUILD="/app/FieldOpt/FieldOpt/cmake-build-debug/bin/"
-ENV FIELDOPT_OUT="/app/fieldopt-output"
-ENV PATH=$PATH:"/app/FieldOpt/FieldOpt/cmake-build-debug/bin/"
-
-# Execute FieldOpt with the help argument
-CMD ["FieldOpt"]
+RUN cmake -DCMAKE_BUILD_TYPE=Release . && make && make install
 

--- a/Docker/Base/README.md
+++ b/Docker/Base/README.md
@@ -1,0 +1,4 @@
+This Dockerfile configures the base for FieldOpt,
+an image containing all dependencies already compiled.
+FieldOpt is then added to this.
+This reduces the build time for FieldOpt images drastically.

--- a/Docker/Develop/Dockerfile
+++ b/Docker/Develop/Dockerfile
@@ -1,0 +1,40 @@
+FROM einar90/fieldopt:base
+MAINTAINER einar90 version: 1.1-develop
+
+# Build using:
+#   sudo docker build --no-cache -t einar90/fieldopt:develop ~/path/to/FieldOpt/Docker/Develop
+#   sudo docker push einar90/fieldopt:develop
+#
+# This container is based on the fieldopt:base image,
+# which contains the base Ubuntu 16.04 OS as well as
+# repository dependencies and compiled dependencies
+# from GitHub (e.g. OPM).
+#
+# This is still a work in progress. In order to work fully,
+# the container still needs a simulator.
+# Flow will be added as a default (other simulators may
+# of course also be added manually by the user).
+
+
+# Build FieldOpt
+WORKDIR /app/FieldOpt
+RUN git pull
+RUN git checkout develop
+RUN mkdir /app/FieldOpt/FieldOpt/cmake-build-debug
+WORKDIR /app/FieldOpt/FieldOpt/cmake-build-debug
+RUN cmake -DCMAKE_BUILD_TYPE=Debug .. && make
+WORKDIR /app/FieldOpt/FieldOpt/cmake-build-debug/bin
+
+# Create output directory
+RUN mkdir /app/fieldopt-output
+
+# Define environment variables needed by example runscripts
+ENV NAME FieldOpt
+ENV FIELDOPT_BIN="/app/FieldOpt/FieldOpt/cmake-build-debug/bin/FieldOpt"
+ENV FIELDOPT_BUILD="/app/FieldOpt/FieldOpt/cmake-build-debug/bin/"
+ENV FIELDOPT_OUT="/app/fieldopt-output"
+ENV PATH=$PATH:"/app/FieldOpt/FieldOpt/cmake-build-debug/bin/"
+
+# Execute FieldOpt with the help argument
+CMD ["FieldOpt"]
+

--- a/Docker/Develop/README.md
+++ b/Docker/Develop/README.md
@@ -1,0 +1,2 @@
+The configuration files here are used to create
+containers from the 'develop' FieldOpt branch.

--- a/Docker/Develop/Singularity
+++ b/Docker/Develop/Singularity
@@ -1,0 +1,25 @@
+BootStrap: docker
+From: einar90/fieldopt:develop
+
+# Build using
+#   singularity build ~/Singularity-Containers/fieldopt-develop.img ~/git/PCG/FieldOpt/Docker/Develop/Singularity
+#
+
+# These need to be changed to fit the paths you want to use.
+# The paths must exist in the environment on which you want
+# to launch the container.
+%post
+    mkdir -p /work/einarjba/fieldopt/singularity
+
+%post
+    # Setup a very minimal bashrc file
+    mkdir -p /opt
+    echo 'PS1="Singularity \w> "' > /opt/bashrc
+
+%runscript
+    echo "@ Welcome to the Singularity FieldOpt container"
+
+    # Disable annoying sudo message
+    touch ~/.sudo_as_admin_successful
+
+    exec /bin/bash --rcfile /opt/bashrc "$@"

--- a/Docker/Release/Dockerfile
+++ b/Docker/Release/Dockerfile
@@ -1,0 +1,40 @@
+FROM einar90/fieldopt:base
+MAINTAINER einar90 version: 1.0-1
+
+# Build using:
+#   sudo docker build --no-cache -t einar90/fieldopt:release ~/path/to/FieldOpt/Docker/Release
+#   sudo docker push einar90/fieldopt:release
+#
+# This container is based on the fieldopt:base image,
+# which contains the base Ubuntu 16.04 OS as well as
+# repository dependencies and compiled dependencies
+# from GitHub (e.g. OPM).
+#
+# This is still a work in progress. In order to work fully,
+# the container still needs a simulator.
+# Flow will be added as a default (other simulators may
+# of course also be added manually by the user).
+
+
+# Build FieldOpt
+WORKDIR /app/FieldOpt
+RUN git pull
+RUN git checkout master
+RUN mkdir /app/FieldOpt/FieldOpt/cmake-build-debug
+WORKDIR /app/FieldOpt/FieldOpt/cmake-build-debug
+RUN cmake -DCMAKE_BUILD_TYPE=Release .. && make
+WORKDIR /app/FieldOpt/FieldOpt/cmake-build-debug/bin
+
+# Create output directory
+RUN mkdir /app/fieldopt-output
+
+# Define environment variables needed by example runscripts
+ENV NAME FieldOpt
+ENV FIELDOPT_BIN="/app/FieldOpt/FieldOpt/cmake-build-debug/bin/FieldOpt"
+ENV FIELDOPT_BUILD="/app/FieldOpt/FieldOpt/cmake-build-debug/bin/"
+ENV FIELDOPT_OUT="/app/fieldopt-output"
+ENV PATH=$PATH:"/app/FieldOpt/FieldOpt/cmake-build-debug/bin/"
+
+# Execute FieldOpt with the help argument
+CMD ["FieldOpt"]
+

--- a/Docker/Release/README.md
+++ b/Docker/Release/README.md
@@ -1,0 +1,3 @@
+The configuration files here are used to create
+containers from the 'master' FieldOpt branch, i.e.
+containers for releases.

--- a/Docker/Release/Singularity
+++ b/Docker/Release/Singularity
@@ -1,0 +1,25 @@
+BootStrap: docker
+From: einar90/fieldopt:release
+
+# Build using
+#   singularity build ~/Singularity-Containers/fieldopt-release.img ~/git/PCG/FieldOpt/Docker/Release/Singularity
+#
+
+# These need to be changed to fit the paths you want to use.
+# The paths must exist in the environment on which you want
+# to launch the container.
+%post
+    mkdir -p /work/einarjba/fieldopt/singularity
+
+%post
+    # Setup a very minimal bashrc file
+    mkdir -p /opt
+    echo 'PS1="Singularity \w> "' > /opt/bashrc
+
+%runscript
+    echo "@ Welcome to the Singularity FieldOpt container"
+
+    # Disable annoying sudo message
+    touch ~/.sudo_as_admin_successful
+
+    exec /bin/bash --rcfile /opt/bashrc "$@"

--- a/FieldOpt/Settings/optimizer.cpp
+++ b/FieldOpt/Settings/optimizer.cpp
@@ -369,7 +369,7 @@ Optimizer::Parameters Optimizer::parseParameters(QJsonObject &json_parameters) {
             params.vfsa_init_temp = json_parameters["VFSA-InitTemp"].toDouble();
         }
         if (json_parameters.contains("VFSA-TempScale")) {
-            params.vfsa_temp_scale = json_parameters["VFSA-InitTemp"].toDouble();
+            params.vfsa_temp_scale = json_parameters["VFSA-TempScale"].toDouble();
         }
 
         // SPSA Parameters


### PR DESCRIPTION
The docker container is now split into two parts:

Base:
Contains the OS, dependencies from repos, and compiled
dependencies from GitHub, as well as the FieldOpt source code.

Develop/Release:
Builds on Base and pulls from the develop/master branch
before building FieldOpt.

This split makes it significantly faster to build new images,
as the dependencies don't have to be re-compiled every time
something changes.

Corresponding configurations for Singularity containers are
also added. They are based on the Docker images.