### PR TITLE
Fix issue with step lengths

### DIFF
--- a/FieldOpt/Optimization/optimizers/APPS.cpp
+++ b/FieldOpt/Optimization/optimizers/APPS.cpp
@@ -1,6 +1,8 @@
 /******************************************************************************
    Created by einar on 11/21/16.
-   Copyright (C) 2016 Einar J.M. Baumann <einar.baumann@gmail.com>
+   Copyright (C) 2019 Einar J.M. Baumann <einar.baumann@gmail.com>
+
+   Modified by Einar J. M. Baumann <einar.baumann@gmail.com> 02/19/19.
 
    This file is part of the FieldOpt project.
 
@@ -65,7 +67,7 @@ void APPS::handleEvaluatedCase(Case *c) {
 
 void APPS::successful_iteration(Case *c) {
     updateTentativeBestCase(c);
-    set_step_lengths(c->origin_step_length());
+    set_step_lengths(c->origin_direction_index(), c->origin_step_length());
     expand();
     reset_active();
     prune_queue();

--- a/FieldOpt/Optimization/optimizers/APPS.h
+++ b/FieldOpt/Optimization/optimizers/APPS.h
@@ -1,6 +1,8 @@
 /******************************************************************************
    Created by einar on 11/21/16.
-   Copyright (C) 2016 Einar J.M. Baumann <einar.baumann@gmail.com>
+   Copyright (C) 2019 Einar J.M. Baumann <einar.baumann@gmail.com>
+
+   Modified by Einar J. M. Baumann <einar.baumann@gmail.com> 02/19/19.
 
    This file is part of the FieldOpt project.
 

--- a/FieldOpt/Optimization/optimizers/GSS.cpp
+++ b/FieldOpt/Optimization/optimizers/GSS.cpp
@@ -27,152 +27,167 @@
 #include "Utilities/printer.hpp"
 
 namespace Optimization {
-    namespace Optimizers {
+namespace Optimizers {
 
-        GSS::GSS(Settings::Optimizer *settings,
-                 Case *base_case,
-                 Model::Properties::VariablePropertyContainer *variables,
-                 Reservoir::Grid::Grid *grid,
-                 Logger *logger,
-                 CaseHandler *case_handler,
-                 Constraints::ConstraintHandler *constraint_handler
-        )
-                : Optimizer(settings, base_case, variables, grid, logger, case_handler, constraint_handler) {
+GSS::GSS(Settings::Optimizer *settings,
+         Case *base_case,
+         Model::Properties::VariablePropertyContainer *variables,
+         Reservoir::Grid::Grid *grid,
+         Logger *logger,
+         CaseHandler *case_handler,
+         Constraints::ConstraintHandler *constraint_handler
+)
+    : Optimizer(settings, base_case, variables, grid, logger, case_handler, constraint_handler) {
 
-            int numRvars = base_case->GetRealVarVector().size();
-            int numIvars = base_case->GetIntegerVarVector().size();
-            num_vars_ = numRvars + numIvars;
-            if (numRvars > 0 && numIvars > 0)
-                std::cout << ("WARNING: Compass search does not handle both continuous and discrete variables at the same time");
+    int numRvars = base_case->GetRealVarVector().size();
+    int numIvars = base_case->GetIntegerVarVector().size();
+    num_vars_ = numRvars + numIvars;
+    if (numRvars > 0 && numIvars > 0)
+        std::cout << ("WARNING: Compass search does not handle both continuous and discrete variables at the same time");
 
-            contr_fac_ = settings->parameters().contraction_factor;
-            assert(contr_fac_ < 1.0);
+    contr_fac_ = settings->parameters().contraction_factor;
+    assert(contr_fac_ < 1.0);
 
-            expan_fac_ = settings->parameters().expansion_factor;
-            assert(expan_fac_ >= 1.0);
+    expan_fac_ = settings->parameters().expansion_factor;
+    assert(expan_fac_ >= 1.0);
 
-            directions_ = GSSPatterns::Compass(num_vars_);
+    directions_ = GSSPatterns::Compass(num_vars_);
 
-            if (!settings->parameters().auto_step_lengths) {
-                step_lengths_ = Eigen::VectorXd(directions_.size());
-                step_lengths_.fill(settings->parameters().initial_step_length);
-                step_tol_ = Eigen::VectorXd(directions_.size());
-                step_tol_.fill(settings->parameters().minimum_step_length);
-            }
-            else {
-                assert(constraint_handler_->HasBoundaryConstraints());
-                auto lower_bound = constraint_handler_->GetLowerBounds(base_case->GetRealVarIdVector());
-                auto upper_bound = constraint_handler_->GetUpperBounds(base_case->GetRealVarIdVector());
-                auto difference = upper_bound - lower_bound;
-                Eigen::VectorXd base = Eigen::VectorXd(directions_.size());
-                for (int i = 0; i < 2; ++i) {
-                    for (int j = 0; j < difference.size(); ++j) {
-                        base(i*num_vars_+j) = difference(j);
-                    }
-                }
-                step_lengths_ = base * settings->parameters().auto_step_init_scale;
-                step_tol_ = base * settings->parameters().auto_step_conv_scale;
-                Printer::ext_info("Step lengths: " + eigenvec_to_str(step_lengths_), "Optimization", "GSS");
-                Printer::ext_info("Step tols: " + eigenvec_to_str(step_tol_), "Optimization", "GSS");
-                assert(step_lengths_.size() == directions_.size());
-                assert(step_lengths_.size() == step_tol_.size());
-            }
-        }
-
-        Optimizer::TerminationCondition GSS::IsFinished()
-        {
-            TerminationCondition tc = NOT_FINISHED;
-            if (case_handler_->CasesBeingEvaluated().size() > 0)
-                return tc;
-            if (evaluated_cases_ >= max_evaluations_)
-                tc = MAX_EVALS_REACHED;
-            else if (is_converged())
-                tc = MINIMUM_STEP_LENGTH_REACHED;
-
-            if (tc != NOT_FINISHED) {
-                if (enable_logging_) {
-                    logger_->AddEntry(this);
-                    logger_->AddEntry(new Summary(this, tc));
-                }
-            }
-            return tc;
-        }
-
-        void GSS::expand(vector<int> dirs) {
-            if (dirs[0] == -1) {
-                step_lengths_ = step_lengths_ * expan_fac_;
-            }
-            else {
-                for (int dir : dirs)
-                    step_lengths_(dir) = step_lengths_(dir) * expan_fac_;
-            }
-        }
-
-        void GSS::contract(vector<int> dirs) {
-            if (dirs[0] == -1) {
-                step_lengths_ = step_lengths_ * contr_fac_;
-            }
-            else {
-                for (int dir : dirs)
-                    step_lengths_(dir) = step_lengths_(dir) * contr_fac_;
-            }
-        }
-
-        QList<Case *> GSS::generate_trial_points(vector<int> dirs) {
-            auto trial_points = QList<Case *>();
-            if (dirs[0] == -1)
-                dirs = range(0, (int)directions_.size(), 1);
-
-            VectorXi int_base = GetTentativeBestCase()->GetIntegerVarVector();
-            VectorXd rea_base = GetTentativeBestCase()->GetRealVarVector();
-
-            for (int dir : dirs) {
-                auto trial_point = new Case(GetTentativeBestCase());
-                if (int_base.size() > 0) {
-                    trial_point->SetIntegerVarValues(perturb(int_base, dir));
-                }
-                else if (rea_base.size() > 0) {
-                    trial_point->SetRealVarValues(perturb(rea_base, dir));
-                }
-                trial_point->set_origin_data(GetTentativeBestCase(), dir, step_lengths_(dir));
-                trial_points.append(trial_point);
-            }
-
-            for (Case *c : trial_points)
-                constraint_handler_->SnapCaseToConstraints(c);
-
-            return trial_points;
-        }
-
-        template<typename T>
-        Matrix<T, Dynamic, 1> GSS::perturb(Matrix<T, Dynamic, 1> base, int dir) {
-            Matrix<T, Dynamic, 1> dirc = directions_[dir].cast<T>();
-            T sl = step_lengths_(dir);
-            Matrix<T, Dynamic, 1> perturbation = base + dirc * sl;
-            return perturbation;
-        }
-
-        bool GSS::is_converged() {
-            for (int i = 0; i < step_lengths_.size(); ++i) {
-                if (step_lengths_(i) >= step_tol_(i))
-                    return false;
-            }
-            return true;
-        }
-
-        void GSS::set_step_lengths(int dir_idx, double len) {
-            step_lengths_[dir_idx] = len;
-        }
-
-        Case * GSS::dequeue_case_with_worst_origin() {
-            auto queued_cases = case_handler_->QueuedCases();
-            std::sort(queued_cases.begin(), queued_cases.end(),
-                      [this](const Case *c1, const Case *c2) -> bool {
-                          return isBetter(c1, c2);
-                      });
-            case_handler_->DequeueCase(queued_cases.last()->id());
-            return queued_cases.last();
-        }
-
+    if (!settings->parameters().auto_step_lengths) {
+        step_lengths_ = Eigen::VectorXd(directions_.size());
+        step_lengths_.fill(settings->parameters().initial_step_length);
+        step_tol_ = Eigen::VectorXd(directions_.size());
+        step_tol_.fill(settings->parameters().minimum_step_length);
     }
+    else {
+        assert(constraint_handler_->HasBoundaryConstraints());
+        auto lower_bound = constraint_handler_->GetLowerBounds(base_case->GetRealVarIdVector());
+        auto upper_bound = constraint_handler_->GetUpperBounds(base_case->GetRealVarIdVector());
+        auto difference = upper_bound - lower_bound;
+        Eigen::VectorXd base = Eigen::VectorXd(directions_.size());
+        for (int i = 0; i < 2; ++i) {
+            for (int j = 0; j < difference.size(); ++j) {
+                base(i*num_vars_+j) = difference(j);
+            }
+        }
+        step_lengths_ = base * settings->parameters().auto_step_init_scale;
+        step_tol_ = base * settings->parameters().auto_step_conv_scale;
+        Printer::ext_info("Step lengths: " + eigenvec_to_str(step_lengths_), "Optimization", "GSS");
+        Printer::ext_info("Step tols: " + eigenvec_to_str(step_tol_), "Optimization", "GSS");
+        assert(step_lengths_.size() == directions_.size());
+        assert(step_lengths_.size() == step_tol_.size());
+    }
+}
+
+Optimizer::TerminationCondition GSS::IsFinished()
+{
+    TerminationCondition tc = NOT_FINISHED;
+    if (case_handler_->CasesBeingEvaluated().size() > 0)
+        return tc;
+    if (evaluated_cases_ >= max_evaluations_)
+        tc = MAX_EVALS_REACHED;
+    else if (is_converged())
+        tc = MINIMUM_STEP_LENGTH_REACHED;
+
+    if (tc != NOT_FINISHED) {
+        if (enable_logging_) {
+            logger_->AddEntry(this);
+            logger_->AddEntry(new Summary(this, tc));
+        }
+    }
+    return tc;
+}
+
+void GSS::expand(vector<int> dirs) {
+    if (dirs[0] == -1) {
+        step_lengths_ = step_lengths_ * expan_fac_;
+    }
+    else {
+        for (int dir : dirs)
+            step_lengths_(dir) = step_lengths_(dir) * expan_fac_;
+    }
+}
+
+void GSS::contract(vector<int> dirs) {
+    if (dirs[0] == -1) {
+        step_lengths_ = step_lengths_ * contr_fac_;
+    }
+    else {
+        for (int dir : dirs)
+            step_lengths_(dir) = step_lengths_(dir) * contr_fac_;
+    }
+}
+
+QList<Case *> GSS::generate_trial_points(vector<int> dirs) {
+    auto trial_points = QList<Case *>();
+    if (dirs[0] == -1)
+        dirs = range(0, (int)directions_.size(), 1);
+
+    VectorXi int_base = GetTentativeBestCase()->GetIntegerVarVector();
+    VectorXd rea_base = GetTentativeBestCase()->GetRealVarVector();
+
+    for (int dir : dirs) {
+        auto trial_point = new Case(GetTentativeBestCase());
+        if (int_base.size() > 0) {
+            trial_point->SetIntegerVarValues(perturb(int_base, dir));
+        }
+        else if (rea_base.size() > 0) {
+            trial_point->SetRealVarValues(perturb(rea_base, dir));
+        }
+        trial_point->set_origin_data(GetTentativeBestCase(), dir, step_lengths_(dir));
+        trial_points.append(trial_point);
+    }
+
+    for (Case *c : trial_points)
+        constraint_handler_->SnapCaseToConstraints(c);
+
+    return trial_points;
+}
+
+template<typename T>
+Matrix<T, Dynamic, 1> GSS::perturb(Matrix<T, Dynamic, 1> base, int dir) {
+    Matrix<T, Dynamic, 1> dirc = directions_[dir].cast<T>();
+    T sl = step_lengths_(dir);
+    Matrix<T, Dynamic, 1> perturbation = base + dirc * sl;
+    return perturbation;
+}
+
+bool GSS::is_converged() {
+    for (int i = 0; i < step_lengths_.size(); ++i) {
+        if (step_lengths_(i) >= step_tol_(i))
+            return false;
+    }
+    return true;
+}
+
+void GSS::set_step_lengths(int dir_idx, double len) {
+    if (!constraint_handler_->HasBoundaryConstraints()) {
+        Printer::ext_warn("No boundary constraints. Setting all step lengths to " + Printer::num2str(len), "Optimization", "GSS");
+        for (int i = 0; i < step_lengths_.size(); ++i) {
+            step_lengths_[i] = max(step_tol_[i], len);
+        }
+        step_lengths_.fill(len);
+        return;
+    }
+    auto lbs = constraint_handler_->GetLowerBounds(tentative_best_case_->GetRealVarIdVector());
+    auto ubs = constraint_handler_->GetUpperBounds(tentative_best_case_->GetRealVarIdVector());
+    int dir = dir_idx > num_vars_ - 1 ? dir_idx - num_vars_ : dir_idx;
+    double S = (len - lbs[dir]) / (ubs[dir] - lbs[dir]);
+    for (int i = 0; i < num_vars_; ++i) {
+        step_lengths_[i] = max(step_tol_[i], lbs[i] + S * (ubs[i] - lbs[i]));
+        step_lengths_[i+num_vars_] = max(step_tol_[i], lbs[i] + S * (ubs[i] - lbs[i]));
+    }
+}
+
+Case * GSS::dequeue_case_with_worst_origin() {
+    auto queued_cases = case_handler_->QueuedCases();
+    std::sort(queued_cases.begin(), queued_cases.end(),
+              [this](const Case *c1, const Case *c2) -> bool {
+                return isBetter(c1, c2);
+              });
+    case_handler_->DequeueCase(queued_cases.last()->id());
+    return queued_cases.last();
+}
+
+}
 }

--- a/FieldOpt/Optimization/optimizers/GSS.cpp
+++ b/FieldOpt/Optimization/optimizers/GSS.cpp
@@ -1,6 +1,8 @@
 /******************************************************************************
    Created by einar on 11/3/16.
-   Copyright (C) 2016 Einar J.M. Baumann <einar.baumann@gmail.com>
+   Copyright (C) 2019 Einar J.M. Baumann <einar.baumann@gmail.com>
+
+   Modified by Einar J. M. Baumann <einar.baumann@gmail.com> 02/19/19.
 
    This file is part of the FieldOpt project.
 
@@ -158,8 +160,8 @@ namespace Optimization {
             return true;
         }
 
-        void GSS::set_step_lengths(double len) {
-            step_lengths_.fill(len);
+        void GSS::set_step_lengths(int dir_idx, double len) {
+            step_lengths_[dir_idx] = len;
         }
 
         Case * GSS::dequeue_case_with_worst_origin() {

--- a/FieldOpt/Optimization/optimizers/GSS.h
+++ b/FieldOpt/Optimization/optimizers/GSS.h
@@ -1,6 +1,8 @@
 /******************************************************************************
    Created by einar on 11/3/16.
-   Copyright (C) 2016 Einar J.M. Baumann <einar.baumann@gmail.com>
+   Copyright (C) 2019 Einar J.M. Baumann <einar.baumann@gmail.com>
+
+   Modified by Einar J. M. Baumann <einar.baumann@gmail.com> 02/19/19.
 
    This file is part of the FieldOpt project.
 
@@ -105,7 +107,7 @@ namespace Optimization {
              * @brief Set _all_ step lengts to the specified length.
              * @param len The value all step lengths should be set to.
              */
-            void set_step_lengths(double len);
+            void set_step_lengths(int dir_idx, double len);
 
             /*!
              * @brief Generate a set of trial points.

--- a/FieldOpt/Optimization/optimizers/GSS.h
+++ b/FieldOpt/Optimization/optimizers/GSS.h
@@ -30,120 +30,132 @@ using namespace Eigen;
 using namespace std;
 
 namespace Optimization {
-    namespace Optimizers {
+namespace Optimizers {
 
-        /*!
-         * @brief The _abstract_ GSS class implements a generalized form of the
-         * Generating Set Search algorithm presented by Kolda, Torczon and Lewis
-         * in the 2003 paper Optimization By Direct Search: New perspectives on
-         * some classical and modern methods (DOI: 10.1137/S003614450242889)
-         *
-         * This implementation also borrows some from the Kolda's 2005 paper on
-         * the Asynchronous Parallel Pattern Search (APPS) (DOI: 0.1137/040603589)
-         * in that it allows for multiple current step lengths (e.g. one per search
-         * direction). This is to allow for more flexibility in the implementation
-         * of specific algorithms (e.g. APPS).
-         *
-         * @note that this is an abstract class. It must be extended by some other
-         * class (e.g. like the CompassSearch class) to provide specific patterns
-         * and contraction/expansion parameter values.
-         */
-        class GSS : public Optimizer {
-        public:
-            /*!
-             * @brief General constructor for GSS algorithms. Sets the step_tol_ property and calls the primary
-             * Optimizer constructor.
-             *
-             * The following properties must be set in the constructor by classes extending this class:
-             *
-             *      contr_fac_  : The contraction factor.
-             *      expan_fac_  : The expansion factor.
-             *      directions_ : The set of search directions to be used.
-             *      step_lengths_ : The set of step lengts to be used (one per step direction).
-             */
-            GSS(Settings::Optimizer *settings,
-                Case *base_case,
-                Model::Properties::VariablePropertyContainer *variables,
-                Reservoir::Grid::Grid *grid,
-                Logger *logger,
-                CaseHandler *case_handler=0,
-                Constraints::ConstraintHandler *constraint_handler=0
-            );
+/*!
+ * @brief The _abstract_ GSS class implements a generalized form of the
+ * Generating Set Search algorithm presented by Kolda, Torczon and Lewis
+ * in the 2003 paper Optimization By Direct Search: New perspectives on
+ * some classical and modern methods (DOI: 10.1137/S003614450242889)
+ *
+ * This implementation also borrows some from the Kolda's 2005 paper on
+ * the Asynchronous Parallel Pattern Search (APPS) (DOI: 0.1137/040603589)
+ * in that it allows for multiple current step lengths (e.g. one per search
+ * direction). This is to allow for more flexibility in the implementation
+ * of specific algorithms (e.g. APPS).
+ *
+ * @note that this is an abstract class. It must be extended by some other
+ * class (e.g. like the CompassSearch class) to provide specific patterns
+ * and contraction/expansion parameter values.
+ */
+class GSS : public Optimizer {
+ public:
+  /*!
+   * @brief General constructor for GSS algorithms. Sets the step_tol_ property and calls the primary
+   * Optimizer constructor.
+   *
+   * The following properties must be set in the constructor by classes extending this class:
+   *
+   *      contr_fac_  : The contraction factor.
+   *      expan_fac_  : The expansion factor.
+   *      directions_ : The set of search directions to be used.
+   *      step_lengths_ : The set of step lengts to be used (one per step direction).
+   */
+  GSS(Settings::Optimizer *settings,
+      Case *base_case,
+      Model::Properties::VariablePropertyContainer *variables,
+      Reservoir::Grid::Grid *grid,
+      Logger *logger,
+      CaseHandler *case_handler=0,
+      Constraints::ConstraintHandler *constraint_handler=0
+  );
 
-            /*!
-             * \brief IsFinished Check if the optimization is finished.
-             *
-             * This algorithm has two termination conditions: max number of objective function evaluations and
-             * minimum step length.
-             * \return True if the algorithm has finished, otherwise false.
-             */
-            TerminationCondition IsFinished();
+  /*!
+   * \brief IsFinished Check if the optimization is finished.
+   *
+   * This algorithm has two termination conditions: max number of objective function evaluations and
+   * minimum step length.
+   * \return True if the algorithm has finished, otherwise false.
+   */
+  TerminationCondition IsFinished();
 
-        protected:
-            int num_vars_; //!< The number of variables in the problem. This is used in initialization.
-            VectorXd step_tol_; //!< Step length convergence tolerance.
-            double contr_fac_; //!< Step length contraction factor.
-            double expan_fac_; //!< Step length expansion factor.
-            VectorXd step_lengths_; //!< Vector of step lengths.
-            vector<VectorXi> directions_; //!< Vector of search directions.
+ protected:
+  int num_vars_; //!< The number of variables in the problem. This is used in initialization.
+  VectorXd step_tol_; //!< Step length convergence tolerance.
+  double contr_fac_; //!< Step length contraction factor.
+  double expan_fac_; //!< Step length expansion factor.
+  VectorXd step_lengths_; //!< Vector of step lengths.
+  vector<VectorXi> directions_; //!< Vector of search directions.
 
-            /*!
-             * @brief Contract the search pattern: step_lengths_ * contr_fac_
-             *
-             * @param dirs (optional) The direction indices to expand. If not provided,
-             * the expansion will be applied to all directions.
-             */
-            void contract(vector<int> dirs = vector<int>{-1});
+  /*!
+   * @brief Contract the search pattern: step_lengths_ * contr_fac_
+   *
+   * @param dirs (optional) The direction indices to expand. If not provided,
+   * the expansion will be applied to all directions.
+   */
+  void contract(vector<int> dirs = vector<int>{-1});
 
-            /*!
-             * @brief Expand the search pattern: step_lengths_ * expan_fac_
-             *
-             * @param dirs (optional) The direction indices to expand. If not provided,
-             * the expansion will be applied to all directions.
-             */
-            void expand(vector<int> dirs = vector<int>{-1});
+  /*!
+   * @brief Expand the search pattern: step_lengths_ * expan_fac_
+   *
+   * @param dirs (optional) The direction indices to expand. If not provided,
+   * the expansion will be applied to all directions.
+   */
+  void expand(vector<int> dirs = vector<int>{-1});
 
-            /*!
-             * @brief Set _all_ step lengts to the specified length.
-             * @param len The value all step lengths should be set to.
-             */
-            void set_step_lengths(int dir_idx, double len);
+  /*!
+   * @brief Set all step lengths _proportionally_ equal to the length provided.
+   *
+   * This will only work properly if bound constraints are provided for all variables. If not, all directions
+   * will be set to the same value (as described in the original paper): max(step_min, len).
+   *
+   * The modification to the operation described in the paper is intended to account for variables with very different
+   * bounds (e.g. when optimizing using the PolarSpline well formulation, or well placement in general in thin
+   * reservoirs).
+   *
+   * Given that the variable at dir_idx has bounds [min_a, max_a], a number S is computed as
+   * S = (len - min_a)/(max_a - min_a). The step length at dir_idx is set to len, and the remaining
+   * step lengths len_i for each direction i are computed as len_i = max(step_tol_i, min_i + S * (max_i - min_i)).
+   * @param dir_idx The direction index that produced an improvement.
+   * @param len The step length that produced an improvement.
+   */
+  void set_step_lengths(int dir_idx, double len);
 
-            /*!
-             * @brief Generate a set of trial points.
-             * @param dirs (optional) The direction indices in which perturbations
-             * should be created.
-             *
-             * @return A list of new trial points.
-             */
-            QList<Case *> generate_trial_points(vector<int> dirs = vector<int>{-1});
+  /*!
+   * @brief Generate a set of trial points.
+   * @param dirs (optional) The direction indices in which perturbations
+   * should be created.
+   *
+   * @return A list of new trial points.
+   */
+  QList<Case *> generate_trial_points(vector<int> dirs = vector<int>{-1});
 
-            /*!
-             * @brief Check if the algorithm has converged, i.e. if all current step lengths
-             * are below the step length convergence tolerance.
-             * @return
-             */
-            bool is_converged();
+  /*!
+   * @brief Check if the algorithm has converged, i.e. if all current step lengths
+   * are below the step length convergence tolerance.
+   * @return
+   */
+  bool is_converged();
 
-            /*!
-             * @brief Remove the case that has the worst origin from the evaluation queue.
-             * @return Return a pointer to the case that is removed.
-             */
-            Case *dequeue_case_with_worst_origin();
+  /*!
+   * @brief Remove the case that has the worst origin from the evaluation queue.
+   * @return Return a pointer to the case that is removed.
+   */
+  Case *dequeue_case_with_worst_origin();
 
-        private:
+ private:
 
-            /*!
-             * @brief Create a perturbation from a point in the specified direction index.
-             * @tparam T An Eigen::VectorX object.
-             * @param base The point to perturb from.
-             * @param dir The direction index in which to perturb.
-             * @return A perturbation (trial point).
-             */
-            template <typename T>
-            Matrix<T, Dynamic, 1> perturb(Matrix<T, Dynamic, 1> base, int dir);
-        };
+  /*!
+   * @brief Create a perturbation from a point in the specified direction index.
+   * @tparam T An Eigen::VectorX object.
+   * @param base The point to perturb from.
+   * @param dir The direction index in which to perturb.
+   * @return A perturbation (trial point).
+   */
+  template <typename T>
+  Matrix<T, Dynamic, 1> perturb(Matrix<T, Dynamic, 1> base, int dir);
+};
 
-    }
+}
 }
 #endif //FIELDOPT_GSS_H


### PR DESCRIPTION
Previously, at successful iterations, _all_ step lengths would be set to the step length that produced the successful candidate.
This is a problem when running optimizations with AutoScaleStep lengths, as the step lengths along very small dimensions may be set to very  large numbers if a step along a large dimension is successful.

Autoindentation has messed up the diff here quite a bit.
The relevant change is in the `GSS:set_step_lengths` method.