### PR TITLE
Add inertia weight parameter for PSO optimizer

### DIFF
--- a/FieldOpt/Optimization/optimizers/PSO.h
+++ b/FieldOpt/Optimization/optimizers/PSO.h
@@ -115,6 +115,10 @@ class PSO : public Optimizer {
   int number_of_particles_; //!< The number of particles in the swarm
   double learning_factor_1_; //!< Learning factor 1 (c1)
   double learning_factor_2_; //!< Learning factor 2 (c2)
+  double inertia_weight_; //!< Inertia weight
+  double inertia_weight_max_; //!< Inertia weight maximum
+  double inertia_weight_min_; //!< Inertia weight minimum
+  bool inertia_decay_; //!< Use inertia weight decay if true
   Eigen::VectorXd v_max_; //!< Max velocity of the particle
   int max_iterations_; //!< Max iterations
   vector<Particle> swarm_; //!< Current swarm of particles

--- a/FieldOpt/Settings/optimizer.cpp
+++ b/FieldOpt/Settings/optimizer.cpp
@@ -346,10 +346,22 @@ Optimizer::Parameters Optimizer::parseParameters(QJsonObject &json_parameters) {
         // PSO parameters
         if(json_parameters.contains("PSO-LearningFactor1")){
             params.pso_learning_factor_1 = json_parameters["PSO-LearningFactor1"].toDouble();
-        }else params.pso_learning_factor_1 = 2;
+        }else params.pso_learning_factor_1 = 1.5;
         if(json_parameters.contains("PSO-LearningFactor2")){
             params.pso_learning_factor_2 = json_parameters["PSO-LearningFactor2"].toDouble();
-        }else params.pso_learning_factor_2 = 2;
+        }else params.pso_learning_factor_2 = 1.5;
+        if(json_parameters.contains("PSO-InertiaWeight")){
+            params.pso_inertia_weight = json_parameters["PSO-InertiaWeight"].toDouble();
+        }else params.pso_inertia_weight = 0.73;
+        if(json_parameters.contains("PSO-InertiaWeightMax")){
+            params.pso_inertia_weight_max = json_parameters["PSO-InertiaWeightMax"].toDouble();
+        }else params.pso_inertia_weight_max = 0.9;
+        if(json_parameters.contains("PSO-InertiaWeightMin")){
+            params.pso_inertia_weight_min = json_parameters["PSO-InertiaWeightMin"].toDouble();
+        }else params.pso_inertia_weight_min = 0.5;
+        if(json_parameters.contains("PSO-InertiaDecay")){
+            params.pso_inertia_decay = json_parameters["PSO-InertiaDecay"].toBool();
+        }
         if(json_parameters.contains("PSO-SwarmSize")){
             params.pso_swarm_size = json_parameters["PSO-SwarmSize"].toDouble();
         }else params.pso_swarm_size = 50;

--- a/FieldOpt/Settings/optimizer.h
+++ b/FieldOpt/Settings/optimizer.h
@@ -82,8 +82,12 @@ class Optimizer
     double upper_bound;       //!< Simple upper bound. This is applied to _all_ variables. Default: +10.0.
 
     // PSO parameters
-    double pso_learning_factor_1; //!< Learning factor (c1), from the swarms best known perturbation. Default: 2
-    double pso_learning_factor_2; //!< Learning factor (c2), from the individual particle's best known perturbation. Default: 2
+    double pso_learning_factor_1; //!< Learning factor (c1), from the swarms best known perturbation. Default: 1.5
+    double pso_learning_factor_2; //!< Learning factor (c2), from the individual particle's best known perturbation. Default: 1.5
+    double pso_inertia_weight; //!< Particle inertia weight. Default: 0.73
+    double pso_inertia_weight_max; //!< Particle maximum inertia weight. Default: 0.9
+    double pso_inertia_weight_min; //!< Particle minimum inertia weight. Default: 0.5
+    bool pso_inertia_decay = false; //!< Particle inertia decay. Default: false
     double pso_swarm_size; //!< The number of particles in the swarm. Default: 50
     double pso_velocity_scale; //!< Scaling factor for particle velocities. Default: 1.0
 


### PR DESCRIPTION
Added inertia weight parameter for PSO optimizer. This parameter can have a fixed value for a run or can decay with iterations. Learning factors 1 and 2 have been changed accordingly.

Parameter would give users more control over the optimization run behavior.

Once approved, I would make similar changes in FieldOpt-Research-Open repository.