### PR TITLE
Feature/test file paths fix

### DIFF
--- a/FieldOpt/CMakeLists.txt
+++ b/FieldOpt/CMakeLists.txt
@@ -389,6 +389,7 @@ if (NOT (BUILD_WIC_ONLY OR BUILD_WIC_ADGPRS))
 
   ## Create an empty directory for test output
   file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/fieldopt-output)
+  file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/fieldopt-output/norne_test)
 endif()
 
 # Compile options ==========================================

--- a/FieldOpt/ConstraintMath/tests/test_domain_boundary.cpp
+++ b/FieldOpt/ConstraintMath/tests/test_domain_boundary.cpp
@@ -4,6 +4,7 @@
 #include "Reservoir/grid/eclgrid.h"
 #include "ConstraintMath/well_constraint_projections/well_constraint_projections.h"
 #include "Utilities/filehandling.hpp"
+#include "Settings/tests/test_resource_example_file_paths.hpp"
 
 using namespace Reservoir::Grid;
 
@@ -26,7 +27,7 @@ protected:
 
 
     Grid *grid_;
-    std::string file_path_ = "../examples/ADGPRS/5spot/ECL_5SPOT.EGRID";
+  string file_path_ = TestResources::ExampleFilePaths::grid_5spot_;
 };
 
 TEST_F(DomainBoundaryTest, cell_boundary_constraint_test){

--- a/FieldOpt/ERTWrapper/tests/test_eclgridreader.cpp
+++ b/FieldOpt/ERTWrapper/tests/test_eclgridreader.cpp
@@ -19,6 +19,7 @@
 
 #include <gtest/gtest.h>
 #include "ERTWrapper/eclgridreader.h"
+#include "Settings/tests/test_resource_example_file_paths.hpp"
 
 using namespace ERTWrapper::ECLGrid;
 
@@ -41,7 +42,7 @@ class ECLGridReaderTest : public ::testing::Test {
   virtual void TearDown() { }
 
   ECLGridReader* ecl_grid_reader_;
-  std::string file_name_ = "../examples/ECLIPSE/HORZWELL/HORZWELL.EGRID";
+  std::string file_name_ = TestResources::ExampleFilePaths::grid_horzwel_;
 
   // Objects declared here can be used by all tests in this test case.
 

--- a/FieldOpt/ERTWrapper/tests/test_eclsummaryreader.cpp
+++ b/FieldOpt/ERTWrapper/tests/test_eclsummaryreader.cpp
@@ -20,6 +20,7 @@
 #include <gtest/gtest.h>
 #include "ERTWrapper/eclsummaryreader.h"
 #include "ERTWrapper/ertwrapper_exceptions.h"
+#include "Settings/tests/test_resource_example_file_paths.hpp"
 
 using namespace ERTWrapper::ECLSummary;
 
@@ -39,7 +40,7 @@ class ECLSummaryReaderTest : public ::testing::Test {
   virtual void TearDown() { }
 
   ECLSummaryReader *ecl_summary_reader_;
-  std::string file_name_ = "../examples/ECLIPSE/HORZWELL/HORZWELL";
+  std::string file_name_ = TestResources::ExampleFilePaths::grid_horzwel_;
 };
 
 TEST_F(ECLSummaryReaderTest, ReportSteps) {

--- a/FieldOpt/Hdf5SummaryReader/tests/test_hdf5_summary_reader.cpp
+++ b/FieldOpt/Hdf5SummaryReader/tests/test_hdf5_summary_reader.cpp
@@ -1,5 +1,6 @@
 #include "../hdf5_summary_reader.h"
 #include <gtest/gtest.h>
+#include "Settings/tests/test_resource_example_file_paths.hpp"
 
 namespace {
     class Hdf5SummaryReaderTest : public ::testing::Test {
@@ -10,8 +11,8 @@ namespace {
     protected:
         virtual void SetUp() {}
         virtual void TearDown() {}
-        std::string file_path = "../examples/ADGPRS/5spot/5SPOT.vars.h5";
-        std::string file_path_gpt = "../examples/ADGPRS/5spot/5SPOT-gpt.vars.h5";
+        std::string file_path = TestResources::ExampleFilePaths::gprs_smry_hdf5_5spot_;
+        std::string file_path_gpt = TestResources::ExampleFilePaths::gprs_smry_gpt_hdf5_5spot_;
     };
 
     TEST_F(Hdf5SummaryReaderTest, Constructor) {

--- a/FieldOpt/Model/tests/test_resource_model.h
+++ b/FieldOpt/Model/tests/test_resource_model.h
@@ -31,7 +31,7 @@ class TestResourceModel : public TestResourceSettings,
 {
  protected:
   TestResourceModel() {
-      settings_full_->paths().SetPath(Paths::GRID_FILE, ExampleFilePaths::grid_5spot_.toStdString());
+      settings_full_->paths().SetPath(Paths::GRID_FILE, ExampleFilePaths::grid_5spot_);
       model_ = new Model::Model(*settings_full_, logger_);
 
   }

--- a/FieldOpt/Model/tests/wells/test_block_to_spline_conversion.cpp
+++ b/FieldOpt/Model/tests/wells/test_block_to_spline_conversion.cpp
@@ -7,6 +7,7 @@
 #include "Settings/settings.h"
 #include "Settings/tests/test_resource_schedule_import_settings.hpp"
 #include "Settings/paths.h"
+#include "Settings/tests/test_resource_example_file_paths.hpp"
 
 namespace {
 
@@ -14,9 +15,9 @@ class BlockToSplineConversionTest : public ::testing::Test {
  protected:
   BlockToSplineConversionTest() {
       auto partial_deck = TestResources::TestResourceSettings::imported_model_settings;
-      paths_.SetPath(Paths::SIM_DRIVER_FILE, "../examples/ECLIPSE/norne-simplified/NORNE_SIMPLIFIED.DATA");
-      paths_.SetPath(Paths::GRID_FILE, "../examples/ECLIPSE/norne-simplified/NORNE_SIMPLIFIED.EGRID");
-      paths_.SetPath(Paths::SIM_SCH_FILE, "../examples/ECLIPSE/norne-simplified/INCLUDE/BC0407_HIST01122006.SCH");
+      paths_.SetPath(Paths::SIM_DRIVER_FILE, TestResources::ExampleFilePaths::norne_deck_);
+      paths_.SetPath(Paths::GRID_FILE, TestResources::ExampleFilePaths::norne_grid_);
+      paths_.SetPath(Paths::SIM_SCH_FILE, TestResources::ExampleFilePaths::norne_sch_);
       sim_json_ = partial_deck["Simulator"].toObject();
       mod_json_ = partial_deck["Model"].toObject();
       sim_settings_ = new Settings::Simulator(sim_json_, paths_);

--- a/FieldOpt/Model/tests/wells/test_segmented_well.cpp
+++ b/FieldOpt/Model/tests/wells/test_segmented_well.cpp
@@ -8,6 +8,7 @@
 #include "Settings/settings.h"
 #include "Settings/tests/test_resource_schedule_segmentation_settings.hpp"
 #include "Settings/paths.h"
+#include "Settings/tests/test_resource_example_file_paths.hpp"
 
 using namespace Model::Wells;
 
@@ -17,9 +18,9 @@ class SegmentedWellTest : public ::testing::Test {
  protected:
   SegmentedWellTest() {
       auto partial_deck = TestResources::TestResourceSettings::multisegment_model_settings;
-      paths_.SetPath(Paths::SIM_DRIVER_FILE, "../examples/ECLIPSE/norne-simplified/NORNE_SIMPLIFIED.DATA");
-      paths_.SetPath(Paths::GRID_FILE, "../examples/ECLIPSE/norne-simplified/NORNE_SIMPLIFIED.EGRID");
-      paths_.SetPath(Paths::SIM_SCH_FILE, "../examples/ECLIPSE/norne-simplified/INCLUDE/BC0407_HIST01122006.SCH");
+      paths_.SetPath(Paths::SIM_DRIVER_FILE, TestResources::ExampleFilePaths::norne_deck_);
+      paths_.SetPath(Paths::GRID_FILE, TestResources::ExampleFilePaths::norne_grid_);
+      paths_.SetPath(Paths::SIM_SCH_FILE, TestResources::ExampleFilePaths::norne_sch_);
       sim_json_ = partial_deck["Simulator"].toObject();
       mod_json_ = partial_deck["Model"].toObject();
       sim_settings_ = new Settings::Simulator(sim_json_, paths_);

--- a/FieldOpt/Model/tests/wells/test_trajectory.cpp
+++ b/FieldOpt/Model/tests/wells/test_trajectory.cpp
@@ -78,7 +78,7 @@ TEST_F(TrajectoryTest, VariableContainerConsistencyAfterCreation) {
 
 TEST_F(TrajectoryTest, MultisplineWell) {
     Paths paths;
-    paths.SetPath(Paths::GRID_FILE, TestResources::ExampleFilePaths::grid_5spot_.toStdString());
+    paths.SetPath(Paths::GRID_FILE, TestResources::ExampleFilePaths::grid_5spot_);
     auto settings = Settings::Model(TestResources::TestResourceModelSettingSnippets::model_adtl_pts(), paths);
     auto wsettings = settings.wells()[0];
     auto varcont = new Model::Properties::VariablePropertyContainer();

--- a/FieldOpt/Model/tests/wells/test_trajectory_curve.cpp
+++ b/FieldOpt/Model/tests/wells/test_trajectory_curve.cpp
@@ -56,7 +56,7 @@ TEST_F(TrajectoryCurveTest, SimpleBezier) {
 }
 TEST_F(TrajectoryCurveTest, WellApplication) {
   Paths paths;
-  paths.SetPath(Paths::GRID_FILE, TestResources::ExampleFilePaths::grid_5spot_.toStdString());
+  paths.SetPath(Paths::GRID_FILE, TestResources::ExampleFilePaths::grid_5spot_);
   auto settings = Settings::Model(TestResources::TestResourceModelSettingSnippets::model_bezier_well(), paths);
   auto wsettings = settings.wells()[0];
   wsettings.use_bezier_spline = true;

--- a/FieldOpt/Reservoir/tests/test_resource_grids.h
+++ b/FieldOpt/Reservoir/tests/test_resource_grids.h
@@ -22,18 +22,15 @@
 
 #include "Reservoir/grid/grid.h"
 #include "Reservoir/grid/eclgrid.h"
+#include "Settings/tests/test_resource_example_file_paths.hpp"
 
 namespace TestResources {
 class TestResourceGrids {
  protected:
   TestResourceGrids() {
-      grid_horzwel_ = new Reservoir::Grid::ECLGrid(
-          "../examples/ECLIPSE/HORZWELL/HORZWELL.EGRID");
-      grid_5spot_ = new Reservoir::Grid::ECLGrid(
-          "../examples/ADGPRS/5spot/ECL_5SPOT.EGRID");
-      grid_norne_ = new Reservoir::Grid::ECLGrid(
-          "../examples/Flow/norne/NORNE_ATW2013.EGRID"
-      );
+      grid_horzwel_ = new Reservoir::Grid::ECLGrid(TestResources::ExampleFilePaths::grid_horzwel_);
+      grid_5spot_ = new Reservoir::Grid::ECLGrid(TestResources::ExampleFilePaths::grid_5spot_);
+      grid_norne_ = new Reservoir::Grid::ECLGrid(TestResources::ExampleFilePaths::norne_atw_grid_);
   }
 
   Reservoir::Grid::Grid *grid_5spot_;

--- a/FieldOpt/Runner/runtime_settings.cpp
+++ b/FieldOpt/Runner/runtime_settings.cpp
@@ -19,6 +19,7 @@
 #include "runtime_settings.h"
 #include <boost/lexical_cast.hpp>
 #include <QtCore/QUuid>
+#include "Utilities/system.hpp"
 
 namespace Runner {
 
@@ -88,7 +89,11 @@ RuntimeSettings::RuntimeSettings(int argc, const char *argv[])
 
     if (vm.count("fieldopt-build-dir")) {
         paths_.SetPath(Paths::BUILD_DIR, vm["fieldopt-build-dir"].as<std::string>());
-    } else paths_.SetPath(Paths::BUILD_DIR, GetAbsoluteFilePath(QString("./")).toStdString());
+    } else if (is_env_var_set("FIELDOPT_BUILD_ROOT")) {
+        paths_.SetPath(Paths::BUILD_DIR, get_env_var_value("FIELDOPT_BUILD_ROOT"));
+    } else {
+        paths_.SetPath(Paths::BUILD_DIR, GetAbsoluteFilePath(QString("./")).toStdString());
+    }
 
     if (vm.count("grid-path")) {
         paths_.SetPath(Paths::GRID_FILE, vm["grid-path"].as<std::string>());

--- a/FieldOpt/Runner/tests/test_resource_runner.hpp
+++ b/FieldOpt/Runner/tests/test_resource_runner.hpp
@@ -29,10 +29,10 @@ class RunnerResources {
  private:
   const int argc = 16;
   const char *argv[16] = {"FieldOpt",
-                          "../examples/ADGPRS/5spot/fo_driver_5vert_wells.json",
-                          "../fieldopt-output",
-                          "-g", "../examples/Flow/5spot/5SPOT.EGRID",
-                          "-s", "../examples/Flow/5spot/5SPOT.DATA",
+                          TestResources::ExampleFilePaths::driver_5spot_.c_str(),
+                          TestResources::ExampleFilePaths::directory_output_.c_str(),
+                          "-g", TestResources::ExampleFilePaths::grid_flow_5spot_.c_str(),
+                          "-s", TestResources::ExampleFilePaths::deck_flow_5spot_.c_str(),
                           "-b", ".",
                           "-r", "mpisync",
                           "-f",
@@ -41,8 +41,8 @@ class RunnerResources {
   };
  protected:
   Runner::RuntimeSettings *rts_ = new Runner::RuntimeSettings(argc, argv);
-  Logger *logger_ = new Logger(rts_, TestResources::ExampleFilePaths::directory_output_, false);
-  Logger *logger_norne_ = new Logger(rts_, TestResources::ExampleFilePaths::norne_test_output_, false);
+  Logger *logger_ = new Logger(rts_, QString::fromStdString(TestResources::ExampleFilePaths::directory_output_), false);
+  Logger *logger_norne_ = new Logger(rts_,  QString::fromStdString(TestResources::ExampleFilePaths::norne_test_output_), false);
 };
 
 }

--- a/FieldOpt/Runner/tests/test_runtime_settings.cpp
+++ b/FieldOpt/Runner/tests/test_runtime_settings.cpp
@@ -1,15 +1,16 @@
 #include <gtest/gtest.h>
 #include "Runner/runtime_settings.h"
+#include "Settings/tests/test_resource_example_file_paths.hpp"
 
 namespace {
 
     class RuntimeSettingsTest : public testing::Test {
         int argc = 16;
         const char *argv[16] = {"FieldOpt",
-                        "../examples/ADGPRS/5spot/fo_driver_5vert_wells.json",
-                        "../fieldopt-output",
-                        "-g", "../examples/Flow/5spot/5SPOT.EGRID",
-                        "-s", "../examples/examples/Flow/5spot/5SPOT.DATA",
+                        TestResources::ExampleFilePaths::driver_5spot_.c_str(),
+                        TestResources::ExampleFilePaths::directory_output_.c_str(),
+                        "-g", TestResources::ExampleFilePaths::grid_flow_5spot_.c_str(),
+                        "-s", TestResources::ExampleFilePaths::deck_flow_5spot_.c_str(),
                         "-b", ".",
                         "-r", "mpisync",
                         "-f",

--- a/FieldOpt/Settings/tests/driver/driver.json
+++ b/FieldOpt/Settings/tests/driver/driver.json
@@ -68,21 +68,19 @@
                 "BoxJmin": 0,
                 "BoxJmax": 9,
                 "BoxKmin": 0,
-                "BoxKmax": 0                
+                "BoxKmax": 0
             }
         ]
     },
     "Simulator": {
         "Type": "ECLIPSE",
         "ExecutionScript": "csh_eclrun",
-        "Commands": ["tcsh -c \"eval source ~/.cshrc; eclrun eclipse\""],
-        "DriverPath": "../examples/ECLIPSE/HORZWELL/HORZWELL.DATA"
+        "Commands": ["tcsh -c \"eval source ~/.cshrc; eclrun eclipse\""]
     },
     "Model": {
         "ControlTimes": [0, 50, 100, 365],
         "Reservoir": {
-            "Type": "ECLIPSE",
-            "Path": "../examples/ADGPRS/5spot/ECL_5SPOT.EGRID"
+            "Type": "ECLIPSE"
         },
         "Wells": [
             {

--- a/FieldOpt/Settings/tests/driver/driver_hybridopt.json
+++ b/FieldOpt/Settings/tests/driver/driver_hybridopt.json
@@ -58,14 +58,12 @@
     "Simulator": {
         "Type": "ECLIPSE",
         "ExecutionScript": "csh_eclrun",
-        "Commands": ["tcsh -c \"eval source ~/.cshrc; eclrun eclipse\""],
-        "DriverPath": "../examples/ECLIPSE/HORZWELL/HORZWELL.DATA"
+        "Commands": ["tcsh -c \"eval source ~/.cshrc; eclrun eclipse\""]
     },
     "Model": {
         "ControlTimes": [0, 50, 100, 365],
         "Reservoir": {
-            "Type": "ECLIPSE",
-            "Path": "../examples/ADGPRS/5spot/ECL_5SPOT.EGRID"
+            "Type": "ECLIPSE"
         },
         "Wells": [
             {

--- a/FieldOpt/Settings/tests/driver/driver_sane.json
+++ b/FieldOpt/Settings/tests/driver/driver_sane.json
@@ -36,14 +36,12 @@
     "Simulator": {
         "Type": "ECLIPSE",
         "ExecutionScript": "csh_eclrun",
-        "Commands": ["tcsh -c \"eval source ~/.cshrc; eclrun eclipse\""],
-        "DriverPath": "../examples/ECLIPSE/HORZWELL/HORZWELL.DATA"
+        "Commands": ["tcsh -c \"eval source ~/.cshrc; eclrun eclipse\""]
     },
     "Model": {
         "ControlTimes": [0, 50, 100, 365],
         "Reservoir": {
-            "Type": "ECLIPSE",
-            "Path": "../examples/ADGPRS/5spot/ECL_5SPOT.EGRID"
+            "Type": "ECLIPSE"
         },
         "Wells": [
             {

--- a/FieldOpt/Settings/tests/test_deck_parser.cpp
+++ b/FieldOpt/Settings/tests/test_deck_parser.cpp
@@ -39,28 +39,14 @@ class DeckParserTest : public ::testing::Test {
 };
 
 TEST_F(DeckParserTest, Initialization) {
-    DeckParser dp = DeckParser("../examples/ECLIPSE/norne-simplified/NORNE_SIMPLIFIED.DATA");
-//    DeckParser dp = DeckParser("/home/einar/Documents/GitHub/PCG/Models/ECLIPSE/olympus_ensemble/OLYMPUS_1/OLYMPUS_1.DATA");
-//    DeckParser dp = DeckParser(TestResources::ExampleFilePaths::deck_horzwel_.toStdString());
-//    auto wells = dp.GetWellData();
-//
-//    for (int i = 0; i < dp.GetTimeDays().size(); ++i) {
-//        std::cout << i << "\t" << dp.GetTimeDays()[i] << "\t" << dp.GetTimeDates()[i] << std::endl;
-//    }
-//
-//    for (auto well : wells) {
-//        std::cout << well.toString();
-//        for (int i=0; i < 3 && i < well.controls.size(); ++i) {
-//            std::cout << well.controls[i].toString() << std::endl;
-//        }
-//    }
+    DeckParser dp = DeckParser(TestResources::ExampleFilePaths::norne_deck_);
 }
 
 TEST_F(DeckParserTest, NumberOfWells) {
     // 1: C-4H i // 2: B-2H // 3: D-2H
     // 4: B-4H   // 5: D-4H // 6: C-1H i // 7: E-3H
     // 8: C-2H i // 9: B-1H //10: C-3H i //11: F-1H i
-    DeckParser dp = DeckParser("../examples/ECLIPSE/norne-simplified/NORNE_SIMPLIFIED.DATA");
+    DeckParser dp = DeckParser(TestResources::ExampleFilePaths::norne_deck_);
     auto wells = dp.GetWellData();
     EXPECT_EQ(wells.size(), 11);
 
@@ -82,7 +68,7 @@ TEST_F(DeckParserTest, NumberOfWells) {
 }
 
 TEST_F(DeckParserTest, NumberOfConnections) {
-    DeckParser dp = DeckParser("../examples/ECLIPSE/norne-simplified/NORNE_SIMPLIFIED.DATA");
+    DeckParser dp = DeckParser(TestResources::ExampleFilePaths::norne_deck_);
     auto wells = dp.GetWellData();
     std::vector<int> n_conns = { 6,  // C-4H
                                  7,  // B-2H

--- a/FieldOpt/Settings/tests/test_multisegment_compartmentalization.cpp
+++ b/FieldOpt/Settings/tests/test_multisegment_compartmentalization.cpp
@@ -22,6 +22,7 @@
 #include "Settings/model.h"
 #include "Settings/simulator.h"
 #include "Settings/tests/test_resource_schedule_segmentation_settings.hpp"
+#include "Settings/tests/test_resource_example_file_paths.hpp"
 
 namespace {
 
@@ -29,8 +30,8 @@ class MultisegmentCompartmentalizationTest : public ::testing::Test {
  protected:
   MultisegmentCompartmentalizationTest() {
       auto partial_deck = TestResources::TestResourceSettings::multisegment_model_settings;
-      paths_.SetPath(Paths::SIM_DRIVER_FILE, "../examples/ECLIPSE/norne-simplified/NORNE_SIMPLIFIED.DATA");
-      paths_.SetPath(Paths::SIM_SCH_FILE, "../examples/ECLIPSE/norne-simplified/INCLUDE/BC0407_HIST01122006.SCH");
+      paths_.SetPath(Paths::SIM_DRIVER_FILE, TestResources::ExampleFilePaths::norne_deck_);
+      paths_.SetPath(Paths::SIM_SCH_FILE, TestResources::ExampleFilePaths::norne_sch_);
       sim_json_ = partial_deck["Simulator"].toObject();
       mod_json_ = partial_deck["Model"].toObject();
   }

--- a/FieldOpt/Settings/tests/test_resource_example_file_paths.hpp
+++ b/FieldOpt/Settings/tests/test_resource_example_file_paths.hpp
@@ -5,35 +5,46 @@
 #ifndef FIELDOPT_TEST_RESOURCE_EXAMPLE_FILE_PATHS_H
 #define FIELDOPT_TEST_RESOURCE_EXAMPLE_FILE_PATHS_H
 
-#include <QString>
+#include "Utilities/system.hpp"
+#include <string>
 
 namespace TestResources {
 namespace ExampleFilePaths {
-static QString driver_example_ = "../examples/driver.json";
-static QString hybridopt_driver_example_ = "../examples/driver_hybridopt.json";
-static QString directory_output_ = "../fieldopt-output";
 
-static QString deck_horzwel_ = "../examples/ECLIPSE/HORZWELL/HORZWELL.DATA";
+inline std::string base_path() {
+    char const* fieldopt_path = getenv("FIELDOPT_BUILD_ROOT");
+    if (!is_env_var_set("FIELDOPT_BUILD_ROOT")) {
+        return "..";
+    }
+    else {
+        return get_env_var_value("FIELDOPT_BUILD_ROOT");
+    }
+}
 
-static QString grid_horzwel_ = "../examples/ECLIPSE/HORZWELL/HORZWELL.EGRID";
-static QString grid_5spot_ = "../examples/ADGPRS/5spot/ECL_5SPOT.EGRID";
-//        static QString grid_5spot_flow_ = "../examples/Flow/5spot/5SPOT.EGRID";
-
-static QString ecl_base_horzwell = "../examples/ECLIPSE/HORZWELL/HORZWELL";
-
-static QString driver_5spot_ = "../examples/ADGPRS/5spot/fo_driver_5vert_wells.json";
-static QString gprs_drv_5spot_ = "../examples/ADGPRS/5spot/5SPOT.gprs";
-static QString gprs_smry_json_5spot_ = "../examples/ADGPRS/5spot/5SPOT.json";
-static QString gprs_smry_hdf5_5spot_ = "../examples/ADGPRS/5spot/5SPOT.vars.h5";
-static QString gprs_base_5spot_ = "../examples/ADGPRS/5spot/5SPOT";
-
-static QString norne_driver_example_ = "../examples/ECLIPSE/norne-simplified/fo_driver.1_rate.cs.json";
-static QString norne_grid_           = "../examples/ECLIPSE/norne-simplified/NORNE_SIMPLIFIED.EGRID";
-static QString norne_test_output_ = "../fieldopt-output/norne_test";
-
-//        static QString driver_5spot_flow_ = "../examples/Flow/5spot/fo_driver_2_horz_placement.json";
-//        static QString flow_drv_5spot_ = "../examples/Flow/5spot/5SPOT.DATA";
-//        static QString flow_base_5spot_ = "../exampels/Flow/5spot";
+static std::string bin_dir_                  = base_path() + "/bin/";
+static std::string driver_example_           = base_path() + "/examples/driver.json";
+static std::string hybridopt_driver_example_ = base_path() + "/examples/driver_hybridopt.json";
+static std::string directory_output_         = base_path() + "/fieldopt-output";
+static std::string norne_test_output_        = base_path() + "/fieldopt-output/norne_test";
+static std::string norne_driver_example_     = base_path() + "/examples/ECLIPSE/norne-simplified/fo_driver.1_rate.cs.json";
+static std::string norne_grid_               = base_path() + "/examples/ECLIPSE/norne-simplified/NORNE_SIMPLIFIED.EGRID";
+static std::string norne_atw_grid_           = base_path() + "/examples/Flow/norne/NORNE_ATW2013.EGRID";
+static std::string norne_deck_               = base_path() + "/examples/ECLIPSE/norne-simplified/NORNE_SIMPLIFIED.DATA";
+static std::string norne_sch_                = base_path() + "/examples/ECLIPSE/norne-simplified/INCLUDE/BC0407_HIST01122006.SCH";
+static std::string deck_horzwel_             = base_path() + "/examples/ECLIPSE/HORZWELL/HORZWELL.DATA";
+static std::string grid_horzwel_             = base_path() + "/examples/ECLIPSE/HORZWELL/HORZWELL.EGRID";
+static std::string ecl_base_horzwell         = base_path() + "/examples/ECLIPSE/HORZWELL/HORZWELL";
+static std::string grid_5spot_               = base_path() + "/examples/ADGPRS/5spot/ECL_5SPOT.EGRID";
+static std::string driver_5spot_             = base_path() + "/examples/ADGPRS/5spot/fo_driver_5vert_wells.json";
+static std::string grid_flow_5spot_          = base_path() + "/examples/Flow/5spot/5SPOT.EGRID";
+static std::string deck_flow_5spot_          = base_path() + "/examples/Flow/5spot/5SPOT.DATA";
+static std::string gprs_drv_5spot_           = base_path() + "/examples/ADGPRS/5spot/5SPOT.gprs";
+static std::string gprs_smry_json_5spot_     = base_path() + "/examples/ADGPRS/5spot/5SPOT.json";
+static std::string gprs_smry_hdf5_5spot_     = base_path() + "/examples/ADGPRS/5spot/5SPOT.vars.h5";
+static std::string gprs_base_5spot_          = base_path() + "/examples/ADGPRS/5spot/5SPOT";
+static std::string gprs_smry_gpt_hdf5_5spot_ = base_path() + "/examples/ADGPRS/5spot/5SPOT-gpt.vars.h5";
+static std::string trajectories_             = base_path() + "/examples/ECLIPSE/norne-simplified/trajectories";
+static std::string cube_grid_                = base_path() + "/examples/ECLIPSE/cube_9x9/CUBE.EGRID";
 
 }
 }

--- a/FieldOpt/Settings/tests/test_resource_schedule_import_settings.hpp
+++ b/FieldOpt/Settings/tests/test_resource_schedule_import_settings.hpp
@@ -5,6 +5,8 @@
 #ifndef FIELDOPT_TEST_RESOURCE_SCHEDULE_IMPORT_SETTINGS_H
 #define FIELDOPT_TEST_RESOURCE_SCHEDULE_IMPORT_SETTINGS_H
 
+#include "Settings/tests/test_resource_example_file_paths.hpp"
+
 namespace TestResources {
 namespace TestResourceSettings {
 
@@ -13,7 +15,7 @@ QJsonObject imported_model_settings {
         {"Type", "ECLIPSE"},
         {"FluidModel", "BlackOil"},
         {"ExecutionScript", "csh_eclrun.sh"},
-        {"DriverPath", "../examples/ECLIPSE/norne-simplified/NORNE_SIMPLIFIED.DATA"},
+        {"DriverPath", QString::fromStdString(TestResources::ExampleFilePaths::norne_deck_)},
         {"SchedulePath", "INCLUDE/BC0407_HIST01122006.SCH"}
     }},
     {"Model", QJsonObject {

--- a/FieldOpt/Settings/tests/test_resource_schedule_segmentation_settings.hpp
+++ b/FieldOpt/Settings/tests/test_resource_schedule_segmentation_settings.hpp
@@ -5,6 +5,8 @@
 #ifndef FIELDOPT_TEST_RESOURCE_SCHEDULE_MULTISEGMENT_SETTINGS_H
 #define FIELDOPT_TEST_RESOURCE_SCHEDULE_MULTISEGMENT_SETTINGS_H
 
+#include "Settings/tests/test_resource_example_file_paths.hpp"
+
 namespace TestResources {
 namespace TestResourceSettings {
 
@@ -13,7 +15,7 @@ QJsonObject multisegment_model_settings {
         {"Type", "ECLIPSE"},
         {"FluidModel", "BlackOil"},
         {"ExecutionScript", "csh_eclrun.sh"},
-        {"DriverPath", "../examples/ECLIPSE/norne-simplified/NORNE_SIMPLIFIED.DATA"},
+        {"DriverPath", QString::fromStdString(TestResources::ExampleFilePaths::norne_deck_)},
         {"SchedulePath", "INCLUDE/BC0407_HIST01122006.SCH"}
     }},
     {"Model", QJsonObject {

--- a/FieldOpt/Settings/tests/test_resource_settings.hpp
+++ b/FieldOpt/Settings/tests/test_resource_settings.hpp
@@ -28,25 +28,23 @@ namespace TestResources {
 class TestResourceSettings {
  protected:
   TestResourceSettings() {
-      paths_.SetPath(Paths::DRIVER_FILE, ExampleFilePaths::driver_example_.toStdString());
-      paths_.SetPath(Paths::OUTPUT_DIR, ExampleFilePaths::directory_output_.toStdString());
+      paths_.SetPath(Paths::DRIVER_FILE, ExampleFilePaths::driver_example_);
+      paths_.SetPath(Paths::OUTPUT_DIR, ExampleFilePaths::directory_output_);
+      paths_.SetPath(Paths::SIM_DRIVER_FILE, ExampleFilePaths::deck_horzwel_);
+      paths_.SetPath(Paths::GRID_FILE, ExampleFilePaths::grid_5spot_);
       settings_full_ = new Settings::Settings(paths_);
       settings_optimizer_ = settings_full_->optimizer();
       settings_simulator_ = settings_full_->simulator();
       settings_model_ = settings_full_->model();
 
-      paths_hybridopt_.SetPath(Paths::DRIVER_FILE, ExampleFilePaths::hybridopt_driver_example_.toStdString());
-      paths_hybridopt_.SetPath(Paths::OUTPUT_DIR, ExampleFilePaths::directory_output_.toStdString());
+      paths_hybridopt_.SetPath(Paths::DRIVER_FILE, ExampleFilePaths::hybridopt_driver_example_);
+      paths_hybridopt_.SetPath(Paths::OUTPUT_DIR, ExampleFilePaths::directory_output_);
+      paths_hybridopt_.SetPath(Paths::SIM_DRIVER_FILE, ExampleFilePaths::deck_horzwel_);
+      paths_hybridopt_.SetPath(Paths::GRID_FILE, ExampleFilePaths::grid_5spot_);
       settings_hybridopt_full_ = new Settings::Settings(paths_hybridopt_);
       settings_hybridopt_optimizer_ = settings_hybridopt_full_->optimizer();
       settings_hybridopt_simulator_ = settings_hybridopt_full_->simulator();
       settings_hybridopt_model_ = settings_hybridopt_full_->model();
-
-
-//      settings_flow_5spot_ = new Settings::Settings(ExampleFilePaths::driver_5spot_flow_,
-//                                                    "/home/einar/.CLion2016.2/system/cmake/generated/FieldOpt-c9373114/c9373114/Debug/fieldopt_output/");
-//      settings_flow_5spot_->simulator()->set_driver_file_path(TestResources::ExampleFilePaths::flow_drv_5spot_);
-//      settings_flow_5spot_->model()->set_reservoir_grid_path(ExampleFilePaths::grid_5spot_flow_);
   }
 
   Settings::Settings *settings_full_;
@@ -60,7 +58,6 @@ class TestResourceSettings {
   Settings::Simulator *settings_hybridopt_simulator_;
   Settings::Model *settings_hybridopt_model_;
   Paths paths_hybridopt_;
-//        Settings::Settings *settings_flow_5spot_;
 };
 
 }

--- a/FieldOpt/Settings/tests/test_schedule_import.cpp
+++ b/FieldOpt/Settings/tests/test_schedule_import.cpp
@@ -22,6 +22,7 @@
 #include "Settings/model.h"
 #include "Settings/simulator.h"
 #include "Settings/tests/test_resource_schedule_import_settings.hpp"
+#include "Settings/tests/test_resource_example_file_paths.hpp"
 
 namespace {
 
@@ -29,8 +30,8 @@ class ScheduleImportSettingsTest : public ::testing::Test {
  protected:
   ScheduleImportSettingsTest() {
       auto partial_deck = TestResources::TestResourceSettings::imported_model_settings;
-      paths_.SetPath(Paths::SIM_DRIVER_FILE, "../examples/ECLIPSE/norne-simplified/NORNE_SIMPLIFIED.DATA");
-      paths_.SetPath(Paths::SIM_SCH_FILE, "../examples/ECLIPSE/norne-simplified/INCLUDE/BC0407_HIST01122006.SCH");
+      paths_.SetPath(Paths::SIM_DRIVER_FILE, TestResources::ExampleFilePaths::norne_deck_ );
+      paths_.SetPath(Paths::SIM_SCH_FILE, TestResources::ExampleFilePaths::norne_sch_);
       sim_json_ = partial_deck["Simulator"].toObject();
       mod_json_ = partial_deck["Model"].toObject();
   }

--- a/FieldOpt/Settings/tests/test_settings.cpp
+++ b/FieldOpt/Settings/tests/test_settings.cpp
@@ -35,20 +35,19 @@ protected:
 
 TEST_F(SettingsTest, ConstructorAndTestFileValidity) {
     Paths paths;
-    paths.SetPath(Paths::DRIVER_FILE, TestResources::ExampleFilePaths::driver_example_.toStdString());
-    paths.SetPath(Paths::OUTPUT_DIR, TestResources::ExampleFilePaths::directory_output_.toStdString());
+    paths.SetPath(Paths::DRIVER_FILE, TestResources::ExampleFilePaths::driver_example_);
+    paths.SetPath(Paths::OUTPUT_DIR, TestResources::ExampleFilePaths::directory_output_);
+    paths.SetPath(Paths::SIM_DRIVER_FILE, TestResources::ExampleFilePaths::deck_horzwel_);
     EXPECT_NO_THROW(auto settings = ::Settings::Settings(paths));
 }
 
 TEST_F(SettingsTest, GlobalSettings) {
     Paths paths;
-    paths.SetPath(Paths::DRIVER_FILE, TestResources::ExampleFilePaths::driver_example_.toStdString());
-    paths.SetPath(Paths::OUTPUT_DIR, TestResources::ExampleFilePaths::directory_output_.toStdString());
+    paths.SetPath(Paths::DRIVER_FILE, TestResources::ExampleFilePaths::driver_example_);
+    paths.SetPath(Paths::OUTPUT_DIR, TestResources::ExampleFilePaths::directory_output_);
+    paths.SetPath(Paths::SIM_DRIVER_FILE, TestResources::ExampleFilePaths::deck_horzwel_);
     auto settings = ::Settings::Settings(paths);
     EXPECT_STREQ("TestRun", settings.name().toLatin1().constData());
-    EXPECT_STREQ(TestResources::ExampleFilePaths::driver_example_.toLatin1().constData(),
-                 settings.paths().GetPath(Paths::DRIVER_FILE).c_str());
-//    EXPECT_EQ(true, settings.verbosity()>0);
 }
 
 }

--- a/FieldOpt/Settings/tests/test_settings_model.cpp
+++ b/FieldOpt/Settings/tests/test_settings_model.cpp
@@ -19,10 +19,6 @@ class ModelSettingsTest : public ::testing::Test,
   virtual void TearDown() {}
 };
 
-TEST_F(ModelSettingsTest, Reservoir) {
-    EXPECT_STREQ("../examples/ADGPRS/5spot/ECL_5SPOT.EGRID", settings_full_->paths().GetPath(Paths::GRID_FILE).c_str());
-}
-
 TEST_F(ModelSettingsTest, ControlTimes) {
     EXPECT_EQ(4, settings_model_->control_times().size());
     EXPECT_EQ(365, settings_model_->control_times().last());
@@ -125,8 +121,8 @@ TEST_F(ModelSettingsTest, MultisplineWell) {
 
     Paths paths_;
     QJsonObject partial_deck = model_adtl_pts;
-    paths_.SetPath(Paths::SIM_DRIVER_FILE, "../examples/ECLIPSE/norne-simplified/NORNE_SIMPLIFIED.DATA");
-    paths_.SetPath(Paths::SIM_SCH_FILE, "../examples/ECLIPSE/norne-simplified/INCLUDE/BC0407_HIST01122006.SCH");
+    paths_.SetPath(Paths::SIM_DRIVER_FILE, TestResources::ExampleFilePaths::norne_deck_ );
+    paths_.SetPath(Paths::SIM_SCH_FILE, TestResources::ExampleFilePaths::norne_sch_);
 //    QJsonObject sim_json_;
     QJsonObject mod_json_;
 //    sim_json_ = partial_deck["Simulator"].toObject();

--- a/FieldOpt/Settings/tests/test_settings_simulator.cpp
+++ b/FieldOpt/Settings/tests/test_settings_simulator.cpp
@@ -46,8 +46,6 @@ protected:
 TEST_F(SimulatorSettingsTest, Fields) {
     EXPECT_EQ(settings_simulator_->type(), Simulator::SimulatorType::ECLIPSE);
     EXPECT_EQ(settings_simulator_->commands()->size(), 1);
-    EXPECT_STREQ("../examples/ECLIPSE/HORZWELL/HORZWELL.DATA",
-                 settings_full_->paths().GetPath(Paths::SIM_DRIVER_FILE).c_str());
 }
 
 }

--- a/FieldOpt/Settings/tests/test_trajectory_importer.cpp
+++ b/FieldOpt/Settings/tests/test_trajectory_importer.cpp
@@ -20,6 +20,7 @@
 
 #include <gtest/gtest.h>
 #include "Settings/trajectory_importer.h"
+#include "Settings/tests/test_resource_example_file_paths.hpp"
 
 namespace {
 
@@ -32,7 +33,7 @@ class TrajectoryImporterTest : public ::testing::Test {
   virtual void SetUp() {}
   virtual void TearDown() {}
 
-  std::string trajectory_path_ = "../examples/ECLIPSE/norne-simplified/trajectories";
+  std::string trajectory_path_ = TestResources::ExampleFilePaths::trajectories_;
   std::vector<std::string> well_names_ = {"D-2H"};
 };
 

--- a/FieldOpt/Simulation/tests/results/test_adgprsresults.cpp
+++ b/FieldOpt/Simulation/tests/results/test_adgprsresults.cpp
@@ -9,7 +9,7 @@ namespace {
         AdgprsResultsTest()
         {
             results_ = new Simulation::Results::AdgprsResults();
-            results_->ReadResults(TestResources::ExampleFilePaths::gprs_base_5spot_);
+            results_->ReadResults(QString::fromStdString(TestResources::ExampleFilePaths::gprs_base_5spot_));
         }
         virtual ~AdgprsResultsTest() {}
         virtual void SetUp() {}

--- a/FieldOpt/Simulation/tests/results/test_eclresults.cpp
+++ b/FieldOpt/Simulation/tests/results/test_eclresults.cpp
@@ -27,12 +27,12 @@ namespace {
 
     TEST_F(ECLResultsTest, ReadSummary) {
         EXPECT_THROW(results_->ReadResults("a"), ResultFileNotFoundException);
-        EXPECT_NO_THROW(results_->ReadResults(TestResources::ExampleFilePaths::ecl_base_horzwell));
+        EXPECT_NO_THROW(results_->ReadResults(QString::fromStdString(TestResources::ExampleFilePaths::ecl_base_horzwell)));
     }
 
     TEST_F(ECLResultsTest, DumpingAndAvailability) {
         // Make results available
-        results_->ReadResults(TestResources::ExampleFilePaths::ecl_base_horzwell);
+        results_->ReadResults(QString::fromStdString(TestResources::ExampleFilePaths::ecl_base_horzwell));
         EXPECT_TRUE(results_->isAvailable());
         EXPECT_NO_THROW(results_->GetValue(ECLResults::Property::Time));
 
@@ -42,13 +42,13 @@ namespace {
         EXPECT_THROW(results_->GetValue(ECLResults::Property::Time), ResultsNotAvailableException);
 
         // Make results available again
-        results_->ReadResults(TestResources::ExampleFilePaths::ecl_base_horzwell);
+        results_->ReadResults(QString::fromStdString(TestResources::ExampleFilePaths::ecl_base_horzwell));
         EXPECT_TRUE(results_->isAvailable());
         EXPECT_NO_THROW(results_->GetValue(ECLResults::Property::Time));
     }
 
     TEST_F(ECLResultsTest, FieldVariables) {
-        results_->ReadResults(TestResources::ExampleFilePaths::ecl_base_horzwell);
+        results_->ReadResults(QString::fromStdString(TestResources::ExampleFilePaths::ecl_base_horzwell));
         EXPECT_FLOAT_EQ(187866.44, results_->GetValue(ECLResults::Property::CumulativeOilProduction));
         EXPECT_FLOAT_EQ(115870.73, results_->GetValue(ECLResults::Property::CumulativeOilProduction, 10));
         EXPECT_THROW(results_->GetValue(ECLResults::Property::CumulativeOilProduction, 30), std::runtime_error);
@@ -60,7 +60,7 @@ namespace {
     }
 
     TEST_F(ECLResultsTest, MiscVariables) {
-        results_->ReadResults(TestResources::ExampleFilePaths::ecl_base_horzwell);
+        results_->ReadResults(QString::fromStdString(TestResources::ExampleFilePaths::ecl_base_horzwell));
         EXPECT_FLOAT_EQ(200, results_->GetValue(ECLResults::Property::Time));
         EXPECT_FLOAT_EQ(100, results_->GetValue(ECLResults::Property::Time, 10));
         EXPECT_THROW(results_->GetValue(ECLResults::Property::Time, 30), std::runtime_error);
@@ -72,7 +72,7 @@ namespace {
     }
 
     TEST_F(ECLResultsTest, WellVariables) {
-        results_->ReadResults(TestResources::ExampleFilePaths::ecl_base_horzwell);
+        results_->ReadResults(QString::fromStdString(TestResources::ExampleFilePaths::ecl_base_horzwell));
         EXPECT_FLOAT_EQ(1116.8876, results_->GetValue(ECLResults::Property::CumulativeWellWaterProduction, "PROD"));
         EXPECT_FLOAT_EQ(524.5061, results_->GetValue(ECLResults::Property::CumulativeWellWaterProduction, "PROD", 10));
     }

--- a/FieldOpt/Simulation/tests/simulator_interfaces/driver_file_writers/adgprs_driver_file_writer.cpp
+++ b/FieldOpt/Simulation/tests/simulator_interfaces/driver_file_writers/adgprs_driver_file_writer.cpp
@@ -7,8 +7,8 @@ namespace {
 class AdgprsDriverFileWriterTest : public ::testing::Test, TestResources::TestResourceModel {
 protected:
     AdgprsDriverFileWriterTest() {
-        settings_full_->paths().SetPath(Paths::BUILD_DIR, "./");
-        settings_full_->paths().SetPath(Paths::SIM_DRIVER_FILE, TestResources::ExampleFilePaths::gprs_drv_5spot_.toStdString());
+        settings_full_->paths().SetPath(Paths::BUILD_DIR, TestResources::ExampleFilePaths::bin_dir_);
+        settings_full_->paths().SetPath(Paths::SIM_DRIVER_FILE, TestResources::ExampleFilePaths::gprs_drv_5spot_);
         settings_full_->paths().SetPath(Paths::SIM_DRIVER_DIR, GetParentDirectoryPath(settings_full_->paths().GetPath(Paths::SIM_DRIVER_FILE)));
         simulator_ = new Simulation::AdgprsSimulator(settings_full_, model_);
     }

--- a/FieldOpt/Simulation/tests/simulator_interfaces/test_adgprssimulator.cpp
+++ b/FieldOpt/Simulation/tests/simulator_interfaces/test_adgprssimulator.cpp
@@ -7,19 +7,12 @@ namespace {
 class AdgprsSimulatorTest : public ::testing::Test, public TestResources::TestResourceModel {
 protected:
     AdgprsSimulatorTest() {
-        settings_full_->paths().SetPath(Paths::DRIVER_FILE, TestResources::ExampleFilePaths::driver_5spot_.toStdString());
-        settings_full_->paths().SetPath(Paths::SIM_DRIVER_FILE, TestResources::ExampleFilePaths::gprs_drv_5spot_.toStdString());
+        settings_full_->paths().SetPath(Paths::DRIVER_FILE, TestResources::ExampleFilePaths::driver_5spot_);
+        settings_full_->paths().SetPath(Paths::SIM_DRIVER_FILE, TestResources::ExampleFilePaths::gprs_drv_5spot_);
         settings_full_->paths().SetPath(Paths::SIM_DRIVER_DIR, GetParentDirectoryPath(settings_full_->paths().GetPath(Paths::SIM_DRIVER_FILE)));
-        settings_full_->paths().SetPath(Paths::BUILD_DIR, "./");
+        settings_full_->paths().SetPath(Paths::BUILD_DIR, TestResources::ExampleFilePaths::bin_dir_);
         simulator_ = new Simulation::AdgprsSimulator(settings_full_, model_);
     }
-
-
-//  static QString driver_5spot_ = "../examples/ADGPRS/5spot/fo_driver_5vert_wells.json";
-//  static QString gprs_drv_5spot_ = "../examples/ADGPRS/5spot/5SPOT.gprs";
-//  static QString gprs_smry_json_5spot_ = "../examples/ADGPRS/5spot/5SPOT.json";
-//  static QString gprs_smry_hdf5_5spot_ = "../examples/ADGPRS/5spot/5SPOT.vars.h5";
-//  static QString gprs_base_5spot_ = "../examples/ADGPRS/5spot/5SPOT";
 
 
     virtual ~AdgprsSimulatorTest() {}

--- a/FieldOpt/Simulation/tests/simulator_interfaces/test_eclsimulator.cpp
+++ b/FieldOpt/Simulation/tests/simulator_interfaces/test_eclsimulator.cpp
@@ -13,10 +13,11 @@ class ECLSimulatorTest : public testing::Test, TestResourceModel {
 protected:
     ECLSimulatorTest() {
         Paths paths;
-        paths.SetPath(Paths::DRIVER_FILE, ExampleFilePaths::norne_driver_example_.toStdString());
-        paths.SetPath(Paths::OUTPUT_DIR, ExampleFilePaths::norne_test_output_.toStdString());
-        paths.SetPath(Paths::GRID_FILE, ExampleFilePaths::norne_grid_.toStdString());
-        paths.SetPath(Paths::BUILD_DIR, "./");
+        paths.SetPath(Paths::DRIVER_FILE, ExampleFilePaths::norne_driver_example_);
+        paths.SetPath(Paths::OUTPUT_DIR, ExampleFilePaths::norne_test_output_);
+        paths.SetPath(Paths::GRID_FILE, ExampleFilePaths::norne_grid_);
+        paths.SetPath(Paths::BUILD_DIR, ExampleFilePaths::bin_dir_);
+        paths.SetPath(Paths::SIM_DRIVER_FILE, ExampleFilePaths::norne_deck_);
         settings_norne_full_ = new Settings::Settings(paths);
         settings_norne_optimizer_ = settings_norne_full_->optimizer();
         settings_norne_simulator_ = settings_norne_full_->simulator();

--- a/FieldOpt/Simulation/tests/simulator_interfaces/test_ix_simulator.cpp
+++ b/FieldOpt/Simulation/tests/simulator_interfaces/test_ix_simulator.cpp
@@ -14,10 +14,11 @@ class IXSimulatorTest : public testing::Test, TestResourceModel {
 protected:
     IXSimulatorTest() {
         Paths paths;
-        paths.SetPath(Paths::DRIVER_FILE, ExampleFilePaths::norne_driver_example_.toStdString());
-        paths.SetPath(Paths::OUTPUT_DIR, ExampleFilePaths::norne_test_output_.toStdString());
-        paths.SetPath(Paths::GRID_FILE, ExampleFilePaths::norne_grid_.toStdString());
-        paths.SetPath(Paths::BUILD_DIR, "./");
+        paths.SetPath(Paths::DRIVER_FILE, ExampleFilePaths::norne_driver_example_);
+        paths.SetPath(Paths::OUTPUT_DIR, ExampleFilePaths::norne_test_output_);
+        paths.SetPath(Paths::GRID_FILE, ExampleFilePaths::norne_grid_);
+        paths.SetPath(Paths::BUILD_DIR, ExampleFilePaths::bin_dir_);
+        paths.SetPath(Paths::SIM_DRIVER_FILE, ExampleFilePaths::norne_deck_);
         settings_norne_full_ = new Settings::Settings(paths);
         settings_norne_optimizer_ = settings_norne_full_->optimizer();
         settings_norne_simulator_ = settings_norne_full_->simulator();

--- a/FieldOpt/Simulation/tests/test_resource_results.h
+++ b/FieldOpt/Simulation/tests/test_resource_results.h
@@ -11,25 +11,20 @@ namespace TestResources {
     protected:
         TestResourceResults() {
             results_ecl_horzwell_ = new Simulation::Results::ECLResults();
-            results_ecl_horzwell_->ReadResults(ExampleFilePaths::ecl_base_horzwell);
+            results_ecl_horzwell_->ReadResults(QString::fromStdString(ExampleFilePaths::ecl_base_horzwell));
 
             results_adgprs_5spot_ = new Simulation::Results::AdgprsResults();
-            results_adgprs_5spot_->ReadResults(ExampleFilePaths::gprs_smry_hdf5_5spot_);
-
-//            results_flow_5spot_ = new Simulation::Results::ECLResults();
-//            results_flow_5spot_->ReadResults(ExampleFilePaths::flow_base_5spot_);
+            results_adgprs_5spot_->ReadResults(QString::fromStdString(ExampleFilePaths::gprs_smry_hdf5_5spot_));
         }
 
         virtual ~TestResourceResults() {
             results_ecl_horzwell_->DumpResults();
             results_adgprs_5spot_->DumpResults();
-//            results_flow_5spot_->DumpResults();
         }
 
     protected:
         Simulation::Results::ECLResults *results_ecl_horzwell_;
         Simulation::Results::AdgprsResults *results_adgprs_5spot_;
-//        Simulation::Results::ECLResults *results_flow_5spot_;
     };
 }
 

--- a/FieldOpt/Utilities/system.hpp
+++ b/FieldOpt/Utilities/system.hpp
@@ -1,0 +1,57 @@
+/******************************************************************************
+   Created by einar on 2/26/19.
+   Copyright (C) 2017 Einar J.M. Baumann <einar.baumann@gmail.com>
+
+   This file is part of the FieldOpt project.
+
+   FieldOpt is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   FieldOpt is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with FieldOpt.  If not, see <http://www.gnu.org/licenses/>.
+******************************************************************************/
+#ifndef FIELDOPT_SYSTEM_H
+#define FIELDOPT_SYSTEM_H
+
+#include <string>
+#include <stdlib.h>
+
+/*!
+ * @brief Check whether an environment variable has been set.
+ * @param var_name Name of variable to check (e.g. FIELDOPT_BUILD_ROOT).
+ * @return True if the variable has been set, otherwise false.
+ */
+inline bool is_env_var_set(std::string var_name) {
+    char const* var_value = getenv(var_name.c_str());
+    if (var_value == NULL) {
+        return false;
+    }
+    else {
+        return true;
+    }
+}
+
+/*!
+ * @brief Get the value of an environment variable. Throws an exception if the variable is unset.
+ * @param var_name Name of variable to check (e.g. FIELDOPT_BUILD_ROOT).
+ * @return Value of environment variable as string.
+ */
+inline std::string get_env_var_value(std::string var_name) {
+    if (!is_env_var_set(var_name)) {
+        throw std::runtime_error("Attempting to get unset environment variable " + var_name);
+    }
+    else {
+        char const* var_value = getenv(var_name.c_str());
+        std::string s(var_value);
+        return var_value;
+    }
+}
+
+#endif //FIELDOPT_SYSTEM_H

--- a/FieldOpt/Utilities/tests/test_filehandling.cpp
+++ b/FieldOpt/Utilities/tests/test_filehandling.cpp
@@ -47,7 +47,7 @@ TEST_F(FileHandlingTest, Existance) {
 }
 
 TEST_F(FileHandlingTest, FileReading) {
-    EXPECT_LE(155, ::Utilities::FileHandling::ReadFileToStringList(TestResources::ExampleFilePaths::driver_example_)->size());
+    EXPECT_LE(155, ::Utilities::FileHandling::ReadFileToStringList(QString::fromStdString(TestResources::ExampleFilePaths::driver_example_))->size());
 }
 
 

--- a/FieldOpt/WellIndexCalculation/tests/test_intersected_cells.cpp
+++ b/FieldOpt/WellIndexCalculation/tests/test_intersected_cells.cpp
@@ -28,6 +28,7 @@
 #include "Reservoir/grid/grid.h"
 #include "Reservoir/grid/eclgrid.h"
 #include "WellIndexCalculation/wicalc_rixx.h"
+#include "Settings/tests/test_resource_example_file_paths.hpp"
 
 using namespace Reservoir::Grid;
 using namespace Reservoir::WellIndexCalculation;
@@ -52,7 +53,7 @@ class IntersectedCellsTest : public ::testing::Test {
   virtual void TearDown() { }
 
   Grid *grid_;
-  string file_path_ = "../examples/ADGPRS/5spot/ECL_5SPOT.EGRID";
+  string file_path_ = TestResources::ExampleFilePaths::grid_5spot_;
   wicalc_rixx *wic_;
 };
 

--- a/FieldOpt/WellIndexCalculation/tests/test_single_cell_wellindex.cpp
+++ b/FieldOpt/WellIndexCalculation/tests/test_single_cell_wellindex.cpp
@@ -28,6 +28,7 @@
 #include "Reservoir/grid/grid.h"
 #include "Reservoir/grid/eclgrid.h"
 #include "WellIndexCalculation/wicalc_rixx.h"
+#include "Settings/tests/test_resource_example_file_paths.hpp"
 
 using namespace Reservoir::Grid;
 using namespace Reservoir::WellIndexCalculation;
@@ -50,7 +51,7 @@ class SingleCellWellIndexTest : public ::testing::Test {
   virtual void TearDown() { }
 
   Grid *grid_;
-  std::string file_path_ = "../examples/ECLIPSE/cube_9x9/CUBE.EGRID";
+  std::string file_path_ = TestResources::ExampleFilePaths::cube_grid_;
 
 
   WellDefinition init_well(Eigen::Vector3d start_point, Eigen::Vector3d end_point) {
@@ -130,7 +131,7 @@ TEST_F(SingleCellWellIndexTest, WellIndexValueHorzX) {
 
 
 TEST_F(SingleCellWellIndexTest, Well_index_grid_test) {
-    file_path_ = "../examples/ADGPRS/5spot/ECL_5SPOT.EGRID";
+    file_path_ = TestResources::ExampleFilePaths::grid_5spot_;
     grid_ = new ECLGrid(file_path_);
     double wellbore_radius = 0.191/2;
 


### PR DESCRIPTION
FieldOpt _may_ now use the value of the environment variable `FIELDOPT_BUILD_ROOT`.
This variable should be set to your root FieldOpt build directory, e.g.

```bash
export FIELDOPT_BUILD_ROOT=~/git/PCG/FieldOpt/FieldOpt/cmake-build-debug
```

If this variable is not set, FieldOpt will behave as it always has.

The main reason for introducing this is to use it as a prefix in the file paths used in tests, ensuring that they can be executed from anywhere on the system. When running `make test` in the root build directory all tests should now pass.

The variable is also used in `RuntimeSettings`, if the build directory is not passed as an argument, to set the `BUILD_DIR` path. If the environment varaible is not set, and the build directory is not provided as an argument, this path will be set to `./` as before.

This pattern here should be used in the future when paths to static system-related things (i.e. not directly related to the current optimization run) is needed.

**The interesting changes in this PR are found in:**

* `Utilities/system.hpp`
* `Runner/runtime_settings.cpp`

The rest of the changes are just noise (updates in test files to work with type changes in `Settings/tests/test_resource_example_file_paths.hpp`.

**Note:** The changes to the JSON driver files used in some tests requires the CMake cache to be cleared. In CLion: Tools -> CMake -> Reset cache and reload project.