### PR TITLE
Add inertia weight parameter for PSO optimizer

### DIFF
--- a/FieldOpt/Optimization/optimizers/PSO.cpp
+++ b/FieldOpt/Optimization/optimizers/PSO.cpp
@@ -191,12 +191,8 @@ PSO::Particle PSO::find_best_in_particle_memory(int particle_num){
 }
 vector<PSO::Particle> PSO::update_velocity() {
     vector<Particle> new_swarm;
-    double inertia_multiple = 0;
-    if (inertia_decay_) {
-        inertia_multiple = inertia_weight_max_ - ((iteration_*1.0/max_iterations_) * (inertia_weight_max_-inertia_weight_min_));
-    } else {
-        inertia_multiple = inertia_weight_;
-    }
+    double inertia_multiple = inertia_decay_ ?
+                            inertia_weight_max_ - ((iteration_*1.0/max_iterations_) * (inertia_weight_max_-inertia_weight_min_)) : inertia_weight_;
     for(int i = 0; i < swarm_.size(); i++){
         Particle best_in_particle_memory = find_best_in_particle_memory(i);
         new_swarm.push_back(swarm_[i]);

--- a/FieldOpt/Optimization/optimizers/PSO.h
+++ b/FieldOpt/Optimization/optimizers/PSO.h
@@ -115,6 +115,10 @@ class PSO : public Optimizer {
   int number_of_particles_; //!< The number of particles in the swarm
   double learning_factor_1_; //!< Learning factor 1 (c1)
   double learning_factor_2_; //!< Learning factor 2 (c2)
+  double inertia_weight_; //!< Inertia weight
+  double inertia_weight_max_; //!< Inertia weight maximum
+  double inertia_weight_min_; //!< Inertia weight minimum
+  bool inertia_decay_; //!< Use inertia weight decay if true
   Eigen::VectorXd v_max_; //!< Max velocity of the particle
   int max_iterations_; //!< Max iterations
   vector<Particle> swarm_; //!< Current swarm of particles

--- a/FieldOpt/Optimization/tests/optimizers/test_pso.cpp
+++ b/FieldOpt/Optimization/tests/optimizers/test_pso.cpp
@@ -86,4 +86,21 @@ TEST_F(PSOTest, TestFunctionRosenbrock) {
     EXPECT_NEAR(1.0, best_case->GetRealVarVector()[1], 0.5);
 }
 
+TEST_F(PSOTest, TestFunctionDecayRosenbrock) {
+    test_case_ga_spherical_6r_->set_objective_function_value(abs(Rosenbrock(test_case_ga_spherical_6r_->GetRealVarVector())));
+    settings_pso_decay_min_->SetRngSeed(5);
+    Optimization::Optimizer *minimizer = new PSO(settings_pso_decay_min_, test_case_ga_spherical_6r_, varcont_6r_, grid_5spot_, logger_ );
+
+    while (!minimizer->IsFinished()) {
+        auto next_case = minimizer->GetCaseForEvaluation();
+        next_case->set_objective_function_value(Rosenbrock(next_case->GetRealVarVector()));
+        minimizer->SubmitEvaluatedCase(next_case);
+    }
+    auto best_case = minimizer->GetTentativeBestCase();
+
+    EXPECT_NEAR(0.0, best_case->objective_function_value(), 1);
+    EXPECT_NEAR(1.0, best_case->GetRealVarVector()[0], 0.5);
+    EXPECT_NEAR(1.0, best_case->GetRealVarVector()[1], 0.5);
+}
+
 }

--- a/FieldOpt/Optimization/tests/test_resource_optimizer.h
+++ b/FieldOpt/Optimization/tests/test_resource_optimizer.h
@@ -44,6 +44,7 @@ class TestResourceOptimizer : public TestResourceModel, public TestResourceCases
       settings_ga_max_ = new Settings::Optimizer(get_json_settings_ga_maximize_);
       settings_ego_max_ = new Settings::Optimizer(get_json_settings_ego_maximize_);
       settings_pso_min_ = new Settings::Optimizer(get_json_settings_pso_minimize_);
+      settings_pso_decay_min_ = new Settings::Optimizer(get_json_settings_pso_decay_minimize_);
       settings_vfsa_min_ = new Settings::Optimizer(get_json_settings_vfsa_minimize_);
       settings_vfsa_max_ = new Settings::Optimizer(get_json_settings_vfsa_maximize_);
       settings_spsa_min_ = new Settings::Optimizer(get_json_settings_spsa_minimize_);
@@ -62,6 +63,7 @@ class TestResourceOptimizer : public TestResourceModel, public TestResourceCases
   Settings::Optimizer *settings_spsa_min_;
   Settings::Optimizer *settings_spsa_max_;
   Settings::Optimizer *settings_pso_min_;
+  Settings::Optimizer *settings_pso_decay_min_;
   Settings::Optimizer *settings_ego_max_;
   Settings::Optimizer *settings_cma_es_min_;
 
@@ -228,9 +230,24 @@ class TestResourceOptimizer : public TestResourceModel, public TestResourceCases
           {"PSO-LearningFactor1",    2.2},
           {"PSO-LearningFactor2",    1.8},
           {"PSO-InertiaWeight",      1.0},
-          //{"PSO-InertiaWeightMax",   0.9},
-          //{"PSO-InertiaWeightMin",   0.5},
-          //{"PSO-InertiaDecay",       true},
+          {"PSO-VelocityScale",      0.025},
+          {"LowerBound",            -5.0},
+          {"UpperBound",             5.0}
+      }},
+      {"Objective", obj_fun_}
+  };
+
+  QJsonObject get_json_settings_pso_decay_minimize_ {
+      {"Type", "PSO"},
+      {"Mode", "Minimize"},
+      {"Parameters", QJsonObject{
+          {"MaxGenerations",        700},
+          {"PSO-SwarmSize",          10},
+          {"PSO-LearningFactor1",    2.2},
+          {"PSO-LearningFactor2",    1.8},
+          {"PSO-InertiaWeightMax",   1.1},
+          {"PSO-InertiaWeightMin",   0.9},
+          {"PSO-InertiaDecay",       true},
           {"PSO-VelocityScale",      0.025},
           {"LowerBound",            -5.0},
           {"UpperBound",             5.0}

--- a/FieldOpt/Optimization/tests/test_resource_optimizer.h
+++ b/FieldOpt/Optimization/tests/test_resource_optimizer.h
@@ -227,7 +227,10 @@ class TestResourceOptimizer : public TestResourceModel, public TestResourceCases
           {"PSO-SwarmSize",          10},
           {"PSO-LearningFactor1",    2.2},
           {"PSO-LearningFactor2",    1.8},
-          {"PSO-InertiaWeight",    1.0},
+          {"PSO-InertiaWeight",      1.0},
+          //{"PSO-InertiaWeightMax",   0.9},
+          //{"PSO-InertiaWeightMin",   0.5},
+          //{"PSO-InertiaDecay",       true},
           {"PSO-VelocityScale",      0.025},
           {"LowerBound",            -5.0},
           {"UpperBound",             5.0}

--- a/FieldOpt/Optimization/tests/test_resource_optimizer.h
+++ b/FieldOpt/Optimization/tests/test_resource_optimizer.h
@@ -227,6 +227,7 @@ class TestResourceOptimizer : public TestResourceModel, public TestResourceCases
           {"PSO-SwarmSize",          10},
           {"PSO-LearningFactor1",    2.2},
           {"PSO-LearningFactor2",    1.8},
+          {"PSO-InertiaWeight",    1.0},
           {"PSO-VelocityScale",      0.025},
           {"LowerBound",            -5.0},
           {"UpperBound",             5.0}

--- a/FieldOpt/Settings/optimizer.cpp
+++ b/FieldOpt/Settings/optimizer.cpp
@@ -346,10 +346,22 @@ Optimizer::Parameters Optimizer::parseParameters(QJsonObject &json_parameters) {
         // PSO parameters
         if(json_parameters.contains("PSO-LearningFactor1")){
             params.pso_learning_factor_1 = json_parameters["PSO-LearningFactor1"].toDouble();
-        }else params.pso_learning_factor_1 = 2;
+        }else params.pso_learning_factor_1 = 1.5;
         if(json_parameters.contains("PSO-LearningFactor2")){
             params.pso_learning_factor_2 = json_parameters["PSO-LearningFactor2"].toDouble();
-        }else params.pso_learning_factor_2 = 2;
+        }else params.pso_learning_factor_2 = 1.5;
+        if(json_parameters.contains("PSO-InertiaWeight")){
+            params.pso_inertia_weight = json_parameters["PSO-InertiaWeight"].toDouble();
+        }else params.pso_inertia_weight = 0.73;
+        if(json_parameters.contains("PSO-InertiaWeightMax")){
+            params.pso_inertia_weight_max = json_parameters["PSO-InertiaWeightMax"].toDouble();
+        }else params.pso_inertia_weight_max = 0.9;
+        if(json_parameters.contains("PSO-InertiaWeightMin")){
+            params.pso_inertia_weight_min = json_parameters["PSO-InertiaWeightMin"].toDouble();
+        }else params.pso_inertia_weight_min = 0.5;
+        if(json_parameters.contains("PSO-InertiaDecay")){
+            params.pso_inertia_decay = json_parameters["PSO-InertiaDecay"].toBool();
+        }
         if(json_parameters.contains("PSO-SwarmSize")){
             params.pso_swarm_size = json_parameters["PSO-SwarmSize"].toDouble();
         }else params.pso_swarm_size = 50;

--- a/FieldOpt/Settings/optimizer.h
+++ b/FieldOpt/Settings/optimizer.h
@@ -82,8 +82,12 @@ class Optimizer
     double upper_bound;       //!< Simple upper bound. This is applied to _all_ variables. Default: +10.0.
 
     // PSO parameters
-    double pso_learning_factor_1; //!< Learning factor (c1), from the swarms best known perturbation. Default: 2
-    double pso_learning_factor_2; //!< Learning factor (c2), from the individual particle's best known perturbation. Default: 2
+    double pso_learning_factor_1; //!< Learning factor (c1), from the swarms best known perturbation. Default: 1.5
+    double pso_learning_factor_2; //!< Learning factor (c2), from the individual particle's best known perturbation. Default: 1.5
+    double pso_inertia_weight; //!< Particle inertia weight. Default: 0.73
+    double pso_inertia_weight_max; //!< Particle maximum inertia weight. Default: 0.9
+    double pso_inertia_weight_min; //!< Particle minimum inertia weight. Default: 0.5
+    bool pso_inertia_decay = false; //!< Particle inertia decay. Default: false
     double pso_swarm_size; //!< The number of particles in the swarm. Default: 50
     double pso_velocity_scale; //!< Scaling factor for particle velocities. Default: 1.0
 

--- a/examples/Flow/wellCtrOpt2w/fo_driver.CntrlOpt.PSO.json
+++ b/examples/Flow/wellCtrOpt2w/fo_driver.CntrlOpt.PSO.json
@@ -216,8 +216,9 @@
         },
         "Parameters": {
             "MaxGenerations": 30,
-            "PSO-LearningFactor1": 2,
-            "PSO-LearningFactor2": 2,
+            "PSO-LearningFactor1": 1.5,
+            "PSO-LearningFactor2": 1.5,
+            "PSO-InertiaWeight": 0.73,
             "PSO-SwarmSize": 24,
             "PSO-VelocityScale": 0.25
         },


### PR DESCRIPTION
Added inertia weight parameter for PSO optimizer. This parameter can have fixed value for a run or can decay with iterations. Learning factors 1 and 2 have been changed accordingly.

Parameter would give users more control over the optimization run behavior. I have run related tests.

Once approved, I would make similar changes in FieldOpt-Research-Open repository.

Reference: Inertia weight control strategies for particle swarm optimization  ( https://www.researchgate.net/publication/309658844_Inertia_weight_control_strategies_for_particle_swarm_optimization_Too_much_momentum_not_enough_analysis )