### PR TITLE
Support post-simulation script execution

### DIFF
--- a/FieldOpt/Settings/simulator.cpp
+++ b/FieldOpt/Settings/simulator.cpp
@@ -88,6 +88,12 @@ void Simulator::setParams(QJsonObject json_simulator) {
     else {
         ecl_use_actionx_ = false;
     }
+    if (json_simulator.contains("UsePostSimScript") && json_simulator["UsePostSimScript"] == true) {
+        use_post_sim_script_ = true;
+    }
+    else {
+        use_post_sim_script_ = false;
+    }
 }
 
 void Simulator::setCommands(QJsonObject json_simulator) {

--- a/FieldOpt/Settings/simulator.h
+++ b/FieldOpt/Settings/simulator.h
@@ -81,6 +81,13 @@ class Simulator
    */
   bool use_actionx() const { return ecl_use_actionx_; }
 
+  /*!
+   * @brief Check whether or not to call a script named FO_POSTSIM.sh
+   * in the same directory as the simulator DATA file after simulation,
+   * if the script is found.
+   */
+  bool use_post_sim_script() const { return use_post_sim_script_; }
+
  private:
   SimulatorType type_;
   SimulatorFluidModel fluid_model_;
@@ -88,6 +95,7 @@ class Simulator
   QString script_name_;
   bool is_ensemble_;
   bool ecl_use_actionx_;
+  bool use_post_sim_script_;
   int max_minutes_;
   Ensemble ensemble_;
 

--- a/FieldOpt/Simulation/simulator_interfaces/eclsimulator.cpp
+++ b/FieldOpt/Simulation/simulator_interfaces/eclsimulator.cpp
@@ -61,6 +61,7 @@ void ECLSimulator::Evaluate()
         script_args_
     );
     if (VERB_SIM >= 2) { Printer::info("Unmonitored simulation done. Reading results."); }
+    PostSimWork();
     results_->ReadResults(QString::fromStdString(paths_.GetPath(Paths::SIM_OUT_DRIVER_FILE)));
     updateResultsInModel();
 }
@@ -82,13 +83,10 @@ bool ECLSimulator::Evaluate(int timeout, int threads) {
     bool success = ::Utilities::Unix::ExecShellScriptTimeout(
         QString::fromStdString(paths_.GetPath(Paths::SIM_EXEC_SCRIPT_FILE)),
         script_args_, t);
-    if (VERB_SIM >= 2) {
-        Printer::info("Monitored simulation done.");
-    }
+    if (VERB_SIM >= 2) Printer::info("Monitored simulation done.");
     if (success) {
-        if (VERB_SIM >= 2) {
-            Printer::info("Simulation successful. Reading results.");
-        }
+        if (VERB_SIM >= 2) Printer::info("Simulation successful. Reading results.");
+        PostSimWork();
         results_->DumpResults();
         results_->ReadResults(QString::fromStdString(paths_.GetPath(Paths::SIM_OUT_DRIVER_FILE)));
     }

--- a/FieldOpt/Simulation/simulator_interfaces/ix_simulator.cpp
+++ b/FieldOpt/Simulation/simulator_interfaces/ix_simulator.cpp
@@ -54,6 +54,7 @@ void IXSimulator::Evaluate() {
     if (result_path_.size() == 0) {
         setResultPath();
     }
+    PostSimWork();
     if (VERB_SIM >= 1) { Printer::info("Unmonitored simulation done. Reading results from " + result_path_.toStdString()); }
     results_->ReadResults(result_path_);
     updateResultsInModel();
@@ -78,6 +79,7 @@ bool IXSimulator::Evaluate(int timeout, int threads) {
         if (result_path_.size() == 0) {
             setResultPath();
         }
+        PostSimWork();
         if (VERB_SIM >= 1) { Printer::info("Simulation successful. Reading results from " + result_path_.toStdString()); }
         results_->ReadResults(result_path_);
     }

--- a/FieldOpt/Simulation/simulator_interfaces/simulator.cpp
+++ b/FieldOpt/Simulation/simulator_interfaces/simulator.cpp
@@ -18,6 +18,7 @@
 ******************************************************************************/
 #include "simulator.h"
 #include "simulator_exceptions.h"
+#include "Utilities/execution.hpp"
 
 namespace Simulation {
 
@@ -52,6 +53,21 @@ Simulator::Simulator(Settings::Settings *settings) {
 ::Simulation::Results::Results *Simulator::results()
 {
     return results_;
+}
+
+void Simulator::PostSimWork() {
+    if (settings_->simulator()->use_post_sim_script()) {
+        std::string expected_scr_path = paths_.GetPath(Paths::SIM_WORK_DIR) + "/FO_POSTSIM.sh";
+        if (VERB_SIM >= 2) Printer::ext_info("Looking for PostSimWork script at " + expected_scr_path, "Simulation", "Simulator");
+        if (Utilities::FileHandling::FileExists(expected_scr_path)) {
+            if (VERB_SIM >= 2) Printer::ext_info("PostSimWork script found. Executing... ", "Simulation", "Simulator");
+            Utilities::Unix::ExecShellScript(QString::fromStdString(expected_scr_path), QStringList());
+            if (VERB_SIM >= 2) Printer::ext_info("Done executing PostSimWork script.", "Simulation", "Simulator");
+        }
+        else {
+            Printer::ext_warn("PostSimWork script not found.");
+        }
+    }
 }
 
 void Simulator::SetVerbosityLevel(int level) {

--- a/FieldOpt/Simulation/simulator_interfaces/simulator.h
+++ b/FieldOpt/Simulation/simulator_interfaces/simulator.h
@@ -102,6 +102,15 @@ class Simulator {
 
   void updateResultsInModel();
 
+  /*!
+   * @brief Perform post-simulation work (if any).
+   *
+   * This if UsePostSimScript is set to true in the driver file, this
+   * will execute a script named FO_POSTSIM.sh in the directory containing
+   * the .DATA file (if the script is found).
+   */
+  void PostSimWork();
+
   Paths paths_;
 
   QString driver_file_name_; //!< The name of the driver main file.


### PR DESCRIPTION
FieldOpt is now able to execute a shell script after each simulation.
This script may do whatever (FieldOpt does not care).

For now, this feature is used as follows:

1. In the driver file, in the simulation section, add `"UsePostSimScript": true`.
This will make FieldOpt search for and (if it is found) execute a script named `FO_POSTSIM.sh`
located in the simulator directory (i.e. the same directory that contains the .DATA file).
2. A file named `FO_POSTSIM.sh` must be placed in the same directory as the .DATA simulator file.
If running with an ensemble, one such file must be placed in each realization directory.

Note that FieldOpt should not crash if no such script is found: a warning will be printed.