### PR TITLE
 Support reading of additional results from JSON file

### DIFF
--- a/FieldOpt/Optimization/objective/NPV.h
+++ b/FieldOpt/Optimization/objective/NPV.h
@@ -47,17 +47,18 @@ class NPV : public Objective {
  */
   struct Component {
    public:
-    QString property_name;
+    std::string property_name;
     double coefficient;
     Simulation::Results::Results::Property property;
     int time_step;
-    QString well;
+    std::string well;
     double resolveValue(Simulation::Results::Results *results);
     double resolveValueDiscount(Simulation::Results::Results *results, double time_step);
     double yearlyToMonthly(double discount_factor);
-    QString interval;
+    std::string interval;
     double discount;
     bool usediscountfactor;
+    bool is_json_component;
   };
 
   QList<Component *> *components_; //!< List of gamma, k pairs.

--- a/FieldOpt/Settings/Sources.cmake
+++ b/FieldOpt/Settings/Sources.cmake
@@ -7,6 +7,7 @@ SET(SETTINGS_HEADERS
 	settings_exceptions.h
 	simulator.h
 	trajectory_importer.h
+    helpers.hpp
 )
 
 SET(SETTINGS_SOURCES

--- a/FieldOpt/Settings/helpers.hpp
+++ b/FieldOpt/Settings/helpers.hpp
@@ -1,0 +1,189 @@
+/******************************************************************************
+   Created by einar on 6/11/19.
+   Copyright (C) 2019 Einar J.M. Baumann <einar.baumann@gmail.com>
+
+   This file is part of the FieldOpt project.
+
+   FieldOpt is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   FieldOpt is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with FieldOpt.  If not, see <http://www.gnu.org/licenses/>.
+******************************************************************************/
+
+
+#ifndef SETTINGS_HELPERS
+#define SETTINGS_HELPERS
+
+#include <QString>
+#include <QList>
+#include <QJsonArray>
+#include "Utilities/printer.hpp"
+#include "Utilities/verbosity.h"
+
+namespace Settings {
+
+/*!
+ * @brief Check if the property defined by a container is to be variable.
+ *
+ * This is done by checking for the precence of an "IsVariable" field,
+ * and checking whether the value is true.
+ */
+inline bool is_prop_variable(const QJsonObject &container) {
+    if (container.contains("IsVariable") && container["IsVariable"].isBool() && container["IsVariable"].toBool() == true) {
+        return true;
+    }
+    else {
+        return false;
+    }
+}
+
+/*!
+* @brief Set an optional double property. Will return true if property is found, otherwise false.
+* @param prop The property that should have its value set.
+* @param container The JSON object that should contain the property.
+* @param prop_name The name of the property to find in the container.
+*/
+inline bool set_opt_prop_double(double &prop, const QJsonObject &container, const QString &prop_name) {
+    if (container.contains(prop_name) && (container[prop_name].isDouble())) {
+        prop = container[prop_name].toDouble();
+        return true;
+    }
+    else {
+        Printer::ext_info("Property " + prop_name.toStdString() + " not found. Using default ("
+                        + Printer::num2str(prop) + ").", "Settings", "Helpers");
+        return false;
+    }
+} 
+
+/*!
+* @brief Set a required double property. Will throw an exception if the property is not found.
+* @param prop The property that should have its value set.
+* @param container The JSON object that should contain the property.
+* @param prop_name The name of the property to find in the container.
+*/
+inline void set_req_prop_double(double &prop, const QJsonObject &container, const QString &prop_name) {
+    if (!set_opt_prop_double(prop, container, prop_name)) {
+        throw std::runtime_error("Required property " + prop_name.toStdString() + " not found.");
+    }
+} 
+
+/*!
+* @brief Set an optional integer property. Will return true if property is found, otherwise false.
+* @param prop The property that should have its value set.
+* @param container The JSON object that should contain the property.
+* @param prop_name The name of the property to find in the container.
+*/
+inline bool set_opt_prop_int(int &prop, const QJsonObject &container, const QString &prop_name) {
+    if (container.contains(prop_name) && (container[prop_name].isDouble())) {
+        prop = container[prop_name].toInt();
+        return true;
+    }
+    else {
+        Printer::ext_info("Property " + prop_name.toStdString() + " not found. Using default ("
+                        + Printer::num2str(prop) + ").", "Settings", "Helpers");
+        return false;
+    }
+} 
+inline void set_req_prop_int(int &prop, const QJsonObject &container, const QString &prop_name) {
+    if (!set_opt_prop_int(prop, container, prop_name)) {
+        throw std::runtime_error("Required property " + prop_name.toStdString() + " not found.");
+    }
+} 
+
+inline bool set_opt_prop_bool(bool &prop, const QJsonObject &container, const QString &prop_name) {
+    if (container.contains(prop_name) && container[prop_name].isBool()) {
+        prop = container[prop_name].toBool();
+        return true;
+    }
+    else {
+        Printer::ext_info("Property " + prop_name.toStdString() + " not found. Using default ("
+                        + Printer::num2str(prop) + ").", "Settings", "Helpers");
+        return false;
+    }
+}
+
+inline bool set_req_prop_bool(bool &prop, const QJsonObject &container, const QString &prop_name) {
+    if (!set_opt_prop_bool(prop, container, prop_name)) {
+        throw std::runtime_error("Required property " + prop_name.toStdString() + " not found.");
+    }
+}
+
+/*!
+* @brief Set an optional string property. Will return true if property is found, otherwise false.
+* @param prop The property that should have its value set.
+* @param container The JSON object that should contain the property.
+* @param prop_name The name of the property to find in the container.
+*/
+inline bool set_opt_prop_string(std::string &prop, const QJsonObject &container, const QString &prop_name){
+    if (container.contains(prop_name) && container[prop_name].isString()) {
+        prop = container[prop_name].toString().toStdString();
+        return true;
+    }
+    else {
+        return false;
+    }
+}
+inline void set_req_prop_string(std::string &prop, const QJsonObject &container, const QString &prop_name) {
+    if (!set_opt_prop_string(prop, container, prop_name)) {
+        throw std::runtime_error("Required property " + prop_name.toStdString() + " not found.");
+    }
+}
+
+/*!
+* @brief Set an optional string array property. Will return true if property is found, otherwise false.
+* @param prop The property that should have its value set.
+* @param container The JSON object that should contain the property.
+* @param prop_name The name of the property to find in the container.
+*/
+inline bool set_opt_prop_string_array(std::vector<std::string> &prop, const QJsonObject &container, const QString &prop_name){
+    if (container.contains(prop_name) && container[prop_name].isArray() && container[prop_name].toArray()[0].isString()) {
+        for (auto elem : container[prop_name].toArray()) {
+            prop.push_back(elem.toString().toStdString());
+        }
+        return true;
+    }
+    else {
+        return false;
+    }
+}
+inline void set_req_prop_string_array(std::vector<std::string> &prop, const QJsonObject &container, const QString &prop_name){
+    if (!set_opt_prop_string_array(prop, container, prop_name)) {
+        throw std::runtime_error("Required property " + prop_name.toStdString() + " not found.");
+    }
+}
+
+/*!
+* @brief Set an optional int array property. Will return true if property is found, otherwise false.
+* @param prop The property that should have its value set.
+* @param container The JSON object that should contain the property.
+* @param prop_name The name of the property to find in the container.
+*/
+inline bool set_opt_prop_int_array(std::vector<int> &prop, const QJsonObject &container, const QString &prop_name) {
+    if (container.contains(prop_name) && container[prop_name].isArray() && container[prop_name].toArray()[0].isDouble()) {
+        for (auto elem : container[prop_name].toArray()) {
+            prop.push_back(elem.toInt());
+        }
+        return true;
+    }
+    else {
+        return false;
+    }
+}
+inline void set_req_prop_int_array(std::vector<int> &prop, const QJsonObject &container, const QString &prop_name) {
+    if (!set_opt_prop_int_array(prop, container, prop_name)) {
+        throw std::runtime_error("Required property " + prop_name.toStdString() + " not found.");
+    }
+}
+
+
+}
+
+#endif // SETTINGS_HELPERS

--- a/FieldOpt/Settings/model.cpp
+++ b/FieldOpt/Settings/model.cpp
@@ -34,6 +34,7 @@
 #include "settings_exceptions.h"
 #include "Utilities/filehandling.hpp"
 #include "trajectory_importer.h"
+#include "Settings/helpers.hpp"
 
 namespace Settings {
 
@@ -712,103 +713,6 @@ void Model::parseICVCompartmentalization(QJsonArray &icv_compartmentalization, W
         }
     }
 }
-
-bool Model::is_prop_variable(const QJsonObject &container) {
-    if (container.contains("IsVariable") && container["IsVariable"].isBool() && container["IsVariable"].toBool() == true) {
-        return true;
-    }
-    else {
-        return false;
-    }
-}
-
-bool Model::set_opt_prop_string_array(std::vector<std::string> &prop, const QJsonObject &container, const QString &prop_name) {
-        if (container.contains(prop_name) && container[prop_name].isArray() && container[prop_name].toArray()[0].isString()) {
-            for (auto elem : container[prop_name].toArray()) {
-                prop.push_back(elem.toString().toStdString());
-            }
-            return true;
-        }
-        else {
-            return false;
-        }
-}
-
-void Model::set_req_prop_string_array(std::vector<std::string> &prop, const QJsonObject &container, const QString &prop_name) {
-    if (!set_opt_prop_string_array(prop, container, prop_name)) {
-        throw std::runtime_error("Required property " + prop_name.toStdString() + " not found.");
-    }
-}
-
-bool Model::set_opt_prop_string(std::string &prop, const QJsonObject &container, const QString &prop_name) {
-    if (container.contains(prop_name) && container[prop_name].isString()) {
-        prop = container[prop_name].toString().toStdString();
-        return true;
-    }
-    else {
-        return false;
-    }
-}
-
-void Model::set_req_prop_string(std::string &prop, const QJsonObject &container, const QString &prop_name) {
-    if (!set_opt_prop_string(prop, container, prop_name)) {
-        throw std::runtime_error("Required property " + prop_name.toStdString() + " not found.");
-    }
-}
-
-bool Model::set_opt_prop_double(double &prop, const QJsonObject &container, const QString &prop_name) {
-    if (container.contains(prop_name) && (container[prop_name].isDouble())) {
-        prop = container[prop_name].toDouble();
-        return true;
-    }
-    else {
-        Printer::ext_info("Property " + prop_name.toStdString() + " not found. Using default ("
-                        + Printer::num2str(prop) + ").", "Settings", "Model");
-        return false;
-    }
-}
-void Model::set_req_prop_double(double &prop, const QJsonObject &container, const QString &prop_name) {
-    if (!set_opt_prop_double(prop, container, prop_name)) {
-        throw std::runtime_error("Required property " + prop_name.toStdString() + " not found.");
-    }
-}
-
-bool Model::set_opt_prop_int(int &prop, const QJsonObject &container, const QString &prop_name) {
-    if (container.contains(prop_name) && (container[prop_name].isDouble())) {
-        prop = container[prop_name].toInt();
-        return true;
-    }
-    else {
-        Printer::ext_info("Property " + prop_name.toStdString() + " not found. Using default ("
-                        + Printer::num2str(prop) + ").", "Settings", "Model");
-        return false;
-    }
-}
-void Model::set_req_prop_int(int &prop, const QJsonObject &container, const QString &prop_name) {
-    if (!set_opt_prop_int(prop, container, prop_name)) {
-        throw std::runtime_error("Required property " + prop_name.toStdString() + " not found.");
-    }
-}
-
-bool Model::set_opt_prop_int_array(std::vector<int> &prop, const QJsonObject &container, const QString &prop_name) {
-        if (container.contains(prop_name) && container[prop_name].isArray() && container[prop_name].toArray()[0].isDouble()) {
-            for (auto elem : container[prop_name].toArray()) {
-                prop.push_back(elem.toInt());
-            }
-            return true;
-        }
-        else {
-            return false;
-        }
-}
-
-void Model::set_req_prop_int_array(std::vector<int> &prop, const QJsonObject &container, const QString &prop_name) {
-    if (!set_opt_prop_int_array(prop, container, prop_name)) {
-        throw std::runtime_error("Required property " + prop_name.toStdString() + " not found.");
-    }
-}
-
-
 
 }
 

--- a/FieldOpt/Settings/model.h
+++ b/FieldOpt/Settings/model.h
@@ -181,66 +181,6 @@ class Model
   void parseSegmentAnnulus(const QJsonObject &json_seg, Well &well) const;
   void parseSegmentCompartments(const QJsonObject &json_seg, Well &well) const;
 
-  /*!
-   * @brief Set a required double property. Will throw an exception if the property is not found.
-   * @param prop The property that should have its value set.
-   * @param container The JSON object that should contain the property.
-   * @param prop_name The name of the property to find in the container.
-   */
-  void set_req_prop_double(double &prop, const QJsonObject &container, const QString &prop_name); 
-
-  /*!
-   * @brief Set an optional double property. Will return true if property is found, otherwise false.
-   * @param prop The property that should have its value set.
-   * @param container The JSON object that should contain the property.
-   * @param prop_name The name of the property to find in the container.
-   */
-  bool set_opt_prop_double(double &prop, const QJsonObject &container, const QString &prop_name); 
-
-  /*!
-   * @brief Set an optional integer property. Will return true if property is found, otherwise false.
-   * @param prop The property that should have its value set.
-   * @param container The JSON object that should contain the property.
-   * @param prop_name The name of the property to find in the container.
-   */
-  bool set_opt_prop_int(int &prop, const QJsonObject &container, const QString &prop_name); 
-  void set_req_prop_int(int &prop, const QJsonObject &container, const QString &prop_name); 
-
-  /*!
-   * @brief Set an optional string property. Will return true if property is found, otherwise false.
-   * @param prop The property that should have its value set.
-   * @param container The JSON object that should contain the property.
-   * @param prop_name The name of the property to find in the container.
-   */
-  bool set_opt_prop_string(std::string &prop, const QJsonObject &container, const QString &prop_name);
-  void set_req_prop_string(std::string &prop, const QJsonObject &container, const QString &prop_name);
-
-  /*!
-   * @brief Set an optional string array property. Will return true if property is found, otherwise false.
-   * @param prop The property that should have its value set.
-   * @param container The JSON object that should contain the property.
-   * @param prop_name The name of the property to find in the container.
-   */
-  bool set_opt_prop_string_array(std::vector<std::string> &prop, const QJsonObject &container, const QString &prop_name);
-  void set_req_prop_string_array(std::vector<std::string> &prop, const QJsonObject &container, const QString &prop_name);
-
-  /*!
-   * @brief Set an optional int array property. Will return true if property is found, otherwise false.
-   * @param prop The property that should have its value set.
-   * @param container The JSON object that should contain the property.
-   * @param prop_name The name of the property to find in the container.
-   */
-  bool set_opt_prop_int_array(std::vector<int> &prop, const QJsonObject &container, const QString &prop_name);
-  void set_req_prop_int_array(std::vector<int> &prop, const QJsonObject &container, const QString &prop_name);
-
-  /*!
-   * @brief Check if the property defined by a container is to be variable.
-   *
-   * This is done by checking for the precence of an "IsVariable" field,
-   * and checking whether the value is true.
-   */
-  bool is_prop_variable(const QJsonObject &container);
-
   void parseICVs(QJsonArray &json_icvs, Well &well);
   void parseICVCompartmentalization(QJsonArray &icv_compartmentalization, Well &well);
 

--- a/FieldOpt/Settings/optimizer.cpp
+++ b/FieldOpt/Settings/optimizer.cpp
@@ -20,6 +20,7 @@
 #include "Utilities/printer.hpp"
 #include "optimizer.h"
 #include "settings_exceptions.h"
+#include "Settings/helpers.hpp"
 
 namespace Settings {
 
@@ -500,49 +501,22 @@ Optimizer::Objective Optimizer::parseObjective(QJsonObject &json_objective) {
                 component.time_step = json_components.at(i).toObject()["TimeStep"].toInt();
                 obj.weighted_sum.append(component);
             }
-        } else if (QString::compare(objective_type, "NPV") == 0) {
+        }
+        else if (QString::compare(objective_type, "NPV") == 0) {
             // -------------------------------------------------
             obj.type = ObjectiveType::NPV;
             obj.NPV_sum = QList<Objective::NPVComponent>();
             // ---------------------------------------------------
-            QJsonArray json_components =
-                json_objective["NPVComponents"].toArray();
+            QJsonArray json_components = json_objective["NPVComponents"].toArray();
             // ---------------------------------------------------
             for (int i = 0; i < json_components.size(); ++i) {
                 // -------------------------------------------------
                 Objective::NPVComponent component;
-                if (json_components.at(i).toObject().contains("Coefficient")) {
-                    component.coefficient =
-                        json_components.at(i).toObject()["Coefficient"].toDouble();
-                } else {
-                    throw UnableToParseOptimizerObjectiveSectionException("Coefficient is not specified");
-                }
-                if (json_components.at(i).toObject().contains("Property")) {
-
-                    component.property =
-                        json_components.at(i).toObject()["Property"].toString();
-                } else {
-                    throw UnableToParseOptimizerObjectiveSectionException("Property is not specified");
-                }
-                if (json_components.at(i).toObject().contains("DiscountFactor")) {
-                    component.discount = json_components.at(i).toObject()["DiscountFactor"].toDouble();
-                } else {
-                    component.discount = 0;
-                }
-                if (json_components.at(i).toObject().contains("UseDiscountFactor")) {
-                    component.usediscountfactor =
-                        json_components.at(i).toObject()["UseDiscountFactor"].toBool();
-                } else {
-                    component.usediscountfactor = false;
-                }
-                if (json_components.at(i).toObject().contains("Interval")) {
-                    component.interval =
-                        json_components.at(i).toObject()["Interval"].toString();
-                } else {
-                    component.interval = nullptr;
-                }
-
-
+                set_req_prop_double(component.coefficient, json_components[i].toObject(), "Coefficient");
+                set_req_prop_string(component.property, json_components[i].toObject(), "Property");
+                set_opt_prop_double(component.discount, json_components[i].toObject(), "DiscountFactor");
+                set_req_prop_string(component.interval, json_components[i].toObject(), "Interval");
+                set_opt_prop_bool(component.usediscountfactor, json_components[i].toObject(), "UseDiscountFactor");
                 obj.NPV_sum.append(component);
             }
         } else

--- a/FieldOpt/Settings/optimizer.h
+++ b/FieldOpt/Settings/optimizer.h
@@ -152,11 +152,20 @@ class Optimizer
     double wellCostZ; //!<Cost associated with drilling in the vertical plane [$/m]
     double wellCost; //!<Cost associated with drilling the well, independent of direction [$/m]
     struct WeightedSumComponent {
-      double coefficient; QString property; int time_step;
-      bool is_well_prop; QString well; }; //!< A component of a weighted sum formulatied objective function
+      double coefficient; 
+      QString property; 
+      int time_step;
+      bool is_well_prop; 
+      QString well; 
+    }; //!< A component of a weighted sum objective function
     struct NPVComponent{
-      double coefficient; QString property; QString interval;
-      bool usediscountfactor; QString well; double discount; };
+      double coefficient;
+      std::string property;
+      std::string interval = "";
+      bool usediscountfactor = false;
+      std::string well;
+      double discount = 0.0;
+    };
     QList<WeightedSumComponent> weighted_sum; //!< The expression for the Objective function formulated as a weighted sum
     QList<NPVComponent> NPV_sum;  //!< The expression for the Objective function formulated as an NPV
 

--- a/FieldOpt/Settings/simulator.cpp
+++ b/FieldOpt/Settings/simulator.cpp
@@ -21,6 +21,7 @@
 #include "simulator.h"
 #include "settings_exceptions.h"
 #include "Utilities/filehandling.hpp"
+#include "Settings/helpers.hpp"
 
 using namespace Utilities::FileHandling;
 
@@ -76,24 +77,10 @@ void Simulator::setType(QJsonObject json_simulator) {
 }
 
 void Simulator::setParams(QJsonObject json_simulator) {
-    if (json_simulator.contains("MaxMinutes") && json_simulator["MaxMinutes"].toInt() > 0) {
-        max_minutes_ = json_simulator["MaxMinutes"].toInt();
-    }
-    else {
-        max_minutes_ = -1;
-    }
-    if (json_simulator.contains("UseACTIONX") && json_simulator["UseACTIONX"].toBool() == true) {
-        ecl_use_actionx_ = true;
-    }
-    else {
-        ecl_use_actionx_ = false;
-    }
-    if (json_simulator.contains("UsePostSimScript") && json_simulator["UsePostSimScript"] == true) {
-        use_post_sim_script_ = true;
-    }
-    else {
-        use_post_sim_script_ = false;
-    }
+    set_opt_prop_int(max_minutes_, json_simulator, "MaxMinutes");
+    set_opt_prop_bool(ecl_use_actionx_, json_simulator, "UseACTIONX");
+    set_opt_prop_bool(use_post_sim_script_, json_simulator, "UsePostSimScript");
+    set_opt_prop_bool(read_external_json_results_, json_simulator, "ReadExternalJsonResults");
 }
 
 void Simulator::setCommands(QJsonObject json_simulator) {

--- a/FieldOpt/Settings/simulator.cpp
+++ b/FieldOpt/Settings/simulator.cpp
@@ -88,6 +88,12 @@ void Simulator::setParams(QJsonObject json_simulator) {
     else {
         ecl_use_actionx_ = false;
     }
+    if (json_simulator.contains("UsePostSimScript") && json_simulator["UsePostSimScript"] == true) {
+        use_post_sim_script_ = true;
+    }
+    else {
+        use_post_sim_script_ = false;
+    }
 }
 
 void Simulator::setCommands(QJsonObject json_simulator) {

--- a/FieldOpt/Settings/simulator.h
+++ b/FieldOpt/Settings/simulator.h
@@ -81,6 +81,13 @@ class Simulator
    */
   bool use_actionx() const { return ecl_use_actionx_; }
 
+  /*!
+   * @brief Check whether or not to call a script named FO_POSTSIM.sh
+   * in the same directory as the simulator DATA file after simulation,
+   * if the script is found.
+   */
+  bool use_post_sim_script() const { return use_post_sim_script_; }
+
  private:
   SimulatorType type_;
   SimulatorFluidModel fluid_model_;
@@ -88,6 +95,7 @@ class Simulator
   QString script_name_;
   bool is_ensemble_;
   bool ecl_use_actionx_;
+  bool use_post_sim_script_;
   int max_minutes_;
   Ensemble ensemble_;
 

--- a/FieldOpt/Settings/simulator.h
+++ b/FieldOpt/Settings/simulator.h
@@ -88,15 +88,23 @@ class Simulator
    */
   bool use_post_sim_script() const { return use_post_sim_script_; }
 
+  /*!
+   * @brief Check whether or not to read external results component from
+   * a file named FO_EXT_RESULTS.json in the same directory as the simulator
+   * DATA file after simulation (and potential call of PostSimScript).
+   */
+  bool read_external_json_results() const { return read_external_json_results_; }
+
  private:
   SimulatorType type_;
   SimulatorFluidModel fluid_model_;
   QStringList *commands_;
   QString script_name_;
-  bool is_ensemble_;
-  bool ecl_use_actionx_;
-  bool use_post_sim_script_;
-  int max_minutes_;
+  bool is_ensemble_ = false;
+  bool ecl_use_actionx_ = false;
+  bool use_post_sim_script_ = false;
+  bool read_external_json_results_ = false;
+  int max_minutes_ = -1;
   Ensemble ensemble_;
 
 

--- a/FieldOpt/Simulation/Sources.cmake
+++ b/FieldOpt/Simulation/Sources.cmake
@@ -5,6 +5,7 @@ SET(SIMULATION_HEADERS
 	results/eclresults.h
 	results/results.h
 	results/results_exceptions.h
+    results/json_results.h
 	simulator_interfaces/adgprssimulator.h
 	simulator_interfaces/driver_file_writers/adgprsdriverfilewriter.h
 	simulator_interfaces/driver_file_writers/driver_parts/adgprs_driver_parts/adgprs_wellcontrols.h
@@ -57,6 +58,7 @@ SET(SIMULATION_SOURCES
 	simulator_interfaces/flowsimulator.cpp
 	simulator_interfaces/ix_simulator.cpp
 	simulator_interfaces/simulator.cpp
+    results/json_results.cpp
 )
 
 SET(SIMULATION_TESTS

--- a/FieldOpt/Simulation/results/json_results.cpp
+++ b/FieldOpt/Simulation/results/json_results.cpp
@@ -1,0 +1,96 @@
+/******************************************************************************
+   Created by einar on 6/11/19.
+   Copyright (C) 2019 Einar J.M. Baumann <einar.baumann@gmail.com>
+
+   This file is part of the FieldOpt project.
+
+   FieldOpt is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   FieldOpt is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with FieldOpt.  If not, see <http://www.gnu.org/licenses/>.
+******************************************************************************/
+
+#include "Simulation/results/json_results.h"
+#include "Utilities/filehandling.hpp"
+#include "QFile"
+#include "QByteArray"
+#include "QJsonDocument"
+#include "QJsonObject"
+#include "QJsonArray"
+#include "Utilities/printer.hpp"
+#include "Utilities/verbosity.h"
+
+namespace Simulation {
+namespace Results {
+
+JsonResults::JsonResults(std::string file_path) {
+    if (VERB_SIM >= 2) Printer::ext_info("Reading JSON results from " + file_path, "Simulation", "JsonResults");
+    assert(Utilities::FileHandling::FileExists(file_path));
+    if (VERB_SIM >= 2) Printer::info("JSON results file exists.");
+    QFile *file = new QFile(QString::fromStdString(file_path));
+    if (!file->open(QIODevice::ReadOnly)) {
+        throw std::runtime_error("Unable to open the JSON results file");
+    }
+    if (VERB_SIM >= 2) Printer::info("JSON results file successfully opened.");
+    QByteArray data = file->readAll();
+    QJsonDocument json = QJsonDocument::fromJson(data);
+
+    if (json.isNull())
+        throw std::runtime_error("Unable to parse the JSON results file.");
+
+    if (!json.isObject())
+        throw std::runtime_error("JSON results file format incorrect.");
+
+    QJsonObject json_results = QJsonObject(json.object());
+    if (VERB_SIM >= 2) Printer::info("JSON results file successfully read.");
+
+    if (!json_results.contains("Components") || !json_results["Components"].isArray()) {
+        throw std::runtime_error("The JSON results file must contain an array named Components.");
+    }
+
+    if (VERB_SIM >= 2) Printer::info("Parsing JSON results file contents.");
+    for (auto comp : json_results["Components"].toArray()) {
+        QJsonObject component = comp.toObject();
+        if (component["Type"] == "Single") {
+            singles_[component["Name"].toString().toStdString()] = component["Value"].toDouble();
+        }
+        else if (component["Type"] == "Monthly") {
+            monthlies_[component["Name"].toString().toStdString()] = std::vector<double>();
+            for (auto value : component["Values"].toArray()) {
+                monthlies_[component["Name"].toString().toStdString()].push_back(value.toDouble());
+            }
+        }
+        else if (component["Type"] == "Yearly") {
+            yearlies_[component["Name"].toString().toStdString()] = std::vector<double>();
+            for (auto value : component["Values"].toArray()) {
+                yearlies_[component["Name"].toString().toStdString()].push_back(value.toDouble());
+            }
+        }
+        else {
+            throw std::runtime_error("Only parsing of Single, Monthly and Yearly type results have been implemented.");
+        }
+    }
+    file->close();
+    if (VERB_SIM >= 2) Printer::ext_info("Done reading additional JSON results.", "Simulation", "JsonResults");
+}
+
+double JsonResults::GetSingleValue(std::string name) {
+    return singles_[name];
+}
+std::vector<double> JsonResults::GetMonthlyValues(std::string name) {
+    return monthlies_[name];
+}
+std::vector<double> JsonResults::GetYearlyValues(std::string name) {
+    return yearlies_[name];
+}
+
+}
+}

--- a/FieldOpt/Simulation/results/json_results.h
+++ b/FieldOpt/Simulation/results/json_results.h
@@ -1,0 +1,76 @@
+/******************************************************************************
+   Created by einar on 6/11/19.
+   Copyright (C) 2019 Einar J.M. Baumann <einar.baumann@gmail.com>
+
+   This file is part of the FieldOpt project.
+
+   FieldOpt is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   FieldOpt is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with FieldOpt.  If not, see <http://www.gnu.org/licenses/>.
+******************************************************************************/
+
+#ifndef JSON_RESULTS_H
+#define JSON_RESULTS_H
+
+#include "string"
+#include "vector"
+#include "map"
+
+namespace Simulation {
+namespace Results {
+
+/*!
+ * @brief Class for reading results from a JSON file
+ * containing additional result components, including single
+ * values, monthly vectors and yearly vectors.
+ *
+ * The file should be structured as follows:
+ *
+ * {
+ *     "Components": [
+ *          {
+ *              "Name": "WaterfrontPenalty",
+ *              "Type": "Single",
+ *              "Value": 5.0
+ *          },
+ *          {
+ *              "Name": "ReservoirPressure",
+ *              "Type": "Monthly",
+ *              "Values": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+ *          },
+ *          {
+ *              "Name": "RecoveryFactor",
+ *              "Type": "Yearly",
+ *              "Values": [1.0, 2.0]
+ *          }
+ *     ]
+ * }
+ */
+class JsonResults {
+    public:
+     JsonResults(){}
+     JsonResults(std::string file_path);
+
+     double GetSingleValue(std::string name);
+     std::vector<double> GetMonthlyValues(std::string name);
+     std::vector<double> GetYearlyValues(std::string name);
+
+    private:
+     std::map<std::string, double> singles_;
+     std::map<std::string, std::vector<double>> monthlies_;
+     std::map<std::string, std::vector<double>> yearlies_;
+};
+
+}
+}
+
+#endif // JSON_RESULTS_H

--- a/FieldOpt/Simulation/results/results.h
+++ b/FieldOpt/Simulation/results/results.h
@@ -4,6 +4,7 @@
 #include <QString>
 #include "results_exceptions.h"
 #include <vector>
+#include "Simulation/results/json_results.h"
 
 namespace Simulation {
     namespace Results {
@@ -106,6 +107,9 @@ namespace Simulation {
              */
             bool isAvailable() const { return available_; }
 
+            JsonResults GetJsonResults() { return json_results_; }
+            void SetJsonResults(JsonResults results) { json_results_ = results; }
+
         protected:
             /*!
              * \brief Results Default constructor. A Results object is not useful on its own; One of the
@@ -128,6 +132,7 @@ namespace Simulation {
 
         private:
             bool available_;
+            JsonResults json_results_;
         };
 
     }}

--- a/FieldOpt/Simulation/simulator_interfaces/eclsimulator.cpp
+++ b/FieldOpt/Simulation/simulator_interfaces/eclsimulator.cpp
@@ -61,6 +61,7 @@ void ECLSimulator::Evaluate()
         script_args_
     );
     if (VERB_SIM >= 2) { Printer::info("Unmonitored simulation done. Reading results."); }
+    PostSimWork();
     results_->ReadResults(QString::fromStdString(paths_.GetPath(Paths::SIM_OUT_DRIVER_FILE)));
     updateResultsInModel();
 }
@@ -82,13 +83,10 @@ bool ECLSimulator::Evaluate(int timeout, int threads) {
     bool success = ::Utilities::Unix::ExecShellScriptTimeout(
         QString::fromStdString(paths_.GetPath(Paths::SIM_EXEC_SCRIPT_FILE)),
         script_args_, t);
-    if (VERB_SIM >= 2) {
-        Printer::info("Monitored simulation done.");
-    }
+    if (VERB_SIM >= 2) Printer::info("Monitored simulation done.");
     if (success) {
-        if (VERB_SIM >= 2) {
-            Printer::info("Simulation successful. Reading results.");
-        }
+        if (VERB_SIM >= 2) Printer::info("Simulation successful. Reading results.");
+        PostSimWork();
         results_->DumpResults();
         results_->ReadResults(QString::fromStdString(paths_.GetPath(Paths::SIM_OUT_DRIVER_FILE)));
     }

--- a/FieldOpt/Simulation/simulator_interfaces/ix_simulator.cpp
+++ b/FieldOpt/Simulation/simulator_interfaces/ix_simulator.cpp
@@ -54,6 +54,7 @@ void IXSimulator::Evaluate() {
     if (result_path_.size() == 0) {
         setResultPath();
     }
+    PostSimWork();
     if (VERB_SIM >= 1) { Printer::info("Unmonitored simulation done. Reading results from " + result_path_.toStdString()); }
     results_->ReadResults(result_path_);
     updateResultsInModel();
@@ -78,6 +79,7 @@ bool IXSimulator::Evaluate(int timeout, int threads) {
         if (result_path_.size() == 0) {
             setResultPath();
         }
+        PostSimWork();
         if (VERB_SIM >= 1) { Printer::info("Simulation successful. Reading results from " + result_path_.toStdString()); }
         results_->ReadResults(result_path_);
     }

--- a/FieldOpt/Simulation/simulator_interfaces/simulator.cpp
+++ b/FieldOpt/Simulation/simulator_interfaces/simulator.cpp
@@ -18,6 +18,7 @@
 ******************************************************************************/
 #include "simulator.h"
 #include "simulator_exceptions.h"
+#include "Utilities/execution.hpp"
 
 namespace Simulation {
 
@@ -52,6 +53,21 @@ Simulator::Simulator(Settings::Settings *settings) {
 ::Simulation::Results::Results *Simulator::results()
 {
     return results_;
+}
+
+void Simulator::PostSimWork() {
+    if (settings_->simulator()->use_post_sim_script()) {
+        std::string expected_scr_path = paths_.GetPath(Paths::SIM_WORK_DIR) + "/FO_POSTSIM.sh";
+        if (VERB_SIM >= 2) Printer::ext_info("Looking for PostSimWork script at " + expected_scr_path, "Simulation", "Simulator");
+        if (Utilities::FileHandling::FileExists(expected_scr_path)) {
+            if (VERB_SIM >= 2) Printer::ext_info("PostSimWork script found. Executing... ", "Simulation", "Simulator");
+            Utilities::Unix::ExecShellScript(QString::fromStdString(expected_scr_path), QStringList());
+            if (VERB_SIM >= 2) Printer::ext_info("Done executing PostSimWork script.", "Simulation", "Simulator");
+        }
+        else {
+            Printer::ext_warn("PostSimWork script not found.");
+        }
+    }
 }
 
 void Simulator::SetVerbosityLevel(int level) {

--- a/FieldOpt/Simulation/simulator_interfaces/simulator.cpp
+++ b/FieldOpt/Simulation/simulator_interfaces/simulator.cpp
@@ -19,6 +19,7 @@
 #include "simulator.h"
 #include "simulator_exceptions.h"
 #include "Utilities/execution.hpp"
+#include "Simulation/results/json_results.h"
 
 namespace Simulation {
 
@@ -67,6 +68,12 @@ void Simulator::PostSimWork() {
         else {
             Printer::ext_warn("PostSimWork script not found.");
         }
+    }
+    if (settings_->simulator()->read_external_json_results()) {
+        std::string expected_res_path = paths_.GetPath(Paths::SIM_WORK_DIR) + "/FO_EXT_RESULTS.json";
+        if (VERB_SIM >= 2) Printer::ext_info("Reading external JSON results at " + expected_res_path, "Simulation", "Simulator");
+        auto json_results = Simulation::Results::JsonResults(expected_res_path);
+        results_->SetJsonResults(json_results);
     }
 }
 

--- a/FieldOpt/Simulation/simulator_interfaces/simulator.h
+++ b/FieldOpt/Simulation/simulator_interfaces/simulator.h
@@ -102,6 +102,15 @@ class Simulator {
 
   void updateResultsInModel();
 
+  /*!
+   * @brief Perform post-simulation work (if any).
+   *
+   * This if UsePostSimScript is set to true in the driver file, this
+   * will execute a script named FO_POSTSIM.sh in the directory containing
+   * the .DATA file (if the script is found).
+   */
+  void PostSimWork();
+
   Paths paths_;
 
   QString driver_file_name_; //!< The name of the driver main file.


### PR DESCRIPTION
FieldOpt now supports reading additional results (scalars or vectors)
from a file named `FO_EXT_RESULTS.json` located in the same directory
as the simulation results.

This is intended to be used with the post-simulation script exection
feature (e.g. a script is called that writes data to the json file
after each simulation.)

Usage:

1. In the Simulation section of the driver file, set
`"ReadExternalJsonResults": true`
This will cause FieldOpt to read the `FO_EXT_RESULTS.json` file
after reading the usual simulation results.

2. In the NPV definition in the driver file, add one or more additional
components. The property name must be prefixed with `EXT-`, it must have
a coefficient, and the interval must be specified. The property name must
match the name in the `FO_EXT_RESULTS.json` file (disregarding the prefix).
Example:

```
{
    "Property": "EXT-Something",
    "Coefficient": 1.0,
    "Interval": "Single"
}
```

2. The `FO_EXT_RESULTS.json` must contain an array named `Components`
specifying the values to be used, including their `Type` (`Single/Monthly/Yearly`),
a name (matching the component listed for the NPV, sans the `EXT-`, and their `Value`
or `Values` array.
Example:

```
{
    "Components": [
        {
            "Type": "Single",
            "Name": "Something",
            "Value": 5.0
        }
    ]
}
```

Also: cleaned up some settings reading.