### PR TITLE
Feature/simulator improvements

### DIFF
--- a/FieldOpt/Model/model.cpp
+++ b/FieldOpt/Model/model.cpp
@@ -312,7 +312,7 @@ map<string, Loggable::WellDescription> Model::Summary::GetWellDescriptions() {
         // Controls
         for (Wells::Control *cont : *well->controls()) {
             Loggable::ControlDescription cd;
-            if (cont->mode() == Settings::Model::ControlMode::RateControl) {
+            if (cont->mode() == Settings::Model::ControlMode::LRATControl) {
                 cd.control = "Rate";
                 cd.value = cont->rate();
             }

--- a/FieldOpt/Model/tests/wells/test_control.cpp
+++ b/FieldOpt/Model/tests/wells/test_control.cpp
@@ -66,7 +66,7 @@ TEST_F(ControlTest, InjectorControl) {
     EXPECT_EQ(0, inj_entry_.time_step);
     EXPECT_EQ(0, all_controls_.last()->time_step());
     EXPECT_TRUE(all_controls_.last()->open());
-    EXPECT_EQ(::Settings::Model::ControlMode::RateControl, all_controls_.last()->mode());
+    EXPECT_EQ(::Settings::Model::ControlMode::LRATControl, all_controls_.last()->mode());
     EXPECT_FLOAT_EQ(1200, all_controls_.last()->rate());
 }
 

--- a/FieldOpt/Model/wells/control.cpp
+++ b/FieldOpt/Model/wells/control.cpp
@@ -45,11 +45,11 @@ Control::Control(::Settings::Model::Well::ControlEntry entry,
                 bhp_->setName(entry.name);
                 variables->AddVariable(bhp_);
             }
-            rate_ = new Properties::ContinousProperty(entry.rate); // Potential simulator limit (-1 if not set)
+            rate_ = new Properties::ContinousProperty(entry.liq_rate); // Potential simulator limit (-1 if not set)
             break;
-        case ::Settings::Model::ControlMode::RateControl:
+        case ::Settings::Model::ControlMode::LRATControl:
             mode_ = entry.control_mode;
-            rate_ = new Properties::ContinousProperty(entry.rate);
+            rate_ = new Properties::ContinousProperty(entry.liq_rate);
             if (entry.is_variable) {
                 rate_->setName(entry.name);
                 variables->AddVariable(rate_);

--- a/FieldOpt/Model/wells/control.cpp
+++ b/FieldOpt/Model/wells/control.cpp
@@ -37,25 +37,54 @@ Control::Control(::Settings::Model::Well::ControlEntry entry,
     else if (entry.state == ::Settings::Model::WellState::WellShut)
         open_ = new Properties::BinaryProperty(false);
 
-    switch (entry.control_mode) {
+
+    liq_rate_ = new Properties::ContinousProperty(entry.liq_rate); // (-1 if not set in settings)
+    oil_rate_ = new Properties::ContinousProperty(entry.oil_rate); // (-1 if not set in settings)
+    gas_rate_ = new Properties::ContinousProperty(entry.gas_rate); // (-1 if not set in settings)
+    wat_rate_ = new Properties::ContinousProperty(entry.wat_rate); // (-1 if not set in settings)
+    res_rate_ = new Properties::ContinousProperty(entry.res_rate); // (-1 if not set in settings)
+    bhp_ = new Properties::ContinousProperty(entry.bhp);           // (-1 if not set in settings)
+
+    mode_ = entry.control_mode;
+    switch (mode_) {
         case ::Settings::Model::ControlMode::BHPControl:
-            mode_ = entry.control_mode;
-            bhp_ = new Properties::ContinousProperty(entry.bhp);
             if (entry.is_variable) {
                 bhp_->setName(entry.name);
                 variables->AddVariable(bhp_);
             }
-            rate_ = new Properties::ContinousProperty(entry.liq_rate); // Potential simulator limit (-1 if not set)
             break;
         case ::Settings::Model::ControlMode::LRATControl:
-            mode_ = entry.control_mode;
-            rate_ = new Properties::ContinousProperty(entry.liq_rate);
             if (entry.is_variable) {
-                rate_->setName(entry.name);
-                variables->AddVariable(rate_);
+                liq_rate_->setName(entry.name);
+                variables->AddVariable(liq_rate_);
             }
-            bhp_ = new Properties::ContinousProperty(entry.bhp); // Potential simulator limit (-1 if not set)
             break;
+        case ::Settings::Model::ControlMode::ORATControl:
+            if (entry.is_variable) {
+                oil_rate_->setName(entry.name);
+                variables->AddVariable(oil_rate_);
+            }
+            break;
+        case ::Settings::Model::ControlMode::GRATControl:
+            if (entry.is_variable) {
+                gas_rate_->setName(entry.name);
+                variables->AddVariable(gas_rate_);
+            }
+            break;
+        case ::Settings::Model::ControlMode::WRATControl:
+            if (entry.is_variable) {
+                wat_rate_->setName(entry.name);
+                variables->AddVariable(wat_rate_);
+            }
+            break;
+        case ::Settings::Model::ControlMode::RESVControl:
+            if (entry.is_variable) {
+                res_rate_->setName(entry.name);
+                variables->AddVariable(res_rate_);
+            }
+            break;
+        default:
+            throw std::runtime_error("Control mode not recognized in Model::Wells::Control.");
     }
 
 }
@@ -66,7 +95,11 @@ Control::Control(const Control & other) {
     this->time_step_ = other.time_step_;
     this->open_ = other.open_;
     this->bhp_ = other.bhp_;
-    this->rate_ = other.rate_;
+    this->liq_rate_ = other.liq_rate_;
+    this->oil_rate_ = other.oil_rate_;
+    this->wat_rate_ = other.wat_rate_;
+    this->gas_rate_ = other.gas_rate_;
+    this->res_rate_ = other.res_rate_;
     this->mode_ = other.mode_;
     this->injection_fluid_ = other.injection_fluid_;
 }

--- a/FieldOpt/Model/wells/control.h
+++ b/FieldOpt/Model/wells/control.h
@@ -67,8 +67,15 @@ class Control
   double bhp() const { return bhp_->value(); }
   void setBhp(double bhp) { bhp_->setValue(bhp); }
 
-  double rate() const { return rate_->value(); }
-  void setRate(double rate) { rate_->setValue(rate); }
+  double rate()          const { return liq_rate_->value(); }
+  double liquidRate()    const { return liq_rate_->value(); }
+  double oilRate()       const { return oil_rate_->value(); }
+  double gasRate()       const { return gas_rate_->value(); }
+  double waterRate()     const { return wat_rate_->value(); }
+  double reservoirRate() const { return res_rate_->value(); }
+
+  void setRate(double rate)       { liq_rate_->setValue(rate); }
+  void setLiquidRate(double rate) { liq_rate_->setValue(rate); }
 
   ::Settings::Model::ControlMode mode() const { return mode_; }
   ::Settings::Model::InjectionType injection_fluid() const { return injection_fluid_; }
@@ -77,7 +84,11 @@ class Control
   Properties::DiscreteProperty *time_step_;
   Properties::BinaryProperty *open_;
   Properties::ContinousProperty *bhp_;
-  Properties::ContinousProperty *rate_;
+  Properties::ContinousProperty *liq_rate_;
+  Properties::ContinousProperty *oil_rate_;
+  Properties::ContinousProperty *gas_rate_;
+  Properties::ContinousProperty *wat_rate_;
+  Properties::ContinousProperty *res_rate_;
   ::Settings::Model::ControlMode mode_;
   ::Settings::Model::InjectionType injection_fluid_;
 };

--- a/FieldOpt/Runner/runtime_settings.cpp
+++ b/FieldOpt/Runner/runtime_settings.cpp
@@ -87,6 +87,10 @@ RuntimeSettings::RuntimeSettings(int argc, const char *argv[])
         paths_.SetPath(Paths::SIM_AUX_DIR, GetAbsoluteFilePath(vm["sim-aux"].as<std::string>()));
     }
 
+    if (vm.count("sim-inset")) {
+        paths_.SetPath(Paths::SIM_SCH_INSET_FILE, GetAbsoluteFilePath(vm["sim-inset"].as<std::string>()));
+    }
+
     if (vm.count("fieldopt-build-dir")) {
         paths_.SetPath(Paths::BUILD_DIR, vm["fieldopt-build-dir"].as<std::string>());
     } else if (is_env_var_set("FIELDOPT_BUILD_ROOT")) {
@@ -183,6 +187,8 @@ po::variables_map RuntimeSettings::createVariablesMap(int argc, const char **arg
          "path to script that executes the reservoir simulation")
         ("sim-aux", po::value<std::string>(),
          "path to directory with additional auxilary simulation files")
+        ("sim-inset", po::value<std::string>(),
+          "path to simulator schedule inset file")
         ("fieldopt-build-dir,b", po::value<std::string>(),
          "path to FieldOpt build directory")
         ("ensemble-path", po::value<std::string>(),

--- a/FieldOpt/Settings/model.cpp
+++ b/FieldOpt/Settings/model.cpp
@@ -388,6 +388,22 @@ Model::Well Model::readSingleWell(QJsonObject json_well)
             control.control_mode = ControlMode::LRATControl;
             control.name = "Rate#" + well.name + "#" + QString::number(control.time_step);
         }
+        else if (ctrl_mode == "ORAT" ) {
+            control.control_mode = ControlMode::ORATControl;
+            control.name = "Rate#" + well.name + "#" + QString::number(control.time_step);
+        }
+        else if (ctrl_mode == "GRAT" ) {
+            control.control_mode = ControlMode::ORATControl;
+            control.name = "Rate#" + well.name + "#" + QString::number(control.time_step);
+        }
+        else if (ctrl_mode == "WRAT" ) {
+            control.control_mode = ControlMode::WRATControl;
+            control.name = "Rate#" + well.name + "#" + QString::number(control.time_step);
+        }
+        else if (ctrl_mode == "RESV" ) {
+            control.control_mode = ControlMode::RESVControl;
+            control.name = "Rate#" + well.name + "#" + QString::number(control.time_step);
+        }
         else throw UnableToParseWellsModelSectionException("Well control type " + json_controls.at(i).toObject()["Mode"].toString().toStdString() + " not recognized for well " + well.name.toStdString());
 
         // Control targets/limits
@@ -396,6 +412,18 @@ Model::Well Model::readSingleWell(QJsonObject json_well)
         }
         if (json_controls[i].toObject().contains("LRAT")) {
             control.liq_rate = json_controls[i].toObject()["LRAT"].toDouble();
+        }
+        if (json_controls[i].toObject().contains("ORAT")) { // Limit for simulator
+            control.oil_rate = json_controls[i].toObject()["ORAT"].toDouble();
+        }
+        if (json_controls[i].toObject().contains("GRAT")) { // Limit for simulator
+            control.gas_rate = json_controls[i].toObject()["GRAT"].toDouble();
+        }
+        if (json_controls[i].toObject().contains("WRAT")) { // Limit for simulator
+            control.wat_rate = json_controls[i].toObject()["WRAT"].toDouble();
+        }
+        if (json_controls[i].toObject().contains("RESV")) { // Limit for simulator
+            control.res_rate = json_controls[i].toObject()["RESV"].toDouble();
         }
         if (json_controls[i].toObject().contains("BHP")) { // Limit for simulator
             control.bhp = json_controls[i].toObject()["BHP"].toDouble();
@@ -447,6 +475,10 @@ std::string Model::Well::ControlEntry::toString() {
     ce << "               Mode:      " << (control_mode == ControlMode::LRATControl ? "Rate" : "BHP") << "\n";
     ce << "               BHP:       " << boost::lexical_cast<std::string>(bhp) << "\n";
     ce << "               Liq. Rate: " << boost::lexical_cast<std::string>(liq_rate) << "\n";
+    ce << "               Oil Rate:  " << boost::lexical_cast<std::string>(oil_rate) << "\n";
+    ce << "               Gas Rate:  " << boost::lexical_cast<std::string>(gas_rate) << "\n";
+    ce << "               Wat. Rate: " << boost::lexical_cast<std::string>(wat_rate) << "\n";
+    ce << "               Res. Rate: " << boost::lexical_cast<std::string>(res_rate) << "\n";
     ce << "               Inj. type: " << (injection_type == InjectionType::WaterInjection ? "Water" : "Gas/UNKWN") << "\n";
     ce << "               Variable:  " << (is_variable ? "Yes" : "No") << "\n";
     return ce.str();

--- a/FieldOpt/Settings/model.h
+++ b/FieldOpt/Settings/model.h
@@ -53,7 +53,7 @@ class Model
  public:
   Model(QJsonObject json_model, Paths &paths); // This should only be accessed externally for testing purposes.
   enum WellType : int { Injector=11, Producer=12, UNKNOWN_TYPE=19 };
-  enum ControlMode : int { BHPControl=21, LRATControl=22, UNKNOWN_CONTROL=29 };
+  enum ControlMode : int { BHPControl=21, LRATControl=22, ORATControl=23, WRATControl=24, RESVControl=25, GRATControl=26, UNKNOWN_CONTROL=29 };
   enum InjectionType : int { WaterInjection=31, GasInjection=32 };
   enum WellDefinitionType : int { WellBlocks=41, WellSpline=42, PseudoContVertical2D=43, PolarSpline=45, UNDEFINED=44 };
   enum WellCompletionType : int { Perforation=61, ICV=62, Packer=63, Tubing=64, Annulus=65 };
@@ -117,7 +117,11 @@ class Model
       WellState state;                               //!< Whether the well is open or shut.
       ControlMode control_mode;                      //!< Control mode.
       double bhp=-1;                                 //!< Bhp target/limit.
-      double liq_rate=-1;                            //!< Liquid Rate target/limit.
+      double liq_rate=-1;                            //!< Liquid Rate target/limit (LRAT).
+      double oil_rate=-1;                            //!< Oil Rate target/limit (ORAT).
+      double gas_rate=-1;                            //!< Gas Rate target/limit (GRAT).
+      double wat_rate=-1;                            //!< Water Rate target/limit (WRAT).
+      double res_rate=-1;                            //!< Reservoir fluid volume rate target (RESV).
       InjectionType injection_type = WaterInjection; //!< Injector type (water/gas). Defaults to water.
       bool is_variable = false;
       QString name;

--- a/FieldOpt/Settings/model.h
+++ b/FieldOpt/Settings/model.h
@@ -53,7 +53,7 @@ class Model
  public:
   Model(QJsonObject json_model, Paths &paths); // This should only be accessed externally for testing purposes.
   enum WellType : int { Injector=11, Producer=12, UNKNOWN_TYPE=19 };
-  enum ControlMode : int { BHPControl=21, RateControl=22, UNKNOWN_CONTROL=29 };
+  enum ControlMode : int { BHPControl=21, LRATControl=22, UNKNOWN_CONTROL=29 };
   enum InjectionType : int { WaterInjection=31, GasInjection=32 };
   enum WellDefinitionType : int { WellBlocks=41, WellSpline=42, PseudoContVertical2D=43, PolarSpline=45, UNDEFINED=44 };
   enum WellCompletionType : int { Perforation=61, ICV=62, Packer=63, Tubing=64, Annulus=65 };
@@ -116,8 +116,8 @@ class Model
       int time_step;                                 //!< The time step this control is to be applied at.
       WellState state;                               //!< Whether the well is open or shut.
       ControlMode control_mode;                      //!< Control mode.
-      double bhp=-1;                                    //!< Bhp target when well is on bhp control.
-      double rate=-1;                                   //!< Rate target when well is on rate control.
+      double bhp=-1;                                 //!< Bhp target/limit.
+      double liq_rate=-1;                            //!< Liquid Rate target/limit.
       InjectionType injection_type = WaterInjection; //!< Injector type (water/gas). Defaults to water.
       bool is_variable = false;
       QString name;

--- a/FieldOpt/Settings/paths.h
+++ b/FieldOpt/Settings/paths.h
@@ -33,7 +33,7 @@ class Paths {
    */
   enum Path : int {DRIVER_FILE=0, SIM_DRIVER_FILE=1, GRID_FILE=2, SIM_EXEC_SCRIPT_FILE=3,
     SIM_SCH_FILE=4, SIM_OUT_DRIVER_FILE=5, SIM_OUT_SCH_FILE=6, SIM_HDF5_FILE=7,
-    ENSEMBLE_FILE=8,
+    ENSEMBLE_FILE=8, SIM_SCH_INSET_FILE=9,
     BUILD_DIR=-1,  OUTPUT_DIR=-2, SIM_DRIVER_DIR=-3, SIM_WORK_DIR=-4,
     SIM_AUX_DIR=-5, TRAJ_DIR=-6
   };
@@ -55,6 +55,7 @@ class Paths {
       std::pair<Path, std::string> {SIM_SCH_FILE, "Simulator schedule section file"},
       std::pair<Path, std::string> {SIM_OUT_DRIVER_FILE, "Simulation output driver file"},
       std::pair<Path, std::string> {SIM_OUT_SCH_FILE, "Simulation output schedule file"},
+      std::pair<Path, std::string> {SIM_SCH_INSET_FILE, "Simulator schedule inset file"},
       std::pair<Path, std::string> {SIM_HDF5_FILE, "HDF5 Summary file"},
       std::pair<Path, std::string> {ENSEMBLE_FILE, "Ensemble description file"},
       std::pair<Path, std::string> {BUILD_DIR, "Build directory"},

--- a/FieldOpt/Settings/tests/test_resource_example_file_paths.hpp
+++ b/FieldOpt/Settings/tests/test_resource_example_file_paths.hpp
@@ -45,6 +45,7 @@ static std::string gprs_base_5spot_          = base_path() + "/examples/ADGPRS/5
 static std::string gprs_smry_gpt_hdf5_5spot_ = base_path() + "/examples/ADGPRS/5spot/5SPOT-gpt.vars.h5";
 static std::string trajectories_             = base_path() + "/examples/ECLIPSE/norne-simplified/trajectories";
 static std::string cube_grid_                = base_path() + "/examples/ECLIPSE/cube_9x9/CUBE.EGRID";
+static std::string schedule_inset_           = base_path() + "/examples/ECLIPSE/schedule_inset.txt";
 
 }
 }

--- a/FieldOpt/Settings/tests/test_settings_model.cpp
+++ b/FieldOpt/Settings/tests/test_settings_model.cpp
@@ -111,8 +111,8 @@ TEST_F(ModelSettingsTest, InjectorControls) {
     EXPECT_EQ(0, injector.controls[0].time_step);
     EXPECT_EQ(Model::InjectionType::WaterInjection, injector.controls[0].injection_type);
     EXPECT_EQ(Model::WellState::WellOpen, injector.controls[0].state);
-    EXPECT_EQ(Model::ControlMode::RateControl, injector.controls[0].control_mode);
-    EXPECT_FLOAT_EQ(1200, injector.controls[0].rate);
+    EXPECT_EQ(Model::ControlMode::LRATControl, injector.controls[0].control_mode);
+    EXPECT_FLOAT_EQ(1200, injector.controls[0].liq_rate);
     EXPECT_FALSE(injector.controls[0].is_variable);
     EXPECT_STREQ("Rate#INJ#0", injector.controls[0].name.toLatin1().constData());
 }

--- a/FieldOpt/Simulation/Sources.cmake
+++ b/FieldOpt/Simulation/Sources.cmake
@@ -18,6 +18,7 @@ SET(SIMULATION_HEADERS
 	simulator_interfaces/driver_file_writers/driver_parts/ecl_driver_parts/welsegs.h
 	simulator_interfaces/driver_file_writers/driver_parts/ecl_driver_parts/welspecs.h
 	simulator_interfaces/driver_file_writers/driver_parts/ecl_driver_parts/wsegvalv.h
+	simulator_interfaces/driver_file_writers/driver_parts/ecl_driver_parts/schedule_insets.h
 	simulator_interfaces/driver_file_writers/driver_parts/ix_driver_parts/flow_control_device.hpp
 	simulator_interfaces/driver_file_writers/driver_parts/ix_driver_parts/ix_control.hpp
 	simulator_interfaces/driver_file_writers/driver_parts/ix_driver_parts/report_tuning.hpp
@@ -47,6 +48,7 @@ SET(SIMULATION_SOURCES
 	simulator_interfaces/driver_file_writers/driver_parts/ecl_driver_parts/welsegs.cpp
 	simulator_interfaces/driver_file_writers/driver_parts/ecl_driver_parts/welspecs.cpp
 	simulator_interfaces/driver_file_writers/driver_parts/ecl_driver_parts/wsegvalv.cpp
+	simulator_interfaces/driver_file_writers/driver_parts/ecl_driver_parts/schedule_insets.cpp
 	simulator_interfaces/driver_file_writers/ecldriverfilewriter.cpp
 	simulator_interfaces/driver_file_writers/flowdriverfilewriter.cpp
 	simulator_interfaces/driver_file_writers/ix_driver_file_writer.cpp
@@ -65,6 +67,7 @@ SET(SIMULATION_TESTS
 	tests/simulator_interfaces/driver_file_writers/driver_parts/ecl_driver_parts/test_schedule_section.cpp
 	tests/simulator_interfaces/driver_file_writers/driver_parts/ecl_driver_parts/test_wellcontrols.cpp
 	tests/simulator_interfaces/driver_file_writers/driver_parts/ecl_driver_parts/test_welspecs.cpp
+	tests/simulator_interfaces/driver_file_writers/driver_parts/ecl_driver_parts/test_schedule_inset.cpp
 	tests/simulator_interfaces/driver_file_writers/flow_driver_file_writer.cpp
 	tests/simulator_interfaces/test_adgprssimulator.cpp
 	tests/simulator_interfaces/test_eclsimulator.cpp

--- a/FieldOpt/Simulation/simulator_interfaces/driver_file_writers/driver_parts/ecl_driver_parts/schedule_insets.cpp
+++ b/FieldOpt/Simulation/simulator_interfaces/driver_file_writers/driver_parts/ecl_driver_parts/schedule_insets.cpp
@@ -1,0 +1,113 @@
+/******************************************************************************
+   Copyright (C) 2019 Einar J.M. Baumann <einar.baumann@gmail.com>
+
+   This file is part of the FieldOpt project.
+
+   FieldOpt is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   FieldOpt is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with FieldOpt.  If not, see <http://www.gnu.org/licenses/>.
+******************************************************************************/
+#include "schedule_insets.h"
+#include "Utilities/filehandling.hpp"
+#include <boost/algorithm/string.hpp>
+#include <sstream>
+#include <boost/lexical_cast.hpp>
+
+namespace Simulation {
+namespace ECLDriverParts {
+
+ScheduleInsets::ScheduleInsets() {
+
+}
+
+ScheduleInsets::ScheduleInsets(const std::string &inset_file_path) {
+    assert(Utilities::FileHandling::FileExists(inset_file_path, true));
+    std::vector<std::string> all_lines = Utilities::FileHandling::ReadFileToStdStringList(inset_file_path);
+    std::deque<std::string> lines = trimEmptyLines(all_lines);
+
+    while (lines.size() > 0 && isKeyword(lines[0])) {
+        insets_.insert(parseNextInset(lines));
+    }
+}
+
+bool ScheduleInsets::HasInset(const int &time) const {
+    if (insets_.count(time) > 0) {
+        return true;
+    }
+    else {
+        return false;
+    }
+}
+
+std::string ScheduleInsets::GetInset(const int &time) const {
+    if (HasInset(time)) {
+        return insets_.at(time);
+    }
+    else {
+        return "";
+    }
+}
+
+std::pair<int, std::string> ScheduleInsets::parseNextInset(std::deque<std::string> &lines) const {
+    std::string kw_line = lines[0]; // First line is on the form INSET=N
+    lines.pop_front(); // Remove first keyword line
+
+    // Split kw string and get the time of insertion
+    std::vector<std::string> kw_parts;
+    boost::split(kw_parts, kw_line, boost::is_any_of("="));
+    assert(kw_parts.size() == 2);
+    int time = boost::lexical_cast<int>(kw_parts.back());
+
+    // Loop through the lines until another keyword is encountered, adding each line
+    // to a stringstream and popping the first string in the list.
+    std::stringstream inset;
+    inset << "-- START FIELDOPT INSET AT DAY " << time << " ~~~~~~~~~~~~~~~~\n";
+    while (!isKeyword(lines[0])) {
+        inset << lines[0] << "\n";
+        lines.pop_front();
+    }
+    inset << "-- END FIELDOPT INSET AT DAY " << time << " ~~~~~~~~~~~~~~~~\n\n";
+    if (lines[0] == "END_INSET") { // Pop the first element if it is the END_INSET keyword
+        lines.pop_front();
+    }
+
+    return std::pair<int, std::string> (time, inset.str());
+}
+
+std::deque<std::string> ScheduleInsets::trimEmptyLines(const std::vector<std::string> &lines) const {
+    std::deque<std::string> trimmed_strings;
+    for (std::string line : lines) {
+        std::string trimmed_line = boost::trim_copy(line);
+        if (trimmed_line.size() > 0) {
+            if (isKeyword(line)) {
+                trimmed_strings.push_back(trimmed_line);
+            }
+            else {
+                trimmed_strings.push_back(boost::trim_right_copy(line));
+            }
+        }
+    }
+    return trimmed_strings;
+}
+
+bool ScheduleInsets::isKeyword(const std::string line) const {
+    std::string trimmed_line = boost::trim_copy(line);
+    if (trimmed_line.compare(0, 5, "INSET") == 0 || trimmed_line.compare("END_INSET") == 0) {
+        return true;
+    }
+    else {
+        return false;
+    }
+}
+
+}
+}

--- a/FieldOpt/Simulation/simulator_interfaces/driver_file_writers/driver_parts/ecl_driver_parts/schedule_insets.h
+++ b/FieldOpt/Simulation/simulator_interfaces/driver_file_writers/driver_parts/ecl_driver_parts/schedule_insets.h
@@ -1,0 +1,106 @@
+/******************************************************************************
+   Copyright (C) 2019 Einar J.M. Baumann <einar.baumann@gmail.com>
+
+   This file is part of the FieldOpt project.
+
+   FieldOpt is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   FieldOpt is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with FieldOpt.  If not, see <http://www.gnu.org/licenses/>.
+******************************************************************************/
+#ifndef FIELDOPT_SCHEDULE_INSETS_H
+#define FIELDOPT_SCHEDULE_INSETS_H
+
+#include <string>
+#include <map>
+#include <vector>
+#include <deque>
+
+namespace Simulation {
+namespace ECLDriverParts {
+
+/*!
+ * @brief The ScheduleInsets class parses a file describing code snippets to be inserted
+ * at spcific times in the schedule and provides convenient access to these.
+ *
+ * The file describing the insets may have any name. The path to the file should be provided
+ * when launching FieldOpt, using the --sim-inset flag.
+ *
+ * The file should be formatted as follows:
+ *
+ * @code
+ * INSET=-1
+ * -- Code inserted at the very beginning of the schedule file written by FieldOpt, before anything else
+ * ECLCMD
+ *  SOMETHING 5 /
+ * END_INSET
+ *
+ * INSET=365
+ * -- Code inserted after 365 days (must be a day in the control times array), after WELSPECS
+ * OTHERCMD
+ *  SHORTABBRV 69 /
+ * END_INSET
+ * @endcode
+ *
+ * Notice the first line: INSET=-1
+ * - INSET is the keyword used to indicate the start of a new inset.
+ * - INSET should be followed by an`=`, followed by the day at which the code should be inserted.
+ * - INSET=-1 indicates that the snippet should be inserted at the very beginning of the schedule written by FieldOpt,
+ *   before the first WELSPECS.
+ * - INSET=N will insert the snippet after the WELSPECS keyword on day N.
+ * - Inserts/snippets should be terminated/ended using the END_INSET keyword.
+ * - The keywords are case sensitive.
+ * - Everything between `INSET=N` and `END_INSET` will be inserted verbatim.
+ *
+ * **Note:** The inset time _must_ be a control time specified in the driver file.
+ *
+ * An example inset file is shown in examples/ECLIPSE/schedule_inset.txt
+ */
+class ScheduleInsets {
+
+ public:
+  /*!
+   * @brief Constructor used when no inserts path is given.
+   */
+  ScheduleInsets();
+
+  /*!
+   * @brief Build the day-snippet mapping by parsing the file at the provided path.
+   * @param inset_file_path Path to inset-file.
+   */
+  ScheduleInsets(const std::string &inset_file_path);
+
+  /*!
+   * @brief Check whether an inset is specified at a control time step.
+   * @param time Time/day to check.
+   * @return True if an inset is specified; otherwise false.
+   */
+  bool HasInset(const int &time) const;
+
+  /*!
+   * @brief Get the inset at the specified time.
+   * @param time Time to get snippet for.
+   * @return Snippet at specified time. If no snippet is specified, an empty string is returned.
+   */
+  std::string GetInset(const int &time) const;
+
+ private:
+  std::map<int, std::string> insets_;
+
+  std::pair<int, std::string> parseNextInset(std::deque<std::string> &lines) const;
+  std::deque<std::string> trimEmptyLines(const std::vector<std::string> &lines) const;
+  bool isKeyword(const std::string line) const;
+
+};
+
+}
+}
+#endif //FIELDOPT_SCHEDULE_INSETS_H

--- a/FieldOpt/Simulation/simulator_interfaces/driver_file_writers/driver_parts/ecl_driver_parts/schedule_section.cpp
+++ b/FieldOpt/Simulation/simulator_interfaces/driver_file_writers/driver_parts/ecl_driver_parts/schedule_section.cpp
@@ -29,11 +29,12 @@
 namespace Simulation {
 namespace ECLDriverParts {
 
-Schedule::Schedule(QList<Model::Wells::Well *> *wells, QList<int> control_times)
+Schedule::Schedule(QList<Model::Wells::Well *> *wells, QList<int> control_times, ScheduleInsets &insets)
 {
     schedule_time_entries_ = QList<ScheduleTimeEntry>();
     for (int ts : control_times) {
-        ScheduleTimeEntry time_entry = ScheduleTimeEntry(Welspecs(wells, ts),
+        ScheduleTimeEntry time_entry = ScheduleTimeEntry(ts,
+                                                         Welspecs(wells, ts),
                                                          Compdat(wells, ts),
                                                          WellControls(wells, control_times, ts),
                                                          Welsegs(wells, ts),
@@ -42,8 +43,15 @@ Schedule::Schedule(QList<Model::Wells::Well *> *wells, QList<int> control_times)
         );
         schedule_time_entries_.append(time_entry);
     }
+
+    if (insets.HasInset(-1)) {
+        schedule_.append(QString::fromStdString(insets.GetInset(-1)));
+    }
     for (auto time_entry : schedule_time_entries_) {
         schedule_.append(time_entry.welspecs.GetPartString());
+        if (insets.HasInset(time_entry.control_time)) {
+            schedule_.append(QString::fromStdString(insets.GetInset(time_entry.control_time)));
+        }
         schedule_.append(time_entry.compdat.GetPartString());
         schedule_.append(time_entry.welsegs.GetPartString());
         schedule_.append(time_entry.compsegs.GetPartString());
@@ -58,7 +66,8 @@ QString Schedule::GetPartString() const
     return schedule_;
 }
 
-Schedule::ScheduleTimeEntry::ScheduleTimeEntry(Welspecs welspecs,
+Schedule::ScheduleTimeEntry::ScheduleTimeEntry(int control_time,
+                                               Welspecs welspecs,
                                                Compdat compdat,
                                                WellControls well_controls,
                                                Welsegs welsegs,
@@ -66,6 +75,7 @@ Schedule::ScheduleTimeEntry::ScheduleTimeEntry(Welspecs welspecs,
                                                Wsegvalv wsegvalv
 )
 {
+    this->control_time = control_time;
     this->welspecs = welspecs;
     this->compdat = compdat;
     this->well_controls = well_controls;

--- a/FieldOpt/Simulation/simulator_interfaces/driver_file_writers/driver_parts/ecl_driver_parts/schedule_section.h
+++ b/FieldOpt/Simulation/simulator_interfaces/driver_file_writers/driver_parts/ecl_driver_parts/schedule_section.h
@@ -1,12 +1,7 @@
 /******************************************************************************
- *
- *
- *
- * Created: 18.11.2015 2015 by einar
- *
  * This file is part of the FieldOpt project.
  *
- * Copyright (C) 2015-2015 Einar J.M. Baumann <einar.baumann@ntnu.no>
+ * Copyright (C) 2015-2019 Einar J.M. Baumann <einar.baumann@ntnu.no>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -34,6 +29,7 @@
 #include "welsegs.h"
 #include "compsegs.h"
 #include "wsegvalv.h"
+#include "schedule_insets.h"
 #include <QStringList>
 
 namespace Simulation {
@@ -41,20 +37,29 @@ namespace ECLDriverParts {
 
 class Schedule : public ECLDriverPart
 {
-public:
-    Schedule(QList<Model::Wells::Well *> *wells, QList<int> control_times);
-    QString GetPartString() const;
+ public:
+  /*!
+   * @brief Constructor. Generate the time entries and build the complete schedule string.
+   * @param wells List of wells from the model.
+   * @param control_times List of control times.
+   * @param insets Text snippets to be inserted at specific time steps in the schedule.
+   */
+  Schedule(QList<Model::Wells::Well *> *wells, QList<int> control_times, ScheduleInsets &insets);
+  QString GetPartString() const;
 
-private:
+ private:
 
   struct ScheduleTimeEntry {
-    ScheduleTimeEntry(Welspecs welspecs,
+    ScheduleTimeEntry(int control_time,
+                      Welspecs welspecs,
                       Compdat compdat,
                       WellControls well_controls,
                       Welsegs welsegs,
                       Compsegs compsegs,
                       Wsegvalv wsegvalv
     );
+    int control_time;
+
     Welspecs welspecs;
     Compdat compdat;
     WellControls well_controls;

--- a/FieldOpt/Simulation/simulator_interfaces/driver_file_writers/driver_parts/ecl_driver_parts/wellcontrols.cpp
+++ b/FieldOpt/Simulation/simulator_interfaces/driver_file_writers/driver_parts/ecl_driver_parts/wellcontrols.cpp
@@ -192,21 +192,38 @@ QString WellControls::createProducerEntry(const WellControls::WellSetting &setti
     switch (setting.control.mode()) {
         case ::Settings::Model::ControlMode::BHPControl:
             producer_entry_line[2] = "BHP";
-            producer_entry_line[8] = QString::number(setting.control.bhp());
-            if (setting.control.rate() > 0) { // Simulator-enforced upper bound
-                producer_entry_line[6] = QString::number(setting.control.rate());
-            }
+            if (setting.control.bhp() < 0) throw std::runtime_error("Invalid BHP control value.");
             break;
         case ::Settings::Model::ControlMode::LRATControl:
             producer_entry_line[2] = "LRAT";
-            producer_entry_line[6] = QString::number(setting.control.rate());
-            if (setting.control.bhp() > 0) { // Simulator-enforced lower bound
-                producer_entry_line[8] = QString::number(setting.control.bhp());
-            }
+            if (setting.control.liquidRate() < 0) throw std::runtime_error("Invalid LRAT control value.");
+            break;
+        case ::Settings::Model::ControlMode::ORATControl:
+            if (setting.control.oilRate() < 0) throw std::runtime_error("Invalid ORAT control value.");
+            producer_entry_line[2] = "ORAT";
+            break;
+        case ::Settings::Model::ControlMode::GRATControl:
+            if (setting.control.gasRate() < 0) throw std::runtime_error("Invalid GRAT control value.");
+            producer_entry_line[2] = "GRAT";
+            break;
+        case ::Settings::Model::ControlMode::WRATControl:
+            if (setting.control.waterRate() < 0) throw std::runtime_error("Invalid WRAT control value.");
+            producer_entry_line[2] = "WRAT";
+            break;
+        case ::Settings::Model::ControlMode::RESVControl:
+            if (setting.control.reservoirRate() < 0) throw std::runtime_error("Invalid RESV control value.");
+            producer_entry_line[2] = "RESV";
             break;
         default:
             throw std::runtime_error("Producer control mode not recognized.");
     }
+    if (setting.control.oilRate()       > 0) producer_entry_line[3] = QString::number(setting.control.oilRate());
+    if (setting.control.waterRate()     > 0) producer_entry_line[4] = QString::number(setting.control.waterRate());
+    if (setting.control.gasRate()       > 0) producer_entry_line[5] = QString::number(setting.control.gasRate());
+    if (setting.control.liquidRate()    > 0) producer_entry_line[6] = QString::number(setting.control.liquidRate());
+    if (setting.control.reservoirRate() > 0) producer_entry_line[7] = QString::number(setting.control.reservoirRate());
+    if (setting.control.bhp()           > 0) producer_entry_line[8] = QString::number(setting.control.bhp());
+
     return "WCONPROD\n   " + producer_entry_line.join(" ") + "/\n/\n\n";
 }
 

--- a/FieldOpt/Simulation/simulator_interfaces/driver_file_writers/driver_parts/ecl_driver_parts/wellcontrols.cpp
+++ b/FieldOpt/Simulation/simulator_interfaces/driver_file_writers/driver_parts/ecl_driver_parts/wellcontrols.cpp
@@ -197,7 +197,7 @@ QString WellControls::createProducerEntry(const WellControls::WellSetting &setti
                 producer_entry_line[6] = QString::number(setting.control.rate());
             }
             break;
-        case ::Settings::Model::ControlMode::RateControl:
+        case ::Settings::Model::ControlMode::LRATControl:
             producer_entry_line[2] = "LRAT";
             producer_entry_line[6] = QString::number(setting.control.rate());
             if (setting.control.bhp() > 0) { // Simulator-enforced lower bound
@@ -237,7 +237,7 @@ QString WellControls::createInjectorEntry(const WellControls::WellSetting &setti
                 injector_entry_line[4] = QString::number(setting.control.rate());
             }
             break;
-        case ::Settings::Model::ControlMode::RateControl:
+        case ::Settings::Model::ControlMode::LRATControl:
             injector_entry_line[3] = "RATE";
             injector_entry_line[4] = QString::number(setting.control.rate());
             if (setting.control.bhp() > 0) { // Simulator-enforced upper bound

--- a/FieldOpt/Simulation/simulator_interfaces/driver_file_writers/driver_parts/ix_driver_parts/ix_control.hpp
+++ b/FieldOpt/Simulation/simulator_interfaces/driver_file_writers/driver_parts/ix_driver_parts/ix_control.hpp
@@ -36,7 +36,7 @@ inline std::string create_single_control(const QString &well_name, bool is_injec
         if (control->mode() == Settings::Model::ControlMode::BHPControl) {
             ss << "        Constraint(" << control->bhp() << " INJECTION_BOTTOM_HOLE_PRESSURE)" << std::endl;
         }
-        else if (control->mode() == Settings::Model::ControlMode::RateControl) {
+        else if (control->mode() == Settings::Model::ControlMode::LRATControl) {
             ss << "        Constraint(" << control->rate() << " WATER_INJECTION_RATE)"          << std::endl;
         }
     }
@@ -44,7 +44,7 @@ inline std::string create_single_control(const QString &well_name, bool is_injec
         if (control->mode() == Settings::Model::ControlMode::BHPControl) {
             ss << "        Constraint(" << control->bhp() << " BOTTOM_HOLE_PRESSURE)"           << std::endl;
         }
-        else if (control->mode() == Settings::Model::ControlMode::RateControl) {
+        else if (control->mode() == Settings::Model::ControlMode::LRATControl) {
             ss << "        Constraint(" << control->rate() << " LIQUID_PRODCTION_RATE)"         << std::endl;
         }
     }

--- a/FieldOpt/Simulation/simulator_interfaces/driver_file_writers/ecldriverfilewriter.cpp
+++ b/FieldOpt/Simulation/simulator_interfaces/driver_file_writers/ecldriverfilewriter.cpp
@@ -39,6 +39,10 @@ EclDriverFileWriter::EclDriverFileWriter(Settings::Settings *settings, Model::Mo
 {
     model_ = model;
     settings_ = settings;
+
+    if (settings->paths().IsSet(Paths::SIM_SCH_INSET_FILE)) {
+        insets_ = ECLDriverParts::ScheduleInsets(settings->paths().GetPath(Paths::SIM_SCH_INSET_FILE));
+    }
 }
 
 void EclDriverFileWriter::WriteDriverFile(QString schedule_file_path)
@@ -48,7 +52,7 @@ void EclDriverFileWriter::WriteDriverFile(QString schedule_file_path)
         Printer::ext_info("Writing driver file to " + fp + ".", "Simulation", "EclDriverFileWriter");
     }
     assert(FileExists(schedule_file_path));
-    Schedule schedule = ECLDriverParts::Schedule(model_->wells(), settings_->model()->control_times());
+    Schedule schedule = ECLDriverParts::Schedule(model_->wells(), settings_->model()->control_times(), insets_);
     model_->SetCompdatString(ECLDriverParts::Compdat(model_->wells()).GetPartString());
     Utilities::FileHandling::WriteStringToFile(schedule.GetPartString(), schedule_file_path);
 }

--- a/FieldOpt/Simulation/simulator_interfaces/driver_file_writers/ecldriverfilewriter.h
+++ b/FieldOpt/Simulation/simulator_interfaces/driver_file_writers/ecldriverfilewriter.h
@@ -29,6 +29,7 @@
 #include "Settings/settings.h"
 #include "Settings/simulator.h"
 #include "Model/model.h"
+#include "driver_parts/ecl_driver_parts/schedule_insets.h"
 
 namespace Simulation {
     class ECLSimulator;
@@ -50,6 +51,7 @@ private:
 
     Model::Model *model_;
     ::Settings::Settings *settings_;
+    ECLDriverParts::ScheduleInsets insets_;
 };
 
 }

--- a/FieldOpt/Simulation/tests/simulator_interfaces/driver_file_writers/driver_parts/ecl_driver_parts/test_schedule_inset.cpp
+++ b/FieldOpt/Simulation/tests/simulator_interfaces/driver_file_writers/driver_parts/ecl_driver_parts/test_schedule_inset.cpp
@@ -1,0 +1,45 @@
+/******************************************************************************
+   Copyright (C) 2019 Einar J.M. Baumann <einar.baumann@gmail.com>
+
+   This file is part of the FieldOpt project.
+
+   FieldOpt is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   FieldOpt is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with FieldOpt.  If not, see <http://www.gnu.org/licenses/>.
+******************************************************************************/
+
+#include <Model/tests/test_resource_model.h>
+#include <gtest/gtest.h>
+#include "Simulation/simulator_interfaces/driver_file_writers/driver_parts/ecl_driver_parts/schedule_section.h"
+#include "Simulation/simulator_interfaces/driver_file_writers/driver_parts/ecl_driver_parts/schedule_insets.h"
+
+using namespace ::Simulation::ECLDriverParts;
+
+namespace {
+
+class DriverPartScheduleInsetTest : public ::testing::Test, public TestResources::TestResourceModel {
+ protected:
+  DriverPartScheduleInsetTest(){
+      insets_ = ScheduleInsets(TestResources::ExampleFilePaths::schedule_inset_);
+      schedule_ = new Schedule(model_->wells(), settings_model_->control_times(), insets_);
+  }
+  virtual ~DriverPartScheduleInsetTest(){}
+
+  Schedule *schedule_;
+  ScheduleInsets insets_;
+};
+
+TEST_F(DriverPartScheduleInsetTest, Constructor) {
+//    std::cout << schedule_->GetPartString().toStdString() << std::endl;
+}
+
+}

--- a/FieldOpt/Simulation/tests/simulator_interfaces/driver_file_writers/driver_parts/ecl_driver_parts/test_schedule_section.cpp
+++ b/FieldOpt/Simulation/tests/simulator_interfaces/driver_file_writers/driver_parts/ecl_driver_parts/test_schedule_section.cpp
@@ -1,6 +1,7 @@
 #include <Model/tests/test_resource_model.h>
 #include <gtest/gtest.h>
 #include "Simulation/simulator_interfaces/driver_file_writers/driver_parts/ecl_driver_parts/schedule_section.h"
+#include "Simulation/simulator_interfaces/driver_file_writers/driver_parts/ecl_driver_parts/schedule_insets.h"
 
 using namespace ::Simulation::ECLDriverParts;
 
@@ -9,15 +10,16 @@ namespace {
 class DriverPartScheduleTest : public ::testing::Test, public TestResources::TestResourceModel {
 protected:
     DriverPartScheduleTest(){
-        schedule_ = new Schedule(model_->wells(), settings_model_->control_times());
+        schedule_ = new Schedule(model_->wells(), settings_model_->control_times(), insets_);
     }
     virtual ~DriverPartScheduleTest(){}
 
     Schedule *schedule_;
+    ScheduleInsets insets_;
 };
 
 TEST_F(DriverPartScheduleTest, Constructor) {
-    //std::cout << schedule_->GetPartString().toStdString() << std::endl;
+//    std::cout << schedule_->GetPartString().toStdString() << std::endl;
 }
 
 }

--- a/examples/ECLIPSE/schedule_inset.txt
+++ b/examples/ECLIPSE/schedule_inset.txt
@@ -1,0 +1,12 @@
+INSET=-1
+-- Inserted by FieldOpt before the first WELSPECS
+RPTRST
+  BASIC=0 /
+END_INSET
+
+INSET=0
+-- Inserted by FieldOpt after WELSPECS at Day 0
+GCONPROD
+  FIELD  ORAT 10000.0 /
+/
+END_INSET


### PR DESCRIPTION
This PR contains two related features:

* New rates (oil/water/gas/reservoir fluid volume) now available as targets/limits/variables. These
are used in the `Controls` part each well in the JSON driver as before with `Rate` and `BHP`. The
old `Rate` keyword still represents `LRAT`, but one can now specify (both values for and as modes)
`ORAT, LRAT, GRAT, WRAT, RESV`. Values can be specified for all or some of these, and each can
be set as the control mode. Whichever is set as the control mode is the rate that will be set as the target for the simulator and used as a variable by FieldOpt (if the control is set variable).

* FieldOpt can now take a file describing snippets that will be inserted verbatim in the schedule at specified control times. This is thoroughly described in the `schedule_insets.h` file.

