### PR TITLE
There is no need to divide by two; removing it to make it easier to u…

### DIFF
--- a/FieldOpt/Simulation/simulator_interfaces/driver_file_writers/driver_parts/ecl_driver_parts/wellcontrols.cpp
+++ b/FieldOpt/Simulation/simulator_interfaces/driver_file_writers/driver_parts/ecl_driver_parts/wellcontrols.cpp
@@ -178,7 +178,7 @@ QString WellControls::createTimeEntry(const double &time, const double &prev_tim
         return QString(""); // A Time entry should not be created for the initial step
     }
     double delta_time = time - prev_time; // The amount of time to advance
-    return QString("TSTEP\n 2*%1 /\n\n").arg(delta_time/2.0);
+    return QString("TSTEP\n %1 /\n\n").arg(delta_time);
 }
 
 QString WellControls::createProducerEntry(const WellControls::WellSetting &setting) const


### PR DESCRIPTION
…se individual timesteps